### PR TITLE
Clarify Java PATH note

### DIFF
--- a/content/1_General/Running_Code_Locally.mdx
+++ b/content/1_General/Running_Code_Locally.mdx
@@ -298,7 +298,7 @@ operable program or batch file.
 ```
 You will have to download and install JDK from [here](https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_x64_windows_hotspot_11.0.9.1_1.msi).
 
-After it finishes installing, if you run `java --version` again, you should get something like above. Note that you may have to add Java to the system path.
+After it finishes installing, if you run `java --version` again, you should get something like above. Note: the installer should automatically add Java into the system `PATH`, but in the event that it doesn't, you can find more information on how to do that [here](https://www.poftut.com/how-to-set-java-jre-and-jdk-home-path-and-environment-variables-on-windows).
 
 #### macOS
 


### PR DESCRIPTION
I clarified the `PATH` note for Windows and added a link to some instructions.