### PR TITLE
Update alternative online judge

### DIFF
--- a/content/3_Silver/Prefix_Sums.mdx
+++ b/content/3_Silver/Prefix_Sums.mdx
@@ -404,7 +404,7 @@ for i in range(Q):
 
 <Warning>
 
-"Haybale Stacking" isn't submittable on the USACO website. Use [this link](https://www.acmicpc.net/problem/5912) to submit.
+"Haybale Stacking" isn't submittable on the USACO website. Use [this link](https://www.spoj.com/problems/HAYBALE/) to submit.
 
 </Warning>
 


### PR DESCRIPTION
Since [haybale stacking](http://www.usaco.org/index.php?page=viewproblem2&cpid=104) isn't submittable on USACO, your Guide's [Prefix Sums Silver](https://usaco.guide/silver/prefix-sums?lang=cpp#problems) module has a little note saying "use this link to submit." Previously, the link led to [this](https://www.acmicpc.net/problem/5912) Korean site that has a little link at the bottom to submit via https://www.spoj.com/problems/HAYBALE/, an English site. I've updated the Guide to just link directly to the English site.