### PR TITLE
Clarify that BFS can be used to get the lexographically smallest toposort

### DIFF
--- a/content/4_Gold/TopoSort.mdx
+++ b/content/4_Gold/TopoSort.mdx
@@ -374,7 +374,7 @@ This code assumes that there are no self-loops.
 
 ## BFS
 
-The BFS version, known as [Kahn's Algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm), makes it obvious how to extract the lexicographically minimum topological sort.
+The BFS version is known as [Kahn's Algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm).
 
 <LanguageSection>
 
@@ -443,6 +443,12 @@ static void topological_sort() {
 </JavaSection>
 
 </LanguageSection>
+
+<Optional>
+
+We can also use Kahn's algorithm to extract the lexicographically minimum topological sort by breaking ties lexographically. However, the above code does not do this.
+
+</Optional>
 
 ## Dynamic Programming
 

--- a/content/4_Gold/TopoSort.mdx
+++ b/content/4_Gold/TopoSort.mdx
@@ -446,7 +446,9 @@ static void topological_sort() {
 
 <Optional>
 
-We can also use Kahn's algorithm to extract the lexicographically minimum topological sort by breaking ties lexographically. However, the above code does not do this.
+We can also use Kahn's algorithm to extract the lexicographically minimum topological sort by breaking ties lexographically.
+
+Although the above code does not do this, one can simply replace the `queue` with a `priority_queue` to implement this extension.
 
 </Optional>
 


### PR DESCRIPTION
Also noted that the code doesn't do it

Closes https://github.com/cpinitiative/usaco-guide/issues/890
