### PR TITLE
Reformat + simplify java code from bronze modules

### DIFF
--- a/content/2_Bronze/Complete_Rec.mdx
+++ b/content/2_Bronze/Complete_Rec.mdx
@@ -468,7 +468,7 @@ public class Main {
 		io.close();
 	}
 
-    CodeSnip{Kattio}
+	CodeSnip{Kattio}
 }
 ```
 

--- a/content/2_Bronze/Complete_Rec.mdx
+++ b/content/2_Bronze/Complete_Rec.mdx
@@ -5,7 +5,7 @@ author: Darren Yao, Sam Zhang, Michael Cao, Andrew Wang, Benjamin Qi, Dong Liu
 description: 'Includes generating subsets and permutations.'
 frequency: 1
 prerequisites:
-  - intro-complete
+- intro-complete
 ---
 
 <Warning>
@@ -99,115 +99,35 @@ import java.util.*;
 import java.io.*;
 
 public class Main {
-
 	static int N;
 	static int weights[];
 
 	public static void main(String[] args) throws Exception {
-		FastIO sc = new FastIO(System.in);  //See "Intro - FastIO" - this class acts similarly to Scanner, but faster
-		PrintWriter pw = new PrintWriter(System.out);
+		Kattio io = new Kattio();
 
-		N = sc.nextInt();
+		N = io.nextInt();
 		weights = new int[N];
 		for (int i = 0; i < N; i++) {
-			weights[i] = sc.nextInt();
+			weights[i] = io.nextInt();
 		}
 
-		pw.println(solve(0, 0, 0));
-		pw.close();
+		io.println(solve(0, 0, 0));
+		io.close();
 	}
 
-	static long solve(int index, long s1_sum, long s2_sum) {
-		if(index == N) {
-			return Math.abs(s1_sum - s2_sum);
+	static long solve(int index, long sum1, long sum2) {
+		if (index == N) {
+			return Math.abs(sum1 - sum2);
 		}
 
-		return Math.min(solve(index+1, s1_sum + weights[index], s2_sum), solve(index+1, s1_sum, s2_sum+weights[index]));
+		return Math.min(
+			solve(index + 1, sum1 + weights[index], sum2), 
+			solve(index + 1, sum1, sum2 + weights[index])
+		);
 	}
 
-	//see "Intro - FastIO"
-	//this class acts similarly to Scanner, but faster
-	static class FastIO {
-
-		InputStream dis;
-		byte[] buffer = new byte[1 << 17];
-		int pointer = 0;
-
-		public FastIO(String fileName) throws Exception {
-			dis = new FileInputStream(fileName);
-		}
-
-		public FastIO(InputStream is) throws Exception {
-			dis = is;
-		}
-
-		int nextInt() throws Exception {
-			int ret = 0;
-
-			byte b;
-			do {
-				b = nextByte();
-			} while (b <= ' ');
-			boolean negative = false;
-			if (b == '-') {
-				negative = true;
-				b = nextByte();
-			}
-			while (b >= '0' && b <= '9') {
-				ret = 10 * ret + b - '0';
-				b = nextByte();
-			}
-
-			return (negative) ? -ret : ret;
-		}
-
-		long nextLong() throws Exception {
-			long ret = 0;
-
-			byte b;
-			do {
-				b = nextByte();
-			} while (b <= ' ');
-			boolean negative = false;
-			if (b == '-') {
-				negative = true;
-				b = nextByte();
-			}
-			while (b >= '0' && b <= '9') {
-				ret = 10 * ret + b - '0';
-				b = nextByte();
-			}
-
-			return (negative) ? -ret : ret;
-		}
-
-		byte nextByte() throws Exception {
-			if (pointer == buffer.length) {
-				dis.read(buffer, 0, buffer.length);
-				pointer = 0;
-			}
-			return buffer[pointer++];
-		}
-
-		String next() throws Exception {
-			StringBuffer ret = new StringBuffer();
-
-			byte b;
-			do {
-				b = nextByte();
-			} while (b <= ' ');
-			while (b > ' ') {
-				ret.appendCodePoint(b);
-				b = nextByte();
-			}
-
-			return ret.toString();
-		}
-
-	}
-
+	CodeSnip{Kattio}
 }
-
 ```
 
 </JavaSection>
@@ -222,7 +142,7 @@ def solve(i, s1, s2):
 	if i == n:
 		return abs(s2-s1)
 	return min(solve(i+1, s1+p[i], s2),
-			   solve(i+1, s1, s2+p[i]))
+			solve(i+1, s1, s2+p[i]))
 
 print(solve(0, 0, 0))
 ```
@@ -249,12 +169,12 @@ minimum difference between their sums.
 Note the fancy bitwise operations:
 
 - `1 << x` for an integer $x$ is another way of writing $2^x$, which, in binary,
-  has only the $x$'th bit turned on.
+has only the $x$'th bit turned on.
 - The `&` (and) operator will take two integers and return a new integer.
-  `a & b` for integers $a$ and $b$ will return a new integer whose $i$'th bit is
-  turned on if and only if the $i$'th bit is turned on for both $a$ and $b$.
-  Thus, `mask & (1 << x)` will return a positive value only if the $x$'th bit is
-  turned on in $mask$.
+`a & b` for integers $a$ and $b$ will return a new integer whose $i$'th bit is
+turned on if and only if the $i$'th bit is turned on for both $a$ and $b$.
+Thus, `mask & (1 << x)` will return a positive value only if the $x$'th bit is
+turned on in $mask$.
 
 <Info title="Bitwise Operations">
 
@@ -322,23 +242,21 @@ import java.io.*;
 
 public class Main {
 	public static void main(String[] args) throws Exception {
-		FastIO sc = new FastIO(System.in); //see "Intro - FastIO" - this class acts similarly to Scanner
-		PrintWriter pw = new PrintWriter(System.out);
+		Kattio io = new Kattio();
 
-		int N = sc.nextInt();
+		int N = io.nextInt();
 		int weights[] = new int[N];
 		for (int i = 0; i < N; i++) {
-			weights[i] = sc.nextInt();
+			weights[i] = io.nextInt();
 		}
 
 		long ans = Long.MAX_VALUE;
-
 		for (int bitmask = 0; bitmask < (1 << N); bitmask++) {
 			long s1 = 0;
 			long s2 = 0;
 
 			for (int i = 0; i < N; i++) {
-				if((bitmask & (1 << i)) > 0) {
+				if ((bitmask & (1 << i)) > 0) {
 					s1 += weights[i];
 				} else {
 					s2 += weights[i];
@@ -347,91 +265,11 @@ public class Main {
 			ans = Math.min(ans, Math.abs(s1-s2));
 		}
 
-		pw.println(ans);
-		pw.close();
+		io.println(ans);
+		io.close();
 	}
 
-
-	//See Intro - FastIO
-	//this class acts similarly to Scanner
-	static class FastIO {
-
-		InputStream dis;
-		byte[] buffer = new byte[1 << 17];
-		int pointer = 0;
-
-		public FastIO(String fileName) throws Exception {
-			dis = new FileInputStream(fileName);
-		}
-
-		public FastIO(InputStream is) throws Exception {
-			dis = is;
-		}
-
-		int nextInt() throws Exception {
-			int ret = 0;
-
-			byte b;
-			do {
-				b = nextByte();
-			} while (b <= ' ');
-			boolean negative = false;
-			if (b == '-') {
-				negative = true;
-				b = nextByte();
-			}
-			while (b >= '0' && b <= '9') {
-				ret = 10 * ret + b - '0';
-				b = nextByte();
-			}
-
-			return (negative) ? -ret : ret;
-		}
-
-		long nextLong() throws Exception {
-			long ret = 0;
-
-			byte b;
-			do {
-				b = nextByte();
-			} while (b <= ' ');
-			boolean negative = false;
-			if (b == '-') {
-				negative = true;
-				b = nextByte();
-			}
-			while (b >= '0' && b <= '9') {
-				ret = 10 * ret + b - '0';
-				b = nextByte();
-			}
-
-			return (negative) ? -ret : ret;
-		}
-
-		byte nextByte() throws Exception {
-			if (pointer == buffer.length) {
-				dis.read(buffer, 0, buffer.length);
-				pointer = 0;
-			}
-			return buffer[pointer++];
-		}
-
-		String next() throws Exception {
-			StringBuffer ret = new StringBuffer();
-
-			byte b;
-			do {
-				b = nextByte();
-			} while (b <= ' ');
-			while (b > ' ') {
-				ret.appendCodePoint(b);
-				b = nextByte();
-			}
-
-			return ret.toString();
-		}
-
-	}
+	CodeSnip{Kattio}
 }
 
 ```
@@ -544,11 +382,11 @@ using pi = pair<int,int>;
 #define s second
 #define mp make_pair
 void setIO(string name = "") { // name is nonempty for USACO file I/O
-    ios_base::sync_with_stdio(0); cin.tie(0); // see Fast Input & Output
-    if(sz(name)){
-        freopen((name+".in").c_str(), "r", stdin); // see Input & Output
-        freopen((name+".out").c_str(), "w", stdout);
-    }
+	ios_base::sync_with_stdio(0); cin.tie(0); // see Fast Input & Output
+	if(sz(name)){
+		freopen((name+".in").c_str(), "r", stdin); // see Input & Output
+		freopen((name+".out").c_str(), "w", stdout);
+	}
 }
 
 int N, cnt[26];
@@ -599,34 +437,38 @@ public class Main {
 		}
 		for (int i = 0; i < 26; ++i) {
 			if (cnt[i] > 0) {
-				--cnt[i];
-				perm += (char)(i + 'a');
+				cnt[i]--;
+				perm += (char) (i + 'a');
 				search();
-				++cnt[i];
-				perm = perm.substring(0, perm.length() - 1); //removes last character
+				cnt[i]++;
+
+                // removes last character
+				perm = perm.substring(0, perm.length() - 1);
 			}
 		}
 	}
 
 	public static void main(String[] args) throws Exception {
-		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-		s = br.readLine();
+		Kattio io = new Kattio();
+		s = io.next();
 		N = s.length();
 		cnt = new int[26];
 		perms = new ArrayList<String>();
 		perm = "";
-		for (int i = 0; i < N; ++i) {
+		for (int i = 0; i < N; i++) {
 			int index = (int)(s.charAt(i) - 'a');
-			++cnt[index];
+			cnt[index]++;
 		}
 		search();
 		Collections.sort(perms);
-		System.out.println(perms.size());
+		io.println(perms.size());
 		for (String i : perms) {
-			System.out.println(i);
+			io.println(i);
 		}
-		br.close();
+		io.close();
 	}
+
+    CodeSnip{Kattio}
 }
 ```
 
@@ -930,11 +772,11 @@ public class Chessboard {
 	public static ArrayList < Integer > perm = new ArrayList < Integer > ();
 	public static boolean[] chosen = new boolean[8];
 	public static int ans = 0;
+
 	public static void main(String[] args) throws IOException {
-		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-		PrintWriter out = new PrintWriter(System.out);
+		Kattio io = new Kattio();
 		for (int i = 0; i < 8; i++) {
-			String str = br.readLine();
+			String str = io.next();
 			for (int j = 0; j < 8; j++) {
 				ok[i][j] = (str.charAt(j) == '.');
 			}
@@ -943,6 +785,7 @@ public class Chessboard {
 		out.println(ans);
 		out.close();
 	}
+	
 	public static void genperm() {
 		if (perm.size() == 8) {
 			boolean works = true;
@@ -1057,15 +900,15 @@ public class Main {
 	}
 
 	public static void main(String[] args) throws Exception {
-		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		Kattio io = new Kattio();
 		g = new String[8];
 		sum = new boolean[15]; dif = new boolean[15]; c = new boolean[8];
 		for(int i = 0; i < 8; ++i) {
-			g[i] = br.readLine();
+			g[i] = io.next();
 		}
 		dfs(0);
-		System.out.println(ans);
-		br.close();
+		io.println(ans);
+		io.close();
 	}
 }
 ```
@@ -1081,17 +924,17 @@ d2 = [0] * 15
 c = [0] * 8
 ans = 0
 def dfs(r): # place queen in r-th row
-    if r == 8:
-        ans += 1
-    else:
-        for i in range(8):
-            if g[r][i] == '*':
-                continue
-            if c[i] or d1[r + i] or d2[i - r + 7]:
-                continue
-            c[i] = d1[r + i] = d2[i - r + 7] = 1
-            dfs(r + 1)
-            c[i] = d1[r + i] = d2[i - r + 7] = 0
+	if r == 8:
+		ans += 1
+	else:
+		for i in range(8):
+			if g[r][i] == '*':
+				continue
+			if c[i] or d1[r + i] or d2[i - r + 7]:
+				continue
+			c[i] = d1[r + i] = d2[i - r + 7] = 1
+			dfs(r + 1)
+			c[i] = d1[r + i] = d2[i - r + 7] = 0
 dfs(0)
 print(ans)
 ```

--- a/content/2_Bronze/Complete_Rec.mdx
+++ b/content/2_Bronze/Complete_Rec.mdx
@@ -820,6 +820,8 @@ public class Chessboard {
 			}
 		}
 	}
+	
+	CodeSnip{Kattio}
 }
 ```
 
@@ -910,6 +912,8 @@ public class Main {
 		io.println(ans);
 		io.close();
 	}
+	
+	CodeSnip{Kattio}
 }
 ```
 

--- a/content/2_Bronze/Complete_Rec.mdx
+++ b/content/2_Bronze/Complete_Rec.mdx
@@ -5,7 +5,7 @@ author: Darren Yao, Sam Zhang, Michael Cao, Andrew Wang, Benjamin Qi, Dong Liu
 description: 'Includes generating subsets and permutations.'
 frequency: 1
 prerequisites:
-- intro-complete
+  - intro-complete
 ---
 
 <Warning>
@@ -77,7 +77,7 @@ ll solve(int i, ll s1, ll s2){
 		return abs(s1 - s2);
 	}
 	return min(solve(i + 1, s1 + weights[i], s2),
-				solve(i + 1, s1, s2 + weights[i]));
+			solve(i + 1, s1, s2 + weights[i]));
 }
 
 int main() {
@@ -169,12 +169,12 @@ minimum difference between their sums.
 Note the fancy bitwise operations:
 
 - `1 << x` for an integer $x$ is another way of writing $2^x$, which, in binary,
-has only the $x$'th bit turned on.
+  has only the $x$'th bit turned on.
 - The `&` (and) operator will take two integers and return a new integer.
-`a & b` for integers $a$ and $b$ will return a new integer whose $i$'th bit is
-turned on if and only if the $i$'th bit is turned on for both $a$ and $b$.
-Thus, `mask & (1 << x)` will return a positive value only if the $x$'th bit is
-turned on in $mask$.
+  `a & b` for integers $a$ and $b$ will return a new integer whose $i$'th bit is
+  turned on if and only if the $i$'th bit is turned on for both $a$ and $b$.
+  Thus, `mask & (1 << x)` will return a positive value only if the $x$'th bit is
+  turned on in $mask$.
 
 <Info title="Bitwise Operations">
 
@@ -442,7 +442,7 @@ public class Main {
 				search();
 				cnt[i]++;
 
-                // removes last character
+				// removes last character
 				perm = perm.substring(0, perm.length() - 1);
 			}
 		}

--- a/content/2_Bronze/Rect_Geo.mdx
+++ b/content/2_Bronze/Rect_Geo.mdx
@@ -92,17 +92,15 @@ int main() {
 
 ```java
 import java.io.*;
-import java.util.StringTokenizer;
+import java.util.*;
 
 public class Paint {
 	public static void main(String[] args) throws IOException {
-		BufferedReader reader = new BufferedReader(new FileReader("paint.in"));
-		StringTokenizer first = new StringTokenizer(reader.readLine());
-		StringTokenizer second = new StringTokenizer(reader.readLine());
-		int a = Integer.parseInt(first.nextToken());
-		int b = Integer.parseInt(first.nextToken());
-		int c = Integer.parseInt(second.nextToken());
-		int d = Integer.parseInt(second.nextToken());
+		Kattio io = new Kattio("paint");
+		int a = io.nextInt();
+		int b = io.nextInt();
+		int c = io.nextInt();
+		int d = io.nextInt();
 
 		// the sum of the two intervals
 		int total = (b - a) + (d - c);
@@ -110,10 +108,11 @@ public class Paint {
 		int intersection = Math.max(Math.min(b, d) - Math.max(a, c), 0);
 		int union = total - intersection;
 
-		PrintWriter writer = new PrintWriter("paint.out");
-		writer.println(union);
-		writer.close();
+		io.println(union);
+		io.close();
 	}
+
+	CodeSnip{Kattio}
 }
 ```
 
@@ -207,15 +206,16 @@ import java.util.*;
 
 public class Billboard {
 	private static final int MAX_POS = 2000;
+	
 	public static void main(String[] args) throws IOException {
-		BufferedReader br = new BufferedReader(new FileReader("billboard.in"));
+		Kattio io = new Kattio("billboard");
 		int visible[][] = new int[MAX_POS][MAX_POS];
+
 		for (int i = 0; i < 3; ++i) {
-			StringTokenizer board = new StringTokenizer(br.readLine());
-			int x1 = Integer.parseInt(board.nextToken());
-			int y1 = Integer.parseInt(board.nextToken());
-			int x2 = Integer.parseInt(board.nextToken());
-			int y2 = Integer.parseInt(board.nextToken());
+			int x1 = io.nextInt();
+			int y1 = io.nextInt();
+			int x2 = io.nextInt();
+			int y2 = io.nextInt();
 			x1 += MAX_POS / 2;
 			y1 += MAX_POS / 2;
 			x2 += MAX_POS / 2;
@@ -233,10 +233,12 @@ public class Billboard {
 				ans += visible[x][y];
 			}
 		}
-		PrintWriter out = new PrintWriter(new FileWriter("billboard.out"));
-		out.println(ans);
-		out.close();
+
+		io.println(ans);
+		io.close();
 	}
+
+    CodeSnip{Kattio}
 }
 ```
 

--- a/content/2_Bronze/Rect_Geo.mdx
+++ b/content/2_Bronze/Rect_Geo.mdx
@@ -238,7 +238,7 @@ public class Billboard {
 		io.close();
 	}
 
-    CodeSnip{Kattio}
+	CodeSnip{Kattio}
 }
 ```
 

--- a/content/2_Bronze/Simulation.mdx
+++ b/content/2_Bronze/Simulation.mdx
@@ -82,41 +82,45 @@ int main()
 ```java
 import java.util.*;
 import java.io.*;
-import java.lang.Math.*;
 
-public class shell
-{
-	public static Kattio io; // Refer to General - Input/Output
-	public static int N;
-	public static int['Simulation'] shell_at_position = new int[3], counter = new int[3];
-	/*
-	N stores the number of operations (as described in the problem statement)
-	shell_at_position[i] stores the label of the shell located at position i
-	counter[i] stores the number of times the shell with label i was picked
-	*/
-	public static void main(String['Simulation'] args) throws IOException
-	{
-		io=new Kattio("shell");
-		for(int i=0;i<3;++i)
-			shell_at_position[i]=i; // We arbitrarily place the shells down (In this case, I happen to be putting the shell with label i at position i)
-		N=io.nextInt();
-		for(int i=0;i<N;++i)
-		{
+public class Shell throws IOException {
+	public static void main(String[] args) throws {
+		Kattio io = new Kattio("shell");
+
+		/*
+		* N stores the number of operations (as described in problem)
+		* shellAtPosition[i] stores the label of the shell at position i
+		* counter[i] stores the number of times the shell i was picked
+		*/
+		int N = io.nextInt();
+		int[] shellAtPosition = new int[3];
+		int[] counter = new int[3];
+
+		// Arbitrarily place the shells down
+		// In this case, we happen to be putting the shell with label i at position i
+		for (int i = 0; i < 3; i++) {
+			shellAtPosition[i] = i;
+		}
+
+		for (int i = 0; i < N; i++) {
 			// Zero indexing: offset all positions by 1
-			int a=io.nextInt()-1;
-			int b=io.nextInt()-1;
-			int g=io.nextInt()-1;
+			int a = io.nextInt()-1;
+			int b = io.nextInt()-1;
+			int g = io.nextInt()-1;
 
 			// Perform Bessie's swapping operation
-			int t=shell_at_position[b];
-			shell_at_position[b]=shell_at_position[a];
-			shell_at_position[a]=t;
+			int t = shellAtPosition[b];
+			shellAtPosition[b] = shellAtPosition[a];
+			shellAtPosition[a] = t;
 
-			++counter[shell_at_position[g]]; // Count the number of times Elsie guesses each particular shell
+			counter[shellAtPosition[g]]++; // Count the number of times Elsie guesses each particular shell
 		}
+
 		io.println(Math.max(counter[0], Math.max(counter[1], counter[2])));
 		io.close();
 	}
+
+	CodeSnip{Kattio}
 }
 ```
 
@@ -214,39 +218,46 @@ int main()
 ```java
 import java.util.*;
 import java.io.*;
-import java.lang.Math.*;
 
-public class mixmilk
-{
-	public static Kattio io; // Refer to General - Input/Output
-	public static final int N = 3;
-	public static int['Simulation'] capacity = new int[N], milk = new int[N];
+public class MixMilk {
 	/*
-	N is the number of buckets (which happens to be a constant value of 3)
-	capacity[i] is the maximum capacity of bucket i
-	milk[i] is the current amount of milk in bucket i
+	* N is the number of buckets (which is 3)
+	* capacity[i] is the maximum capacity of bucket i
+	* milk[i] is the current amount of milk in bucket i
 	*/
-	public static void pour(int i, int j)
-	{
-		int amt=Math.min(milk[i], capacity[j]-milk[j]);
-		// Amount of milk to pour is the minimum of the remaining milk in bucket i and the available capacity in bucket j
-		milk[i]-=amt;
-		milk[j]+=amt;
+	static int N = 3;
+	static int[] capacity = new int[N];
+	static int[] milk = new int[N];
+
+	public static void pour(int i, int j) {
+		// Amount of milk to pour is the minimum of remaining milk in bucket i
+		// and the available capacity in bucket j
+		int amount = Math.min(milk[i], capacity[j] - milk[j]);
+		milk[i] -= amt;
+		milk[j] += amt;
 	}
-	public static void main(String['Simulation'] args) throws IOException
-	{
-		io = new Kattio("mixmilk");
-		for(int i=0;i<N;++i)
-		{
+
+	public static void main(String[] args) throws IOException {
+		Kattio io = new Kattio("mixmilk");
+
+		for (int i = 0; i < N; i++) {
 			capacity[i] = io.nextInt();
 			milk[i] = io.nextInt();
 		}
-		for(int i=0;i<100;++i)
-			pour(i%N, (i+1)%N); // Pour milk from one bucket to the next
-		for(int i=0;i<N;++i)
+
+		// Simulate all 100 pour operations, where we pour milk from one bucket
+		// to the next
+		for (int i = 0; i < 100; i++) {
+			pour(i % N, (i + 1) % N);
+		}
+
+		for(int i=0; i < N; i++) {
 			io.println(milk[i]);
+		}
 		io.close();
 	}
+	
+	CodeSnip{Kattio}
 }
 ```
 

--- a/content/2_Bronze/Simulation.mdx
+++ b/content/2_Bronze/Simulation.mdx
@@ -104,9 +104,9 @@ public class Shell {
 
 		for (int i = 0; i < N; i++) {
 			// Zero indexing: offset all positions by 1
-			int a = io.nextInt()-1;
-			int b = io.nextInt()-1;
-			int g = io.nextInt()-1;
+			int a = io.nextInt() - 1;
+			int b = io.nextInt() - 1;
+			int g = io.nextInt() - 1;
 
 			// Perform Bessie's swapping operation
 			int t = shellAtPosition[b];

--- a/content/2_Bronze/Simulation.mdx
+++ b/content/2_Bronze/Simulation.mdx
@@ -234,8 +234,8 @@ public class MixMilk {
 		// Amount of milk to pour is the minimum of remaining milk in bucket i
 		// and the available capacity in bucket j
 		int amount = Math.min(milk[i], capacity[j] - milk[j]);
-		milk[i] -= amt;
-		milk[j] += amt;
+		milk[i] -= amount;
+		milk[j] += amount;
 	}
 
 	public static void main(String[] args) throws IOException {

--- a/content/2_Bronze/Simulation.mdx
+++ b/content/2_Bronze/Simulation.mdx
@@ -83,8 +83,8 @@ int main()
 import java.util.*;
 import java.io.*;
 
-public class Shell throws IOException {
-	public static void main(String[] args) throws {
+public class Shell {
+	public static void main(String[] args) throws IOException {
 		Kattio io = new Kattio("shell");
 
 		/*

--- a/content/2_Bronze/Simulation.mdx
+++ b/content/2_Bronze/Simulation.mdx
@@ -88,10 +88,10 @@ public class Shell throws IOException {
 		Kattio io = new Kattio("shell");
 
 		/*
-		* N stores the number of operations (as described in problem)
-		* shellAtPosition[i] stores the label of the shell at position i
-		* counter[i] stores the number of times the shell i was picked
-		*/
+		 * N stores the number of operations (as described in problem)
+		 * shellAtPosition[i] stores the label of the shell at position i
+		 * counter[i] stores the number of times the shell i was picked
+		 */
 		int N = io.nextInt();
 		int[] shellAtPosition = new int[3];
 		int[] counter = new int[3];
@@ -137,6 +137,7 @@ sys.stdout = open("shell.out", "w")
 N=int(input())
 shell_at_position=[0,1,2]
 counter=[0,0,0]
+
 """
 N stores the number of operations (as described in the problem statement)
 shell_at_position[i] stores the label of the shell located at position i
@@ -221,10 +222,10 @@ import java.io.*;
 
 public class MixMilk {
 	/*
-	* N is the number of buckets (which is 3)
-	* capacity[i] is the maximum capacity of bucket i
-	* milk[i] is the current amount of milk in bucket i
-	*/
+	 * N is the number of buckets (which is 3)
+	 * capacity[i] is the maximum capacity of bucket i
+	 * milk[i] is the current amount of milk in bucket i
+	 */
 	static int N = 3;
 	static int[] capacity = new int[N];
 	static int[] milk = new int[N];
@@ -251,7 +252,7 @@ public class MixMilk {
 			pour(i % N, (i + 1) % N);
 		}
 
-		for(int i = 0; i < N; i++) {
+		for (int i = 0; i < N; i++) {
 			io.println(milk[i]);
 		}
 		io.close();

--- a/content/2_Bronze/Simulation.mdx
+++ b/content/2_Bronze/Simulation.mdx
@@ -251,7 +251,7 @@ public class MixMilk {
 			pour(i % N, (i + 1) % N);
 		}
 
-		for(int i=0; i < N; i++) {
+		for(int i = 0; i < N; i++) {
 			io.println(milk[i]);
 		}
 		io.close();


### PR DESCRIPTION
I wanted to make code from some bronze modules easier to read by adding Kattio instead of buffered reader and formatting the code to follow Java conventions. The reformatted code has all been tested.