### PR TITLE
Change problem link

### DIFF
--- a/content/6_Advanced/Min_Cut.mdx
+++ b/content/6_Advanced/Min_Cut.mdx
@@ -14,7 +14,7 @@ export const problems = {
 		new Problem(
 			'Kattis',
 			'The Wrath of Khan',
-			'https://maps20.kattis.com/problems/thewrathofkahn',
+			'https://open.kattis.com/problems/thewrathofkahn',
 			'Hard',
 			false,
 			[],


### PR DESCRIPTION
Change problem link from https://maps20.kattis.com/problems/thewrathofkahn to https://open.kattis.com/problems/thewrathofkahn so people can submit to the judge without being an official participant