### PR TITLE
Fix dashboard problem statistics

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -46,6 +46,7 @@ export default function DashboardPage(props: PageProps) {
           url: `${moduleIDToURLMap[problem.module.frontmatter.id]}/#problem-${
             problem.uniqueId
           }`,
+          moduleId: problem.module.frontmatter.id,
         };
       }
       return acc;


### PR DESCRIPTION
`moduleId` was deleted so the statistics section was showing 0 problems. I noticed that the dashboard problem total doesn't match the problem total in the section, is this because some problems show up in multiple sections/modules?