### PR TITLE
starred greedy problems and difficuties

### DIFF
--- a/content/3_Silver/Greedy.mdx
+++ b/content/3_Silver/Greedy.mdx
@@ -69,7 +69,7 @@ export const problems = {
 			'CSES',
 			'Stick Division',
 			'1161',
-			'Hard',
+			'Normal',
 			false,
 			[],
 			'@CPH 6.5'


### PR DESCRIPTION
Starred: Towers (search for the one is greater, clear greedy), task and deadlines, movie festival II (standard ideas important to know),
High card low card (cool problem with a neat greedy approach).

Difficulty: I put high card low card gold in normal because the implementation is harder than the silver one and the problem in general.

Suggestions: I personally would put stick divisions normal and not hard (I sum up the two lower values every time and it gave me AC), also I think problems like berry picking and sure bet are a little bit harder than this one, but probably is personal opinion.
