### PR TITLE
Replace mdx editor with monaco

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
     "@mdx-js/runtime": "^1.6.16",
+    "@monaco-editor/react": "^3.6.3",
     "@tailwindcss/ui": "^0.5.0",
     "@tippyjs/react": "^4.1.0",
     "algoliasearch": "^4.4.0",

--- a/src/pages/liveupdate.tsx
+++ b/src/pages/liveupdate.tsx
@@ -9,6 +9,7 @@ import { PageProps } from 'gatsby';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 import { useState } from 'react';
+import Editor from '@monaco-editor/react';
 
 const RawMarkdownRenderer = React.lazy(() =>
   import('../components/LiveUpdateMarkdownRenderer')
@@ -20,26 +21,11 @@ export default function LiveUpdatePage(props: PageProps) {
   return (
     <Layout>
       <SEO title="MDX Renderer" />
-
-      <div className="h-screen flex">
-        <div className="flex-1">
-          <textarea
-            value={markdown}
-            onChange={e => setMarkdown(e.target.value)}
-            className="w-full border border-gray-200 h-screen overflow-y-auto p-4 bg-gray-50 font-mono tracking-tight"
-            placeholder="Enter mdx here..."
-            style={{ resize: 'none' }}
-          />
+      <div className="h-screen grid grid-cols-2">
+        <div className="col-span-1">
+          <Editor theme="dark" language="markdown" value={markdown} />
         </div>
-        <div className="flex-1 p-4 h-screen overflow-y-auto">
-          <div className="markdown">
-            {typeof window !== 'undefined' && (
-              <React.Suspense fallback={'Loading'}>
-                <RawMarkdownRenderer markdown={markdown} />
-              </React.Suspense>
-            )}
-          </div>
-        </div>
+        <div className="col-span-1"></div>
       </div>
     </Layout>
   );

--- a/src/pages/liveupdate.tsx
+++ b/src/pages/liveupdate.tsx
@@ -5,15 +5,17 @@
 // }
 
 import * as React from 'react';
+import { Suspense } from 'react';
 import { PageProps } from 'gatsby';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 import { useState } from 'react';
-import Editor from '@monaco-editor/react';
 
 const RawMarkdownRenderer = React.lazy(() =>
   import('../components/LiveUpdateMarkdownRenderer')
 );
+
+const Editor = React.lazy(() => import('@monaco-editor/react'));
 
 export default function LiveUpdatePage(props: PageProps) {
   const [markdown, setMarkdown] = useState('');
@@ -23,7 +25,9 @@ export default function LiveUpdatePage(props: PageProps) {
       <SEO title="MDX Renderer" />
       <div className="h-screen grid grid-cols-2">
         <div className="col-span-1">
-          <Editor theme="dark" language="markdown" value={markdown} />
+          <Suspense fallback={<div>Loading...</div>}>
+            <Editor theme="dark" language="markdown" value={markdown} />
+          </Suspense>
         </div>
         <div className="col-span-1"></div>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2966,6 +2966,14 @@
   resolved "https://registry.yarnpkg.com/@mikaelkristiansson/domready/-/domready-1.0.10.tgz#f6d69866c0857664e70690d7a0bfedb72143adb5"
   integrity sha512-6cDuZeKSCSJ1KvfEQ25Y8OXUjqDJZ+HgUs6dhASWbAX8fxVraTfPsSeRe2bN+4QJDsgUaXaMWBYfRomCr04GGg==
 
+"@monaco-editor/react@^3.6.3":
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-3.6.3.tgz#62b9af6c437d4035c901c2ce27122d4c3147f10d"
+  integrity sha512-HjDIhoGuLKWeGxvyaQ9eyIBUXrnEdqGxm74u84qnmtfurLSkUACC0+GL0hD3V0PrL2ebkH16u6ZPjQweSIinWw==
+  dependencies:
+    "@babel/runtime" "^7.11.0"
+    state-local "^1.0.1"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -16871,6 +16879,11 @@ stackframe@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
   integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
+
+state-local@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.1.tgz#0d3c0a2bb610d3b81699b30e98fafa00bcf4ac9c"
+  integrity sha512-CkiwT61ZhZd0/z183fcceu7+RSws/Sq5BT3RNQ2xK/Se9A/jn/4Z/eIe1bawoI9wNYC9wrcG2Drz+6GnjtKynA==
 
 state-toggle@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
I found a Monaco React component, so I just added the dependency and used the component. Also added lazy-loading, and I changed the Tailwind styles a bit so the scrolling issue should be gone. Still yet to connect it to the renderer.