### PR TITLE
increase tag limit + fix tag alignment

### DIFF
--- a/src/components/ProblemsPage/ProblemHits.tsx
+++ b/src/components/ProblemsPage/ProblemHits.tsx
@@ -86,10 +86,10 @@ function ProblemHit({ hit }: { hit: AlgoliaProblemInfo }) {
         ))}
       </ul>
 
-      <div className="pt-4 space-x-2">
+      <div className="pt-4">
         {hit.tags?.map(tag => (
           <span
-            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-dark-high-emphasis"
+            className="mr-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-dark-high-emphasis"
             key={tag}
           >
             {tag}

--- a/src/pages/problems.tsx
+++ b/src/pages/problems.tsx
@@ -40,7 +40,7 @@ export default function ProblemsPage(props: PageProps) {
             </div>
             <CustomRefinementList
               attribute="tags"
-              limit={100}
+              limit={500}
               searchable
               transformItems={items =>
                 items.sort((x, y) => x.label.localeCompare(y.label))


### PR DESCRIPTION
closes #1762 

I also increased the tag limit to 500, since the original tag limit of 100 didn't show all the tags, making it hard to search for problems tagged "Sorting" or "Simulation", for example. I can revert if this change isn't good, though.

I think that limiting tags to 100 is fine, except the tags are sorted alphabetically, so it doesn't make sense. It might be better to sort tags by their frequency and limit to the 100 most frequent tags.