### PR TITLE
CodeBlock: Add Code Snips (excuse the spaghetti)

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -75,7 +75,10 @@ export const plugins = [
         // },
       ],
       remarkPlugins: [require(`remark-external-links`), require('remark-math')],
-      rehypePlugins: [require('./src/mdx-plugins/rehype-math.js')],
+      rehypePlugins: [
+        require('./src/mdx-plugins/rehype-math.js'),
+        require('./src/mdx-plugins/rehype-snippets.js'),
+      ],
       plugins: [
         {
           resolve: `gatsby-remark-autolink-headers`,

--- a/src/components/DynamicMarkdownRenderer.tsx
+++ b/src/components/DynamicMarkdownRenderer.tsx
@@ -12,6 +12,7 @@ import grayMatter from 'gray-matter';
 import { components } from './markdown/MDXProvider';
 import { Problem } from '../models/problem';
 import customRehypeKatex from '../mdx-plugins/rehype-math.js';
+import rehypeSnippets from '../mdx-plugins/rehype-snippets.js';
 
 class ErrorBoundary extends React.Component {
   state: {
@@ -75,7 +76,7 @@ export const _frontmatter = ${JSON.stringify(data)}`;
         const jsx = (
           await mdx(content, {
             remarkPlugins: [remarkExternalLinks, remarkMath],
-            rehypePlugins: [customRehypeKatex],
+            rehypePlugins: [customRehypeKatex, rehypeSnippets],
             skipExport: true,
           })
         ).trim();

--- a/src/components/markdown/CodeBlock/CodeBlock.tsx
+++ b/src/components/markdown/CodeBlock/CodeBlock.tsx
@@ -27,7 +27,14 @@ const LineSnip = styled.span`
   white-space: nowrap;
   user-select: none;
   width: 1em;
-  padding-right: 1em;
+  padding-right: 0.5em;
+`;
+
+const CodeSnipButtonIcon = styled.svg`
+  color: rgba(156, 220, 254, 0.3);
+  &:hover {
+    color: rgba(156, 220, 254, 0.7);
+  }
 `;
 
 const LineContent = styled.span`
@@ -35,9 +42,9 @@ const LineContent = styled.span`
 `;
 
 const CodeSnippetLineContent = styled(LineContent)`
-  color: #00bb00; // any better color?
+  color: #00bb00a0; // any better color?
   &:hover > span {
-    text-decoration: underline;
+    color: #00bb00c0;
     cursor: pointer;
   }
 `;
@@ -52,11 +59,10 @@ const CodeSnipButton = ({
   onShowSnipChange: (snipID: number, showSnip: boolean) => void;
 }) => {
   return (
-    <svg
+    <CodeSnipButtonIcon
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      opacity="0.3"
       className={
         'transform transition translate-y-0.5 h-4 cursor-pointer' +
         (!showSnip ? ' -rotate-90' : '')
@@ -69,7 +75,7 @@ const CodeSnipButton = ({
         strokeWidth={3}
         d="M17 10l-5 5-5-5"
       />
-    </svg>
+    </CodeSnipButtonIcon>
   );
 };
 

--- a/src/components/markdown/CodeBlock/CodeBlock.tsx
+++ b/src/components/markdown/CodeBlock/CodeBlock.tsx
@@ -34,42 +34,55 @@ const LineContent = styled.span`
   display: table-cell;
 `;
 
-class CodeSnipButton extends React.Component {
-  constructor(props) {
-    super(props);
-    this.clickEvent = this.clickEvent.bind(this);
+const CodeSnippetLineContent = styled(LineContent)`
+  color: #00bb00; // any better color?
+  &:hover {
+    text-decoration: underline;
+    cursor: pointer;
   }
+`;
 
-  clickEvent() {
-    this.props.setCodeSnipShow(this.props.codeSnipID, !this.props.showSnip);
+const CodeSnipButton = ({
+  snipID,
+  showSnip,
+  onShowSnipChange,
+}: {
+  snipID: number;
+  showSnip: boolean;
+  onShowSnipChange: (snipID: number, showSnip: boolean) => void;
+}) => {
+  return (
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      opacity="0.3"
+      className={
+        'transform transition translate-y-0.5 h-4 cursor-pointer' +
+        (!showSnip ? ' -rotate-90' : '')
+      }
+      onClick={() => onShowSnipChange(snipID, !showSnip)}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={3}
+        d="M17 10l-5 5-5-5"
+      />
+    </svg>
+  );
+};
+
+class CodeBlock extends React.Component<
+  {
+    children: string;
+    className: string;
+  },
+  {
+    collapsed: boolean;
+    codeSnipShow: boolean[];
   }
-
-  render() {
-    return (
-      <svg
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        opacity="0.3"
-        style={{ height: '1em' } /* todo: make class */}
-        className={
-          'transform transition translate-y-0.5' +
-          (!this.props.showSnip ? ' -rotate-90' : '')
-        }
-        onClick={this.clickEvent}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={3}
-          d="M17 10l-5 5-5-5"
-        />
-      </svg>
-    );
-  }
-}
-
-class CodeBlock extends React.Component {
+> {
   codeSnips = [];
 
   constructor(props) {
@@ -133,16 +146,21 @@ class CodeBlock extends React.Component {
                 <LineNo data-line-number={'..'} />
                 <LineSnip>
                   <CodeSnipButton
-                    setCodeSnipShow={this.setCodeSnipShow}
-                    codeSnipID={curSnip}
+                    onShowSnipChange={this.setCodeSnipShow}
+                    snipID={curSnip}
                     showSnip={false}
                   />{' '}
                   {/*this.state.codeSnipShow[curSnip] is false*/}
                 </LineSnip>
-                <LineContent>
-                  {codeSnips[curSnip].value}{' '}
-                  {/*kinda scuffed but if it's an empty string nothing happens anyways; todo: make it lighter or have some custom color*/}
-                </LineContent>
+                <CodeSnippetLineContent
+                  onClick={this.setCodeSnipShow.bind(this, curSnip, true)}
+                >
+                  Code Snippet
+                  {codeSnips[curSnip].value
+                    ? `: ${codeSnips[curSnip].value}`
+                    : ''}{' '}
+                  (Click to expand)
+                </CodeSnippetLineContent>
               </Line>
             );
           } else return null; // or nothing
@@ -163,8 +181,8 @@ class CodeBlock extends React.Component {
           i < codeSnips[curSnip].end ? (
             <LineSnip>
               <CodeSnipButton
-                setCodeSnipShow={this.setCodeSnipShow}
-                codeSnipID={curSnip}
+                onShowSnipChange={this.setCodeSnipShow}
+                snipID={curSnip}
                 showSnip={true}
               />{' '}
               {/*this.state.codeSnipShow[curSnip] is true*/}

--- a/src/components/markdown/CodeBlock/CodeBlock.tsx
+++ b/src/components/markdown/CodeBlock/CodeBlock.tsx
@@ -15,7 +15,6 @@ const LineNo = styled.span`
   display: table-cell;
   white-space: nowrap;
   text-align: right;
-  padding-right: 1em;
   user-select: none;
   opacity: 0.5;
   &::before {
@@ -23,115 +22,266 @@ const LineNo = styled.span`
   }
 `;
 
+const LineSnip = styled.span`
+  display: table-cell;
+  white-space: nowrap;
+  user-select: none;
+  width: 1em;
+  padding-right: 1em;
+`;
+
 const LineContent = styled.span`
   display: table-cell;
 `;
 
-const renderTokens = (tokens, getLineProps, getTokenProps) => {
-  return tokens.map((line, i) => {
-    if (line.length === 1 && line[0].content === '') line[0].content = '\n';
-    return (
-      <Line key={i} {...getLineProps({ line, key: i })}>
-        <LineNo data-line-number={i + 1} />
-        <LineContent>
-          {line.map((token, key) => {
-            token.content = token.content.replace(/ {4}/g, '\t');
-            return <span key={key} {...getTokenProps({ token, key })} />;
-          })}
-        </LineContent>
-      </Line>
-    );
-  });
-};
+class CodeSnipButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.clickEvent = this.clickEvent.bind(this);
+  }
 
-export default ({ children, className }) => {
-  if (className === undefined) {
-    // no styling, just a regular pre tag
+  clickEvent() {
+    this.props.setCodeSnipShow(this.props.codeSnipID, !this.props.showSnip);
+  }
+
+  render() {
     return (
-      <pre className="-mx-4 sm:-mx-6 lg:mx-0 lg:rounded bg-gray-100 p-4 mb-4 whitespace-pre-wrap break-all dark:bg-gray-900">
-        {children}
-      </pre>
+      <svg
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        opacity="0.3"
+        style={{ height: '1em' } /* todo: make class */}
+        className={
+          'transform transition translate-y-0.5' +
+          (!this.props.showSnip ? ' -rotate-90' : '')
+        }
+        onClick={this.clickEvent}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={3}
+          d="M17 10l-5 5-5-5"
+        />
+      </svg>
     );
   }
-  const language = className.replace(/language-/, '');
-  const [collapsed, setCollapsed] = useState(true);
+}
 
-  // console.warn() if line length is > 80. uncomment to enable
-  // Warning: Performance will be negatively impacted! Make sure to comment out before pushing
-  // You may want to comment out pages/liveupdate.tsx (see file for instructions) to speed up build times
-  // let tooLong = false;
-  // for (let line of children.trim().split("\n")) {
-  //   if (line.length > 80) {
-  //     tooLong = true;
-  //     console.error(line + "               ---- too long! (" + line.length + " chars)")
-  //   }
-  // }
+class CodeBlock extends React.Component {
+  codeSnips = [];
 
-  return (
-    // @ts-ignore
-    <Highlight
-      Prism={Prism as any}
-      code={children.trim()}
-      language={language}
-      theme={vsDark}
-    >
-      {({ className, style, tokens, getLineProps, getTokenProps }) => (
-        <div className="gatsby-highlight" data-language={language}>
-          <pre
-            className={
-              '-mx-4 sm:-mx-6 lg:mx-0 lg:rounded whitespace-pre-wrap break-all p-4 mb-4 relative ' +
-              className
-            }
-            style={{ ...style }}
-          >
-            {collapsed && tokens.length > 15
-              ? renderTokens(tokens.slice(0, 10), getLineProps, getTokenProps)
-              : renderTokens(tokens, getLineProps, getTokenProps)}
-            {tokens.length > 15 && !collapsed && <div className="h-8" />}
-            {tokens.length > 15 && (
-              <div
-                className={
-                  (collapsed ? 'h-full' : 'h-12') +
-                  ' absolute inset-x-0 bottom-0 flex items-end justify-center group cursor-pointer lg:rounded-b'
-                }
-                onClick={() => setCollapsed(!collapsed)}
-              >
+  constructor(props) {
+    super(props);
+    let i = 0;
+    let prev = -1;
+    let prevVal = '';
+    let codeSnipShowDefault = [];
+    for (let line of this.props.children.trim().split('\n')) {
+      if (prev == -1) {
+        const found = line.match(/BeginCodeSnip{(}|.*?[^\\]})/); // BeginCodeSnip{...}
+        if (found != null)
+          (prev = i), (prevVal = found[0].slice(14, found[0].length - 1)); // stuff inside curly brackets
+      } else {
+        const found = line.match(/EndCodeSnip/);
+        if (found != null) {
+          //assert(end - prev > 1);
+          this.codeSnips.push({ begin: prev, end: i, value: prevVal }); // inclusive bounds
+          codeSnipShowDefault.push(false);
+          prev = -1;
+        }
+      }
+      ++i;
+    }
+    //console.log(this.codeSnips);
+    //console.log(codeSnipShowDefault);
+    this.state = { collapsed: true, codeSnipShow: codeSnipShowDefault };
+
+    //bind
+    this.setCodeSnipShow = this.setCodeSnipShow.bind(this);
+  }
+
+  setCollapsed(_collapsed) {
+    this.setState({ collapsed: _collapsed });
+  }
+
+  setCodeSnipShow(id, val) {
+    this.setState(state => {
+      let codeSnipShow = state.codeSnipShow;
+      codeSnipShow[id] = val;
+      return { codeSnipShow: codeSnipShow };
+    });
+  }
+
+  renderTokens(tokens, maxLines, getLineProps, getTokenProps) {
+    const codeSnips = this.codeSnips;
+    let curSnip = 0;
+    let delta = 1;
+    return tokens.map((line, i) => {
+      if (maxLines == 0) return null;
+      if (line.length === 1 && line[0].content === '') line[0].content = '\n';
+      if (curSnip < codeSnips.length && i >= codeSnips[curSnip].begin) {
+        // inside code snip
+        if (i == codeSnips[curSnip].begin) {
+          delta -= 1;
+          if (!this.state.codeSnipShow[curSnip]) {
+            --maxLines;
+            return (
+              // press to show code snip
+              <Line key={i} {...getLineProps({ line, key: i })}>
+                <LineNo data-line-number={'..'} />
+                <LineSnip>
+                  <CodeSnipButton
+                    setCodeSnipShow={this.setCodeSnipShow}
+                    codeSnipID={curSnip}
+                    showSnip={false}
+                  />{' '}
+                  {/*this.state.codeSnipShow[curSnip] is false*/}
+                </LineSnip>
+                <LineContent>
+                  {codeSnips[curSnip].value}{' '}
+                  {/*kinda scuffed but if it's an empty string nothing happens anyways; todo: make it lighter or have some custom color*/}
+                </LineContent>
+              </Line>
+            );
+          } else return null; // or nothing
+        } else if (i == codeSnips[curSnip].end) {
+          delta -= 1;
+          ++curSnip;
+          return null;
+        } else if (!this.state.codeSnipShow[curSnip]) return null;
+      }
+
+      //proceed as normal: (show must == true)
+      --maxLines;
+      return (
+        <Line key={i} {...getLineProps({ line, key: i })}>
+          <LineNo data-line-number={i + delta} />
+          {curSnip < codeSnips.length &&
+          codeSnips[curSnip].begin < i &&
+          i < codeSnips[curSnip].end ? (
+            <LineSnip>
+              <CodeSnipButton
+                setCodeSnipShow={this.setCodeSnipShow}
+                codeSnipID={curSnip}
+                showSnip={true}
+              />{' '}
+              {/*this.state.codeSnipShow[curSnip] is true*/}
+            </LineSnip>
+          ) : (
+            <LineSnip />
+          )}
+          <LineContent>
+            {line.map((token, key) => {
+              token.content = token.content.replace(/ {4}/g, '\t');
+              return <span key={key} {...getTokenProps({ token, key })} />;
+            })}
+          </LineContent>
+        </Line>
+      );
+    });
+  }
+
+  render() {
+    const children = this.props.children;
+    const className = this.props.className;
+    if (className === undefined) {
+      // no styling, just a regular pre tag
+      return (
+        <pre className="-mx-4 sm:-mx-6 lg:mx-0 lg:rounded bg-gray-100 p-4 mb-4 whitespace-pre-wrap break-all dark:bg-gray-900">
+          {children}
+        </pre>
+      );
+    }
+    const language = className.replace(/language-/, '');
+    /*const [codeSnips, setCodeSnips] = useState(
+      for(let line of children.trim().split("\n"))
+      {
+      }
+    );*/
+
+    // console.warn() if line length is > 80. uncomment to enable
+    // Warning: Performance will be negatively impacted! Make sure to comment out before pushing
+    // You may want to comment out pages/liveupdate.tsx (see file for instructions) to speed up build times
+    // let tooLong = false;
+    // for (let line of children.trim().split("\n")) {
+    //   if (line.length > 80) {
+    //     tooLong = true;
+    //     console.error(line + "               ---- too long! (" + line.length + " chars)")
+    //   }
+    // }
+
+    const collapsed = this.state.collapsed;
+
+    return (
+      // @ts-ignore
+      <Highlight
+        Prism={Prism as any}
+        code={children}
+        language={language}
+        theme={vsDark}
+      >
+        {({ className, style, tokens, getLineProps, getTokenProps }) => (
+          <div className="gatsby-highlight" data-language={language}>
+            <pre
+              className={
+                '-mx-4 sm:-mx-6 lg:mx-0 lg:rounded whitespace-pre-wrap break-all p-4 mb-4 relative ' +
+                className
+              }
+              style={{ ...style }}
+            >
+              {collapsed && tokens.length > 15
+                ? this.renderTokens(tokens, 10, getLineProps, getTokenProps)
+                : this.renderTokens(tokens, -1, getLineProps, getTokenProps)}
+              {tokens.length > 15 && !collapsed && <div className="h-8" />}
+              {tokens.length > 15 && (
                 <div
                   className={
-                    (collapsed ? 'h-20' : 'h-12') +
-                    ' absolute inset-x-0 bottom-0 flex items-end justify-center'
+                    (collapsed ? 'h-full' : 'h-12') +
+                    ' absolute inset-x-0 bottom-0 flex items-end justify-center group cursor-pointer lg:rounded-b'
                   }
-                  style={
-                    collapsed
-                      ? {
-                          background:
-                            'linear-gradient(0deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0) 100%)',
-                        }
-                      : null
-                  }
+                  onClick={() => this.setCollapsed(!collapsed)}
                 >
-                  <svg
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
+                  <div
                     className={
-                      'text-white w-6 h-6 transform group-hover:-translate-y-2 transition mb-2 ' +
-                      (collapsed ? '' : 'rotate-180')
+                      (collapsed ? 'h-20' : 'h-12') +
+                      ' absolute inset-x-0 bottom-0 flex items-end justify-center'
+                    }
+                    style={
+                      collapsed
+                        ? {
+                            background:
+                              'linear-gradient(0deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0) 100%)',
+                          }
+                        : null
                     }
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
+                    <svg
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      className={
+                        'text-white w-6 h-6 transform group-hover:-translate-y-2 transition mb-2 ' +
+                        (collapsed ? '' : 'rotate-180')
+                      }
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 9l-7 7-7-7"
+                      />
+                    </svg>
+                  </div>
                 </div>
-              </div>
-            )}
-          </pre>
-        </div>
-      )}
-    </Highlight>
-  );
-};
+              )}
+            </pre>
+          </div>
+        )}
+      </Highlight>
+    );
+  }
+}
+
+export default CodeBlock;

--- a/src/mdx-plugins/rehype-snippets.js
+++ b/src/mdx-plugins/rehype-snippets.js
@@ -7,7 +7,7 @@ const replacements = {
   'Benq Template': `//BeginCodeSnip{Benq Template}
 #include <bits/stdc++.h>
 using namespace std;
- 
+
 using ll = long long;
 using db = long double; // or double, if TL is tight
 using str = string; // yay python!
@@ -19,17 +19,17 @@ using pd = pair<db,db>;
 using vi = vector<int>;
 using vb = vector<bool>;
 using vl = vector<ll>;
-using vd = vector<db>; 
+using vd = vector<db>;
 using vs = vector<str>;
 using vpi = vector<pi>;
-using vpl = vector<pl>; 
+using vpl = vector<pl>;
 using vpd = vector<pd>;
 
 #define tcT template<class T
 #define tcTU tcT, class U
 // ^ lol this makes everything look weird but I'll try it
-tcT> using V = vector<T>; 
-tcT, size_t SZ> using AR = array<T,SZ>; 
+tcT> using V = vector<T>;
+tcT, size_t SZ> using AR = array<T,SZ>;
 tcT> using PR = pair<T,T>;
 
 // pairs
@@ -42,19 +42,19 @@ tcT> using PR = pair<T,T>;
 #define sz(x) int((x).size())
 #define bg(x) begin(x)
 #define all(x) bg(x), end(x)
-#define rall(x) x.rbegin(), x.rend() 
-#define sor(x) sort(all(x)) 
+#define rall(x) x.rbegin(), x.rend()
+#define sor(x) sort(all(x))
 #define rsz resize
-#define ins insert 
+#define ins insert
 #define ft front()
 #define bk back()
 #define pb push_back
-#define eb emplace_back 
+#define eb emplace_back
 #define pf push_front
 #define rtn return
 
 #define lb lower_bound
-#define ub upper_bound 
+#define ub upper_bound
 tcT> int lwb(V<T>& a, const T& b) { return int(lb(all(a),b)-bg(a)); }
 
 // loops
@@ -70,14 +70,14 @@ const int MX = 2e5+5;
 const ll INF = 1e18; // not too close to LLONG_MAX
 const db PI = acos((db)-1);
 const int dx[4] = {1,0,-1,0}, dy[4] = {0,1,0,-1}; // for every grid problem!!
-mt19937 rng((uint32_t)chrono::steady_clock::now().time_since_epoch().count()); 
+mt19937 rng((uint32_t)chrono::steady_clock::now().time_since_epoch().count());
 template<class T> using pqg = priority_queue<T,vector<T>,greater<T>>;
 
 // bitwise ops
 // also see https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html
 constexpr int pct(int x) { return __builtin_popcount(x); } // # of bits set
 constexpr int bits(int x) { // assert(x >= 0); // make C++11 compatible until USACO updates ...
-\treturn x == 0 ? 0 : 31-__builtin_clz(x); } // floor(log2(x)) 
+\treturn x == 0 ? 0 : 31-__builtin_clz(x); } // floor(log2(x))
 constexpr int p2(int x) { return 1<<x; }
 constexpr int msk2(int x) { return p2(x)-1; }
 
@@ -91,18 +91,18 @@ tcT> bool ckmax(T& a, const T& b) {
 
 tcTU> T fstTrue(T lo, T hi, U f) {
 \thi ++; assert(lo <= hi); // assuming f is increasing
-\twhile (lo < hi) { // find first index such that f is true 
+\twhile (lo < hi) { // find first index such that f is true
 \t\tT mid = lo+(hi-lo)/2;
-\t\tf(mid) ? hi = mid : lo = mid+1; 
-\t} 
+\t\tf(mid) ? hi = mid : lo = mid+1;
+\t}
 \treturn lo;
 }
 tcTU> T lstTrue(T lo, T hi, U f) {
 \tlo --; assert(lo <= hi); // assuming f is decreasing
-\twhile (lo < hi) { // find first index such that f is true 
+\twhile (lo < hi) { // find first index such that f is true
 \t\tT mid = lo+(hi-lo+1)/2;
 \t\tf(mid) ? lo = mid : hi = mid-1;
-\t} 
+\t}
 \treturn lo;
 }
 tcT> void remDup(vector<T>& v) { // sort and remove duplicates
@@ -170,20 +170,23 @@ module.exports = options => {
     if (node.children.length !== 1) {
       throw 'Expected only one child for a code block';
     }
-    for (let key of Object.keys(replacements)) {
-      let newValue = [];
-      for (let line of node.children[0].value.split('\n')) {
-        let results = line.match(new RegExp(`^(\\s*)\/\/CodeSnip\\{${key}\\}`));
+    let newValue = [];
+    for (let line of node.children[0].value.split('\n')) {
+      let found = false;
+      for (let key of Object.keys(replacements)) {
+        let results = line.match(new RegExp(`^.*?(CodeSnip\\{${key}\\})`));
         if (results) {
-          let prefix = results[1];
+          let prefix = results[0].match(/^\s+/);
+          if (!prefix) prefix = '';
           for (let snippetLine of replacements[key].split('\n')) {
             newValue.push(`${prefix}${snippetLine}`);
           }
-        } else {
-          newValue.push(line);
+          found = true;
+          break;
         }
       }
-      node.children[0].value = newValue.join('\n');
+      if (!found) newValue.push(line);
     }
+    node.children[0].value = newValue.join('\n');
   }
 };

--- a/src/mdx-plugins/rehype-snippets.js
+++ b/src/mdx-plugins/rehype-snippets.js
@@ -122,6 +122,38 @@ template<class H, class... T> void DBG(H h, T... t) {
 #define dbg(...) 0
 #endif
 //EndCodeSnip`,
+  Kattio: `//BeginCodeSnip{Kattio}
+class Kattio extends PrintWriter {
+\tprivate BufferedReader r;
+\tprivate StringTokenizer st;
+
+\t// standard input
+\tpublic Kattio() { this(System.in,System.out); }
+\tpublic Kattio(InputStream i, OutputStream o) {
+\t\tsuper(o);
+\t\tr = new BufferedReader(new InputStreamReader(i));
+\t}
+\t// USACO-style file input
+\tpublic Kattio(String problemName) throws IOException {
+\t\tsuper(new FileWriter(problemName+".out"));
+\t\tr = new BufferedReader(new FileReader(problemName+".in"));
+\t}
+
+\t// returns null if no more input
+\tpublic String next() {
+\t\ttry {
+\t\t\twhile (st == null || !st.hasMoreTokens())
+\t\t\t\tst = new StringTokenizer(r.readLine());
+\t\t\treturn st.nextToken();
+\t\t} catch (Exception e) {}
+\t\treturn null;
+\t}
+
+\tpublic int nextInt() { return Integer.parseInt(next()); }
+\tpublic double nextDouble() { return Double.parseDouble(next()); }
+\tpublic long nextLong() { return Long.parseLong(next()); }
+}
+//EndCodeSnip`,
 };
 
 module.exports = options => {

--- a/src/mdx-plugins/rehype-snippets.js
+++ b/src/mdx-plugins/rehype-snippets.js
@@ -154,6 +154,30 @@ class Kattio extends PrintWriter {
 \tpublic long nextLong() { return Long.parseLong(next()); }
 }
 //EndCodeSnip`,
+  TemplateShort: `//BeginCodeSnip{C++ Short Template}
+#include <bits/stdc++.h> // see /general/running-code-locally
+using namespace std;
+
+using ll = long long;
+
+using vi = vector<int>;
+#define pb push_back
+#define all(x) begin(x), end(x)
+#define sz(x) (int)(x).size()
+
+using pi = pair<int,int>;
+#define f first
+#define s second
+#define mp make_pair
+
+void setIO(string name = "") {
+\tcin.tie(0)->sync_with_stdio(0); // see /general/fast-io
+\tif (sz(name)) {
+\t\tfreopen((name+".in").c_str(), "r", stdin); // see /general/io
+\t\tfreopen((name+".out").c_str(), "w", stdout);
+\t}
+}
+//EndCodeSnip`,
 };
 
 module.exports = options => {

--- a/src/mdx-plugins/rehype-snippets.js
+++ b/src/mdx-plugins/rehype-snippets.js
@@ -139,10 +139,19 @@ module.exports = options => {
       throw 'Expected only one child for a code block';
     }
     for (let key of Object.keys(replacements)) {
-      node.children[0].value = node.children[0].value.replace(
-        new RegExp(`//CodeSnip\\{${key}\\}`, 'g'),
-        replacements[key]
-      );
+      let newValue = [];
+      for (let line of node.children[0].value.split('\n')) {
+        let results = line.match(new RegExp(`^(\\s*)\/\/CodeSnip\\{${key}\\}`));
+        if (results) {
+          let prefix = results[1];
+          for (let snippetLine of replacements[key].split('\n')) {
+            newValue.push(`${prefix}${snippetLine}`);
+          }
+        } else {
+          newValue.push(line);
+        }
+      }
+      node.children[0].value = newValue.join('\n');
     }
   }
 };

--- a/src/mdx-plugins/rehype-snippets.js
+++ b/src/mdx-plugins/rehype-snippets.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const visit = require('unist-util-visit');
+const nodeToString = require('hast-util-to-string');
+
+const replacements = {
+  'Benq Template': `//BeginCodeSnip{Benq Template}
+#include <bits/stdc++.h>
+using namespace std;
+ 
+using ll = long long;
+using db = long double; // or double, if TL is tight
+using str = string; // yay python!
+
+using pi = pair<int,int>;
+using pl = pair<ll,ll>;
+using pd = pair<db,db>;
+
+using vi = vector<int>;
+using vb = vector<bool>;
+using vl = vector<ll>;
+using vd = vector<db>; 
+using vs = vector<str>;
+using vpi = vector<pi>;
+using vpl = vector<pl>; 
+using vpd = vector<pd>;
+
+#define tcT template<class T
+#define tcTU tcT, class U
+// ^ lol this makes everything look weird but I'll try it
+tcT> using V = vector<T>; 
+tcT, size_t SZ> using AR = array<T,SZ>; 
+tcT> using PR = pair<T,T>;
+
+// pairs
+#define mp make_pair
+#define f first
+#define s second
+
+// vectors
+// oops size(x), rbegin(x), rend(x) need C++17
+#define sz(x) int((x).size())
+#define bg(x) begin(x)
+#define all(x) bg(x), end(x)
+#define rall(x) x.rbegin(), x.rend() 
+#define sor(x) sort(all(x)) 
+#define rsz resize
+#define ins insert 
+#define ft front()
+#define bk back()
+#define pb push_back
+#define eb emplace_back 
+#define pf push_front
+#define rtn return
+
+#define lb lower_bound
+#define ub upper_bound 
+tcT> int lwb(V<T>& a, const T& b) { return int(lb(all(a),b)-bg(a)); }
+
+// loops
+#define FOR(i,a,b) for (int i = (a); i < (b); ++i)
+#define F0R(i,a) FOR(i,0,a)
+#define ROF(i,a,b) for (int i = (b)-1; i >= (a); --i)
+#define R0F(i,a) ROF(i,0,a)
+#define rep(a) F0R(_,a)
+#define each(a,x) for (auto& a: x)
+
+const int MOD = 1e9+7;
+const int MX = 2e5+5;
+const ll INF = 1e18; // not too close to LLONG_MAX
+const db PI = acos((db)-1);
+const int dx[4] = {1,0,-1,0}, dy[4] = {0,1,0,-1}; // for every grid problem!!
+mt19937 rng((uint32_t)chrono::steady_clock::now().time_since_epoch().count()); 
+template<class T> using pqg = priority_queue<T,vector<T>,greater<T>>;
+
+// bitwise ops
+// also see https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html
+constexpr int pct(int x) { return __builtin_popcount(x); } // # of bits set
+constexpr int bits(int x) { // assert(x >= 0); // make C++11 compatible until USACO updates ...
+\treturn x == 0 ? 0 : 31-__builtin_clz(x); } // floor(log2(x)) 
+constexpr int p2(int x) { return 1<<x; }
+constexpr int msk2(int x) { return p2(x)-1; }
+
+ll cdiv(ll a, ll b) { return a/b+((a^b)>0&&a%b); } // divide a by b rounded up
+ll fdiv(ll a, ll b) { return a/b-((a^b)<0&&a%b); } // divide a by b rounded down
+
+tcT> bool ckmin(T& a, const T& b) {
+\treturn b < a ? a = b, 1 : 0; } // set a = min(a,b)
+tcT> bool ckmax(T& a, const T& b) {
+\treturn a < b ? a = b, 1 : 0; }
+
+tcTU> T fstTrue(T lo, T hi, U f) {
+\thi ++; assert(lo <= hi); // assuming f is increasing
+\twhile (lo < hi) { // find first index such that f is true 
+\t\tT mid = lo+(hi-lo)/2;
+\t\tf(mid) ? hi = mid : lo = mid+1; 
+\t} 
+\treturn lo;
+}
+tcTU> T lstTrue(T lo, T hi, U f) {
+\tlo --; assert(lo <= hi); // assuming f is decreasing
+\twhile (lo < hi) { // find first index such that f is true 
+\t\tT mid = lo+(hi-lo+1)/2;
+\t\tf(mid) ? lo = mid : hi = mid-1;
+\t} 
+\treturn lo;
+}
+tcT> void remDup(vector<T>& v) { // sort and remove duplicates
+\tsort(all(v)); v.erase(unique(all(v)),end(v)); }
+tcTU> void erase(T& t, const U& u) { // don't erase
+\tauto it = t.find(u); assert(it != end(t));
+\tt.erase(it); } // element that doesn't exist from (multi)set
+
+
+void DBG() { cerr << "]" << endl; }
+template<class H, class... T> void DBG(H h, T... t) {
+\tcerr << h; if (sizeof...(t)) cerr << ", ";
+\tDBG(t...); }
+#ifdef LOCAL // compile with -DLOCAL
+#define dbg(...) cerr << "LINE(" << __LINE__ << ") -> [" << #__VA_ARGS__ << "]: [", DBG(__VA_ARGS__)
+#else
+#define dbg(...) 0
+#endif
+//EndCodeSnip`,
+};
+
+module.exports = options => {
+  options = options || {};
+
+  return tree => {
+    visit(tree, 'element', visitor);
+  };
+
+  function visitor(node, index, parent) {
+    if (!parent || parent.tagName !== 'pre' || node.tagName !== 'code') {
+      return;
+    }
+    if (node.children.length !== 1) {
+      throw 'Expected only one child for a code block';
+    }
+    for (let key of Object.keys(replacements)) {
+      node.children[0].value = node.children[0].value.replace(
+        new RegExp(`//CodeSnip\\{${key}\\}`, 'g'),
+        replacements[key]
+      );
+    }
+  }
+};


### PR DESCRIPTION
A few problems I can fix if they need to be fixed:
- The "replacement text" (aka stuff in curly braces that is placed on the snipped line) is not formatted.
- Directly used style instead of a class

A few problems someone better than me needs to fix if they cause problems:
- If the majority of the code is snipped off, then the collapse detection fails.
- Did not use modern react stuff (I had to resort to `class ... extends React.component`)
- The part that detects BeginCodeSnip maybe hinders runtime

Use:
Put "`BeginCodeSnip{any random replacement text}`" somewhere in the code block and "`EndCodeSnip`" somewhere else. Everything on these 2 lines are deleted, and everything between them are code snips that are automatically minimized. There's buttons that can maximize it. I found the liveedit tool to be helpful for testing this.

^^ BTW if there is a better UI or format for the user to specify where to snip code, then we can probably change it without too much difficulty.

<details>
<summary> example </summary>

paste

````
```cpp
//BeginCodeSnip{}
#include <bits/stdc++.h>
using namespace std;
 
using ll = long long;
using db = long double; // or double, if TL is tight
using str = string; // yay python!

using pi = pair<int,int>;
using pl = pair<ll,ll>;
using pd = pair<db,db>;

using vi = vector<int>;
using vb = vector<bool>;
using vl = vector<ll>;
using vd = vector<db>; 
using vs = vector<str>;
using vpi = vector<pi>;
using vpl = vector<pl>; 
using vpd = vector<pd>;

#define tcT template<class T
#define tcTU tcT, class U
// ^ lol this makes everything look weird but I'll try it
tcT> using V = vector<T>; 
tcT, size_t SZ> using AR = array<T,SZ>; 
tcT> using PR = pair<T,T>;

// pairs
#define mp make_pair
#define f first
#define s second

// vectors
// oops size(x), rbegin(x), rend(x) need C++17
#define sz(x) int((x).size())
#define bg(x) begin(x)
#define all(x) bg(x), end(x)
#define rall(x) x.rbegin(), x.rend() 
#define sor(x) sort(all(x)) 
#define rsz resize
#define ins insert 
#define ft front()
#define bk back()
#define pb push_back
#define eb emplace_back 
#define pf push_front
#define rtn return

#define lb lower_bound
#define ub upper_bound 
tcT> int lwb(V<T>& a, const T& b) { return int(lb(all(a),b)-bg(a)); }

// loops
#define FOR(i,a,b) for (int i = (a); i < (b); ++i)
#define F0R(i,a) FOR(i,0,a)
#define ROF(i,a,b) for (int i = (b)-1; i >= (a); --i)
#define R0F(i,a) ROF(i,0,a)
#define rep(a) F0R(_,a)
#define each(a,x) for (auto& a: x)

const int MOD = 1e9+7;
const int MX = 2e5+5;
const ll INF = 1e18; // not too close to LLONG_MAX
const db PI = acos((db)-1);
const int dx[4] = {1,0,-1,0}, dy[4] = {0,1,0,-1}; // for every grid problem!!
mt19937 rng((uint32_t)chrono::steady_clock::now().time_since_epoch().count()); 
template<class T> using pqg = priority_queue<T,vector<T>,greater<T>>;

// bitwise ops
// also see https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html
constexpr int pct(int x) { return __builtin_popcount(x); } // # of bits set
constexpr int bits(int x) { // assert(x >= 0); // make C++11 compatible until USACO updates ...
	return x == 0 ? 0 : 31-__builtin_clz(x); } // floor(log2(x)) 
constexpr int p2(int x) { return 1<<x; }
constexpr int msk2(int x) { return p2(x)-1; }

ll cdiv(ll a, ll b) { return a/b+((a^b)>0&&a%b); } // divide a by b rounded up
ll fdiv(ll a, ll b) { return a/b-((a^b)<0&&a%b); } // divide a by b rounded down

tcT> bool ckmin(T& a, const T& b) {
	return b < a ? a = b, 1 : 0; } // set a = min(a,b)
tcT> bool ckmax(T& a, const T& b) {
	return a < b ? a = b, 1 : 0; }

tcTU> T fstTrue(T lo, T hi, U f) {
	hi ++; assert(lo <= hi); // assuming f is increasing
	while (lo < hi) { // find first index such that f is true 
		T mid = lo+(hi-lo)/2;
		f(mid) ? hi = mid : lo = mid+1; 
	} 
	return lo;
}
tcTU> T lstTrue(T lo, T hi, U f) {
	lo --; assert(lo <= hi); // assuming f is decreasing
	while (lo < hi) { // find first index such that f is true 
		T mid = lo+(hi-lo+1)/2;
		f(mid) ? lo = mid : hi = mid-1;
	} 
	return lo;
}
tcT> void remDup(vector<T>& v) { // sort and remove duplicates
	sort(all(v)); v.erase(unique(all(v)),end(v)); }
tcTU> void erase(T& t, const U& u) { // don't erase
	auto it = t.find(u); assert(it != end(t));
	t.erase(it); } // element that doesn't exist from (multi)set


void DBG() { cerr << "]" << endl; }
template<class H, class... T> void DBG(H h, T... t) {
	cerr << h; if (sizeof...(t)) cerr << ", ";
	DBG(t...); }
#ifdef LOCAL // compile with -DLOCAL
#define dbg(...) cerr << "LINE(" << __LINE__ << ") -> [" << #__VA_ARGS__ << "]: [", DBG(__VA_ARGS__)
#else
#define dbg(...) 0
#endif
//EndCodeSnip

int N, Q, a[MX];
ll p[MX];

int main()
{
	scanf("%d%d", &N, &Q);
	for(int i=0;i<N;++i)
		scanf("%d", a+i);
	for(int i=0;i<N;++i)
		p[i+1]=p[i]+a[i];
	for(int i=0;i<Q;++i)
	{
		int l,r;
		scanf("%d%d", &l, &r);
		printf("%lld\n", p[r]-p[l]);
	}
	return 0;
}
```
````

into liveedit

</details>
