### PR TITLE
Typo for Python 3 example solution "Weird Algorithm"

### DIFF
--- a/content/1_General/IO.mdx
+++ b/content/1_General/IO.mdx
@@ -428,7 +428,7 @@ x = int(input())
 while x != 1:
 	print(x, end = " ")
 	if x % 2 == 0:
-		x /= 2
+		x //= 2
 	else:
 		x = 3 * x + 1
 print(x)


### PR DESCRIPTION
In Python 3 "/" will result in a float, so it must be "//" which will be an int.