### PR TITLE
replace four spaces with tab in code block

### DIFF
--- a/src/components/markdown/CodeBlock/CodeBlock.tsx
+++ b/src/components/markdown/CodeBlock/CodeBlock.tsx
@@ -34,9 +34,10 @@ const renderTokens = (tokens, getLineProps, getTokenProps) => {
       <Line key={i} {...getLineProps({ line, key: i })}>
         <LineNo data-line-number={i + 1} />
         <LineContent>
-          {line.map((token, key) => (
-            <span key={key} {...getTokenProps({ token, key })} />
-          ))}
+          {line.map((token, key) => {
+            token.content = token.content.replace(/ {4}/g, '\t');
+            return <span key={key} {...getTokenProps({ token, key })} />;
+          })}
         </LineContent>
       </Line>
     );


### PR DESCRIPTION
note: this replaces *all* instances of four spaces with a tab, regardless of whether the .mdx file was using four spaces or a tab.

this probably will create some issues:

- If the code is supposed to use a mixture of tabs and spaces, then all the spaces will be converted to tabs.
- If the code is poorly formatted (with two/three spaces), the tabs will get messed up.

closes #768 