### PR TITLE
Fix bug in silver successor graph solution to "Badge"

### DIFF
--- a/content/3_Silver/Func_Graphs.mdx
+++ b/content/3_Silver/Func_Graphs.mdx
@@ -403,7 +403,7 @@ public class badge
 			f[n]=n;//Nodes in cycle point to themselves
 			u[p[n]]=false;//remember where cycle started
 			u[n]=false;
-			return -1;
+			return u != p[u] ? -1 : u;
 		}
 		else if(v[p[n]]) //You point into some already visited cycle
 		{


### PR DESCRIPTION
The previous code had a bug when a node pointed to a node that pointed to itself. Because the node that pointed to itself would return -1, the node pointing to it would consider itself part of the cycle, when it should not be. The codeforces test cases (strangely) must not have had such an example, as the previous code AC'd. The testcase below (from Planet Cycles cses) is an example of such a case, in which 3 points to 8 which points to itself.

10
4 7 8 10 5 7 4 8 3 7

The previous code outputs

4 7 **3** 4 5 7 7 8 3 10 

when it should output

4 7 **8** 4 5 7 7 8 3 10 

which it does with the few characters modified in this pr. 