### PR TITLE
add editorial for atcoder dp contest + small wording fixes

### DIFF
--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -82,7 +82,7 @@ If you prefer watching videos instead, here are some options:
 
 <Info title="Pro Tip">
 
-Usually, it is a good idea to write a slower solution first. For example, if the
+It's usually a good idea to write a slower solution first. For example, if the
 complexity required for full points is $\mathcal{O}(N)$ and you come up with a
 simple $\mathcal{O}(N^2)$ solution, then you should definitely type that up
 first and earn some partial credit. Afterwards, you can rewrite parts of your

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -125,7 +125,7 @@ problemsetters rarely set direct applications of them.
 		url="https://atcoder.jp/contests/dp/tasks"
 		starred
 	>
-		Some tasks are beyond the scope of Gold. An editorial for problems A-I can be found [here](https://nwatx.me/post/atcoderdp).
+		Some tasks are beyond the scope of Gold. An editorial for problems A-L can be found [here](https://github.com/jessechoe10/CP/tree/master/AtCoder/DP%20Contest).
 	</Resource>
 	<Resource
 		source="CF@Codeforces"

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -125,7 +125,7 @@ problemsetters rarely set direct applications of them.
 		url="https://atcoder.jp/contests/dp/tasks"
 		starred
 	>
-		Some tasks are beyond the scope of Gold. Editorials for problems A to O can be found [here](https://nwatx.me/post/atcoderdp).
+		Some tasks are beyond the scope of Gold. Editorials for problems A to U can be found [here](https://nwatx.me/post/atcoderdp).
 	</Resource>
 	<Resource
 		source="CF@Codeforces"

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -125,7 +125,7 @@ problemsetters rarely set direct applications of them.
 		url="https://atcoder.jp/contests/dp/tasks"
 		starred
 	>
-		Some tasks are beyond the scope of Gold. An editorial for problems A-L can be found [here](https://github.com/jessechoe10/CP/tree/master/AtCoder/DP%20Contest).
+		Some tasks are beyond the scope of Gold. An editorial for problems A-I can be found [here](https://nwatx.me/post/atcoderdp). Alternative implementations for problems A - L can be found [here](https://github.com/jessechoe10/CP/tree/master/AtCoder/DP%20Contest).
 	</Resource>
 	<Resource
 		source="CF@Codeforces"

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -125,7 +125,7 @@ problemsetters rarely set direct applications of them.
 		url="https://atcoder.jp/contests/dp/tasks"
 		starred
 	>
-		Some tasks are beyond the scope of Gold. An editorial for problems A-E can be found [here](https://nwatx.me/post/atcoderdp).
+		Some tasks are beyond the scope of Gold. An editorial for problems A-E can be found [here](https://nwatx.me/post/atcoderdp). Alternative solutions for problems A - I can be found [here](https://github.com/jessechoe10/CP/tree/master/AtCoder/DP%20Contest).
 	</Resource>
 	<Resource
 		source="CF@Codeforces"

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -125,7 +125,7 @@ problemsetters rarely set direct applications of them.
 		url="https://atcoder.jp/contests/dp/tasks"
 		starred
 	>
-		Some tasks are beyond the scope of Gold. An editorial for problems A-I can be found [here](https://nwatx.me/post/atcoderdp). Alternative implementations for problems A - L can be found [here](https://github.com/jessechoe10/CP/tree/master/AtCoder/DP%20Contest).
+		Some tasks are beyond the scope of Gold. Editorials for problems A to I can be found [here](https://nwatx.me/post/atcoderdp). Alternative implementations for problems A to L can be found [here](https://github.com/jessechoe10/CP/tree/master/AtCoder/DP%20Contest).
 	</Resource>
 	<Resource
 		source="CF@Codeforces"

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -125,7 +125,7 @@ problemsetters rarely set direct applications of them.
 		url="https://atcoder.jp/contests/dp/tasks"
 		starred
 	>
-		Some tasks are beyond the scope of Gold. An editorial for problems A-E can be found [here](https://nwatx.me/post/atcoderdp). Alternative solutions for problems A - I can be found [here](https://github.com/jessechoe10/CP/tree/master/AtCoder/DP%20Contest).
+		Some tasks are beyond the scope of Gold. An editorial for problems A-I can be found [here](https://nwatx.me/post/atcoderdp).
 	</Resource>
 	<Resource
 		source="CF@Codeforces"

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -1,7 +1,7 @@
 ---
 id: intro-dp
 title: 'Introduction to DP'
-author: Michael Cao, Benjamin Qi, Jesse Choe, Neo Wang
+author: Michael Cao, Benjamin Qi
 prerequisites:
   - complete-rec
   - modular

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -125,7 +125,7 @@ problemsetters rarely set direct applications of them.
 		url="https://atcoder.jp/contests/dp/tasks"
 		starred
 	>
-		Some tasks are beyond the scope of Gold. Editorials for problems A to I can be found [here](https://nwatx.me/post/atcoderdp).
+		Some tasks are beyond the scope of Gold. Editorials for problems A to O can be found [here](https://nwatx.me/post/atcoderdp).
 	</Resource>
 	<Resource
 		source="CF@Codeforces"

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -125,7 +125,7 @@ problemsetters rarely set direct applications of them.
 		url="https://atcoder.jp/contests/dp/tasks"
 		starred
 	>
-		Some tasks are beyond the scope of Gold. Editorials for problems A to I can be found [here](https://nwatx.me/post/atcoderdp). Alternative implementations for problems A to L can be found [here](https://github.com/jessechoe10/CP/tree/master/AtCoder/DP%20Contest).
+		Some tasks are beyond the scope of Gold. Editorials for problems A to I can be found [here](https://nwatx.me/post/atcoderdp).
 	</Resource>
 	<Resource
 		source="CF@Codeforces"

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -1,7 +1,7 @@
 ---
 id: intro-dp
 title: 'Introduction to DP'
-author: Michael Cao, Benjamin Qi
+author: Michael Cao, Benjamin Qi, Neo Wang
 prerequisites:
   - complete-rec
   - modular
@@ -30,23 +30,20 @@ competitors in the USACO Gold division.
 		title="DP from Novice to Advanced"
 		url="dynamic-programming-from-novice-to-advanced"
 	>
-		great for all skill levels
+		General tutorial, great for all skill levels
 	</Resource>
 	<Resource source="CPC" title="6 - DP" url="06_dynamic_programming">
-		examples with nonclassical problems
+		Contains examples with nonclassical problems
 	</Resource>
 	<Resource source="CP2" title="3.5 - DP">
-		describes many ways to solve example problem, additional classical examples
+		Describes many ways to solve the example problem + additional classical examples
 	</Resource>
 	<Resource
 		source="HR@HackerRank"
 		title="DP"
 		url="https://www.hackerrank.com/topics/dynamic-programming"
 	>
-		also covers many classical problems
-	</Resource>
-	<Resource source="PAPS" title="9 - DP">
-		starts with DAGs, which are covered in "Topological Sort"
+		Covers classical problems
 	</Resource>
 </Resources>
 
@@ -58,34 +55,34 @@ If you prefer watching videos instead, here are some options:
 		title="Errichto DP #1 - Fibonacci, iteration vs recursion"
 		url="https://www.youtube.com/watch?v=YBSt1jYwVfU"
 	>
-		Great Introductory Errichto DP Video
+		Great introduction video
 	</Resource>
 	<Resource
 		source="Youtube"
 		title="Errichto DP #2 - Coin change, double counting"
 		url="https://www.youtube.com/watch?v=1mtvm2ubHCY"
 	>
-		Another Errichto DP video regarding coin change
+		Errichto DP video regarding coin change
 	</Resource>
 	<Resource
 		source="Youtube"
 		title="Errichto DP #3 - Line of Wines"
 		url="https://www.youtube.com/watch?v=pwpOC1dph6U"
 	>
-		Another Errichto DP video
+		Errichto DP problem editorial
 	</Resource>
 	<Resource
 		source="Youtube"
 		title="WilliamFiset DP Videos"
 		url="https://www.youtube.com/watch?v=_tur2nPkIKo&list=PLDV1Zeh2NRsAsbafOroUBnNV8fhZa7P4u"
 	>
-		more DP videos, but some are more related to interview questions than CP
+		Animated DP videos that pertain to interview questions
 	</Resource>
 </Resources>
 
 <Info title="Pro Tip">
 
-It's usually a good idea to write a slower solution first. For example, if the
+Usually, it is a good idea to write a slower solution first. For example, if the
 complexity required for full points is $\mathcal{O}(N)$ and you come up with a
 simple $\mathcal{O}(N^2)$ solution, then you should definitely type that up
 first and earn some partial credit. Afterwards, you can rewrite parts of your
@@ -97,7 +94,7 @@ against.
 
 ## Classical Problems
 
-The next few modules provide examples of some classical problems, or Dynamic
+The next few modules provide examples of some classical problems: Dynamic
 Programming problems which are well known. However, classical doesn't
 necessarily mean common. Since so many competitors know about these problems,
 problemsetters rarely set direct applications of them.
@@ -128,7 +125,7 @@ problemsetters rarely set direct applications of them.
 		url="https://atcoder.jp/contests/dp/tasks"
 		starred
 	>
-		Some tasks are beyond the scope of Gold.
+		Some tasks are beyond the scope of Gold. An editorial for problems A-E can be found [here](https://nwatx.me/post/atcoderdp).
 	</Resource>
 	<Resource
 		source="CF@Codeforces"
@@ -136,8 +133,7 @@ problemsetters rarely set direct applications of them.
 		url="https://codeforces.com/blog/entry/86532"
 	>
 		Beginner-friendly classical problems. Some tasks requires input/output
-		files. <a href="https://github.com/Farrius/div3_dp_practice">Here</a> you
-		can check the solutions.
+		files. The solutions can be found <a href="https://github.com/Farrius/div3_dp_practice">here</a> 
 	</Resource>
 	<Resource
 		source="CF@Codeforces"

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -1,7 +1,7 @@
 ---
 id: intro-dp
 title: 'Introduction to DP'
-author: Michael Cao, Benjamin Qi
+author: Michael Cao, Benjamin Qi, Jesse Choe, Neo Wang
 prerequisites:
   - complete-rec
   - modular

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -1,7 +1,7 @@
 ---
 id: intro-dp
 title: 'Introduction to DP'
-author: Michael Cao, Benjamin Qi, Neo Wang
+author: Michael Cao, Benjamin Qi
 prerequisites:
   - complete-rec
   - modular


### PR DESCRIPTION
Like [last time](https://github.com/cpinitiative/usaco-guide/pull/998), I guess screenshot the blog directly to review it. A link can be found [here](https://nwatx.me/post/atcoderdp), or you can PR [source](https://github.com/nwatx/nwatx-blog/blob/main/content/atcoderdp.mdx) directly I guess.