### PR TITLE
typo fix from Time_Comp.mdx

### DIFF
--- a/content/2_Bronze/Time_Comp.mdx
+++ b/content/2_Bronze/Time_Comp.mdx
@@ -79,7 +79,7 @@ for (int i = 1; i <= n; i++) {
 ```cpp
 int i = 0;
 while (i < n) {
-    // constant time node here
+    // constant time code here
     i++;
 }
 ```
@@ -96,7 +96,7 @@ for (int i = 1; i <= n; i++) {
 ```java
 int i = 0;
 while (i < n) {
-    // constant time node here
+    // constant time code here
     i++;
 }
 ```
@@ -112,7 +112,7 @@ for i in range(1, n+1):
 ```py
 i = 0
 while (i < n):
-    # constant time node here
+    # constant time code here
     i += 1
 ```
 


### PR DESCRIPTION
not sure if it was intentional but "node" was used instead of "code."