### PR TITLE
remove outdated DMOJ acronym

### DIFF
--- a/content/1_General/Contests.mdx
+++ b/content/1_General/Contests.mdx
@@ -41,7 +41,7 @@ These websites hold contests that I frequently participate in.
   - Div 2, Div 1
   - 75 min coding, 15 min challenge
   - Solutions only tested after contest!
-- [Don Mills OJ](http://dmoj.ca/)
+- [DMOJ](http://dmoj.ca/)
   - at least one contest every month during school year
   - practice implementation!!
 

--- a/content/1_General/Contests.mdx
+++ b/content/1_General/Contests.mdx
@@ -41,7 +41,7 @@ These websites hold contests that I frequently participate in.
   - Div 2, Div 1
   - 75 min coding, 15 min challenge
   - Solutions only tested after contest!
-- [DMOJ](http://dmoj.ca/)
+- [DMOJ Modern Online Judge](http://dmoj.ca/)
   - at least one contest every month during school year
   - practice implementation!!
 

--- a/docs/Content Documentation.md
+++ b/docs/Content Documentation.md
@@ -358,7 +358,7 @@ Special functionality based on source:
     	HE: 'HackerEarth',
     	AC: 'AtCoder',
     	CC: 'CodeChef',
-    	DMOJ: 'Don Mills Online Judge',
+    	DMOJ: 'DMOJ',
     	SPOJ: 'Sphere Online Judge',
     	YS: 'Library Checker',
     	LC: 'LeetCode',

--- a/docs/Content Documentation.md
+++ b/docs/Content Documentation.md
@@ -127,9 +127,11 @@ Good:
 
 <Spoiler>
 
+
 This is **bold**.
 
 </Spoiler>
+
 ```
 
 ```mdx
@@ -358,7 +360,7 @@ Special functionality based on source:
     	HE: 'HackerEarth',
     	AC: 'AtCoder',
     	CC: 'CodeChef',
-    	DMOJ: 'DMOJ',
+    	DMOJ: 'DMOJ Modern Online Judge',
     	SPOJ: 'Sphere Online Judge',
     	YS: 'Library Checker',
     	LC: 'LeetCode',
@@ -399,6 +401,7 @@ There are two main types of tooltips: text tooltips, which display a dotted unde
 <LanguageSection>
 <CPPSection>
 
+
 # A heading that only appears in C++
 
 CPP content goes here, note the newlines!
@@ -406,11 +409,13 @@ CPP content goes here, note the newlines!
 </CPPSection>
 <JavaSection>
 
+
 Java content goes here!
 
 </JavaSection>
 <PySection />
 </LanguageSection>
+
 ```
 
 In the example above, nothing will be rendered for Python.
@@ -420,8 +425,10 @@ In the example above, nothing will be rendered for Python.
 ```mdx
 <IncompleteSection>
 
+
 - this list is optional and can be used to specify what is missing
 - missing 32-bit integer explanation
 
 </IncompleteSection>
+
 ```

--- a/src/models/problem.ts
+++ b/src/models/problem.ts
@@ -73,7 +73,7 @@ const probSources = {
   ],
   DMOJ: [
     'https://dmoj.ca/problem/',
-    'Don Mills Online Judge',
+    'DMOJ',
     'There might be a "Read Editorial" button on the right side of the page.',
   ],
   FHC: [

--- a/src/models/problem.ts
+++ b/src/models/problem.ts
@@ -73,7 +73,7 @@ const probSources = {
   ],
   DMOJ: [
     'https://dmoj.ca/problem/',
-    'DMOJ',
+    'DMOJ Modern Online Judge',
     'There might be a "Read Editorial" button on the right side of the page.',
   ],
   FHC: [


### PR DESCRIPTION
DMOJ no longer stands for Don Mills Online Judge.