### PR TITLE
Update userLang.ts

### DIFF
--- a/src/components/MarkdownLayout/MarkdownLayout.tsx
+++ b/src/components/MarkdownLayout/MarkdownLayout.tsx
@@ -10,7 +10,7 @@ import { ContactUsSlideoverProvider } from '../../context/ContactUsSlideoverCont
 import MarkdownLayoutContext from '../../context/MarkdownLayoutContext';
 import { ProblemSolutionContext } from '../../context/ProblemSolutionContext';
 import { ProblemSuggestionModalProvider } from '../../context/ProblemSuggestionModalContext';
-import { setLangURLIfNone } from '../../context/UserDataContext/properties/userLang';
+import { updateLangURL } from '../../context/UserDataContext/properties/userLang';
 import UserDataContext from '../../context/UserDataContext/UserDataContext';
 import { ModuleInfo } from '../../models/module';
 import { SolutionInfo } from '../../models/solution';
@@ -67,8 +67,9 @@ export default function MarkdownLayout({
     UserDataContext
   );
   React.useEffect(() => {
+    // console.log('FOUND USERLANG: ' + lang);
     if (lang !== 'showAll') {
-      setLangURLIfNone(lang);
+      updateLangURL(lang);
     }
   }, [lang]);
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);

--- a/src/context/UserDataContext/properties/userLang.ts
+++ b/src/context/UserDataContext/properties/userLang.ts
@@ -90,23 +90,33 @@ export default class UserLang extends SimpleUserDataPropertyAPI {
   protected storageKey = 'lang';
   protected defaultValue = 'cpp';
   protected setterFunctionName = 'setLang';
+  protected changedLang = false;
 
   public initializeFromLocalStorage = () => {
-    this.value =
-      getLangFromUrl() ||
-      this.getValueFromLocalStorage(
+    const langFromUrl = getLangFromUrl();
+    if (!this.changedLang && langFromUrl !== null) {
+      this.value = langFromUrl;
+      this.saveLocalStorageValue(this.storageKey, this.value); // save to localstorage
+    } else {
+      this.value = this.getValueFromLocalStorage(
         this.getLocalStorageKey(this.storageKey),
         this.defaultValue
       );
+    }
     updateLangURL(this.value);
   };
 
   public importValueFromObject = data => {
-    this.value =
-      getLangFromUrl() ||
-      (data.hasOwnProperty(this.storageKey) && data[this.storageKey] !== null
-        ? data[this.storageKey]
-        : this.defaultValue);
+    const langFromUrl = getLangFromUrl();
+    if (!this.changedLang && langFromUrl !== null) {
+      this.value = langFromUrl;
+      this.saveFirebaseValue(this.storageKey, this.value); // save to firebase
+    } else {
+      this.value =
+        data.hasOwnProperty(this.storageKey) && data[this.storageKey] !== null
+          ? data[this.storageKey]
+          : this.defaultValue;
+    }
     updateLangURL(this.value);
   };
 
@@ -115,6 +125,7 @@ export default class UserLang extends SimpleUserDataPropertyAPI {
       [this.storageKey]: this.value,
       [this.setterFunctionName]: v => {
         if (v !== 'showAll') {
+          this.changedLang = true;
           this.value = v;
           updateLangURL(this.value);
           this.updateValueAndRerender(this.storageKey, v);

--- a/src/context/UserDataContext/properties/userLang.ts
+++ b/src/context/UserDataContext/properties/userLang.ts
@@ -72,7 +72,7 @@ const getLangFromUrl = () => {
   return null;
 };
 
-function updateLangURL(newLang: string) {
+export function updateLangURL(newLang: string): void {
   if (shouldLangParamApply()) {
     window.history.replaceState(
       {},
@@ -82,9 +82,9 @@ function updateLangURL(newLang: string) {
   }
 } // https://stackoverflow.com/questions/10970078/modifying-a-query-string-without-reloading-the-page
 
-export function setLangURLIfNone(newLang: string): void {
-  if (getLangFromUrl() == null) updateLangURL(newLang);
-}
+// export function setLangURLIfNone(newLang: string): void {
+//   if (getLangFromUrl() == null) updateLangURL(newLang);
+// }
 
 export default class UserLang extends SimpleUserDataPropertyAPI {
   protected storageKey = 'lang';
@@ -93,6 +93,7 @@ export default class UserLang extends SimpleUserDataPropertyAPI {
   protected changedLang = false;
 
   public initializeFromLocalStorage = () => {
+    // console.log('USERLANG: INIT FROM LOCALSTORAGE');
     const langFromUrl = getLangFromUrl();
     if (!this.changedLang && langFromUrl !== null) {
       this.value = langFromUrl;
@@ -107,6 +108,7 @@ export default class UserLang extends SimpleUserDataPropertyAPI {
   };
 
   public importValueFromObject = data => {
+    // console.log('USERLANG: IMPORT FROM OBJECT');
     const langFromUrl = getLangFromUrl();
     if (!this.changedLang && langFromUrl !== null) {
       this.value = langFromUrl;


### PR DESCRIPTION
addresses https://github.com/cpinitiative/usaco-guide/issues/1550#issuecomment-846425681 ?

Intended behavior:
 1. Suppose that current language is C++.
 2. Visit `/gold/bfs?lang=java`, sets your language to Java.
 3. Visit settings page, should see that your language is set to Java.
 4. Change your language in the settings page (say, back to C++).
 5. Press the back button (going back to `/gold/bfs`). Module should now switch to C++.