### PR TITLE
content: fix small typo in bubblesort editorial

### DIFF
--- a/solutions/JOI 13-bubblesort.mdx
+++ b/solutions/JOI 13-bubblesort.mdx
@@ -24,7 +24,7 @@ $$
 (\text{No. of points strictly inside the rectangle }(i, a_i, j, a_j)) + (\text{No. of points in or on the rectangle }(i, a_i, j, a_j)) - 1
 $$
 
-From this, we also find that if we have $x < y$ and $a_x \geq a_y$, then $a_y$ can't be the left index in the optimal swap.
+From this, we also find that if we have $x < y$ and $a_x \geq a_y$, then $y$ can't be the left index in the optimal swap.
 
 This means that we can simply consider a set of $i$ with strictly increasing $a_i$ as candidates for the left index in the optimal swap!
 


### PR DESCRIPTION
At least, I think this is a typo?