### PR TITLE
Inline problem name on problems page

### DIFF
--- a/src/components/ProblemsPage/ProblemHits.tsx
+++ b/src/components/ProblemsPage/ProblemHits.tsx
@@ -12,7 +12,7 @@ function ProblemHit({ hit }: { hit: AlgoliaProblemInfo }) {
       <p className="text-xl leading-6 mt-1 mb-2">
         {/* <Highlight hit={hit} attribute="name" /> */}
         <Link to={hit.url} target="_blank">
-          <h1 className="text-lg hover:underline cursor-pointer">{hit.name}</h1>
+          <h1 className="text-lg hover:underline inline">{hit.name}</h1>
         </Link>
         {hit.isStarred && (
           <svg

--- a/src/components/ProblemsPage/ProblemHits.tsx
+++ b/src/components/ProblemsPage/ProblemHits.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'gatsby';
 import * as React from 'react';
+import { Highlight } from 'react-instantsearch-dom';
 import { moduleIDToSectionMap } from '../../../content/ordering';
 import { AlgoliaProblemInfo, getProblemURL } from '../../models/problem';
 
@@ -10,10 +11,14 @@ function ProblemHit({ hit }: { hit: AlgoliaProblemInfo }) {
         {hit.source}
       </span>
       <p className="text-xl leading-6 mt-1 mb-2">
-        {/* <Highlight hit={hit} attribute="name" /> */}
-        <Link to={hit.url} target="_blank">
-          <h1 className="text-lg hover:underline inline">{hit.name}</h1>
-        </Link>
+        <a
+          href={hit.url}
+          target="_blank"
+          rel="noreferrer"
+          className="hover:underline"
+        >
+          <Highlight hit={hit} attribute="name" />
+        </a>
         {hit.isStarred && (
           <svg
             className="h-6 w-4 text-blue-400 ml-2 pb-1 inline-block"


### PR DESCRIPTION
The problem name being block made the star appear on the next line.

Is there anything else that needs to be changed about the problems page? The clickable problem name makes the view problem statement redundant, but since it's not obvious that the problem name is clickable, people who are used to clicking the link below might not know what happened.
The link styling is also inconsistent; only the title underlines when hovered and they're all different colors.
