### PR TITLE
New guidelines for authors vs contributors

### DIFF
--- a/content/1_General/Adding_Solution.mdx
+++ b/content/1_General/Adding_Solution.mdx
@@ -1,7 +1,8 @@
 ---
 id: adding-solution
 title: Adding Solutions
-author: Nathan Wang, Benjamin Qi, Maggie Liu, Sathvik Chundru, Qi Wang
+author: Nathan Wang, Benjamin Qi, Qi Wang
+contributors: Maggie Liu, Sathvik Chundru
 description: 'How you can add your own solutions to the guide.'
 prerequisites:
   - contributing

--- a/content/1_General/Contributing.mdx
+++ b/content/1_General/Contributing.mdx
@@ -7,8 +7,9 @@ prerequisites:
   - modules
 ---
 
-All modules are written in [MDX](https://mdxjs.com/) (Markdown + JSX) with the [XDM](https://github.com/wooorm/xdm) compiler.
-$\LaTeX$ is supported through [KaTeX](https://katex.org/), and the Guide uses a number of custom MDX
+All modules are written in [MDX](https://mdxjs.com/) (Markdown + JSX) with the
+[XDM](https://github.com/wooorm/xdm) compiler. $\LaTeX$ is supported through
+[KaTeX](https://katex.org/), and the Guide uses a number of custom MDX
 components. If you are confused about something, or if there's a certain feature
 that you want to add, reach out to Nathan Wang.
 
@@ -75,6 +76,11 @@ Some examples:
     templates.
   - Should be consistent across languages.
 - Adding modules!
+- If you add a substantial amount of text content to a module, add your name to
+  the list of authors in the frontmatter.
+- If you add code implementations or improve existing implementations in a more
+  significant way than simply refactoring code, or if you add a short
+  explanation, add your name to the list of contributors.
 
 ### Problems
 

--- a/content/1_General/Cpp_Command.mdx
+++ b/content/1_General/Cpp_Command.mdx
@@ -1,8 +1,8 @@
 ---
 id: cpp-command
 title: C++ With the Command Line
-author:
-  Benjamin Qi, Hankai Zhang, Anthony Wang, Nathan Wang, Nathan Chen, Michael Lan
+author: Many
+contributors: Benjamin Qi, Hankai Zhang, Anthony Wang, Nathan Wang, Nathan Chen, Michael Lan
 description:
   'OS-specific instructions for installing and running C++ via the command line.'
 prerequisites:

--- a/content/1_General/IO.mdx
+++ b/content/1_General/IO.mdx
@@ -1,7 +1,7 @@
 ---
 id: io
 title: Input & Output
-author: Darren Yao, Benjamin Qi, Nathan Wang, Allen Li
+author: Darren Yao, Benjamin Qi, Allen Li
 description:
   Demonstrates how to read input and print output for USACO contests, including
   an example problem.

--- a/content/1_General/Modules.mdx
+++ b/content/1_General/Modules.mdx
@@ -66,12 +66,8 @@ topic!
 
 We'll try our best to write full editorials for problems which don't have them
 (or if existing editorials are poorly written). _Starred problems will generally
-have better editorials._
-
-_Pre-release note_: Currently, very few problems have full editorials. We've
-provided some temporary _solution sketches_ (very short solution explanations)
-while we continue working on this guide. If you believe an editorial is needed
-for a problem, please let us know using the "Contact Us" button.
+have better editorials._ If you believe an editorial is needed for a problem,
+please let us know using the "Contact Us" button.
 
 <Warning>
 

--- a/content/1_General/Running_Code_Locally.mdx
+++ b/content/1_General/Running_Code_Locally.mdx
@@ -1,9 +1,8 @@
 ---
 id: running-code-locally
 title: Running Code Locally
-author:
-  Benjamin Qi, Hankai Zhang, Anthony Wang, Nathan Wang, Nathan Chen, Owen Wang,
-  Shourya Bansal, Dong Liu
+author: Many
+contributors: Benjamin Qi, Hankai Zhang, Anthony Wang, Nathan Wang, Nathan Chen, Owen Wang, Shourya Bansal, Dong Liu
 description: Options for running your language of choice locally.
 prerequisites:
   - running-code-online

--- a/content/1_General/Running_Code_Online.mdx
+++ b/content/1_General/Running_Code_Online.mdx
@@ -1,7 +1,7 @@
 ---
 id: running-code-online
 title: Running Code Online
-author: Benjamin Qi, Hankai Zhang, Anthony Wang, Nathan Wang, Nathan Chen
+author: Benjamin Qi, Nathan Wang
 description: Options for running your language of choice online.
 prerequisites:
   - resources-learning-to-code

--- a/content/1_General/Working_MDX.mdx
+++ b/content/1_General/Working_MDX.mdx
@@ -9,9 +9,10 @@ prerequisites:
   - modules
 ---
 
-We're using [MDX](https://mdxjs.com/), a superset of Markdown, using the [XDM compiler](https://github.com/wooorm/xdm). HTML and React
-components are supported, so it is possible to add interactivity / custom
-components to each module.
+We're using [MDX](https://mdxjs.com/), a superset of Markdown, using the
+[XDM compiler](https://github.com/wooorm/xdm). HTML and React components are
+supported, so it is possible to add interactivity / custom components to each
+module.
 
 ## Frontmatter
 
@@ -25,6 +26,8 @@ written in [YAML](https://yaml.org/). It stores the "metadata" for each module.
   based off this.
 - **Title**: _Required_. The title of the module. Ex: `Getting Started`
 - **Author**: _Required_. The author of the module. Ex: `Unknown`
+- **Contributors**: _Optional_. The people who contributed code and short
+  explanations to the module.
 - **Description**: _Required_. A short description of the module, similar to
   what [codecademy](https://www.codecademy.com/learn/paths/computer-science) has
   in their syllabus. Markdown/Latex does not work in the description field.
@@ -84,11 +87,19 @@ Markdown. Keep this in mind when formatting your module.
 <Optional title="XDM and MDX">
 We use the [XDM compiler](https://github.com/wooorm/xdm), which has a few differences from MDX v1:
 
-- Markdown interleaved in JSX is fully supported; ie. this works as expected: `<Info>some **markdown**</Info>`
-- As an extension of (1), indentation is fully supported. You can indent the markdown nested in JSX tags. This also means that indenting text with four spaces doesn't make it a code block; explicitly wrap the code block with three backticks instead.
+- Markdown interleaved in JSX is fully supported; ie. this works as expected:
+  `<Info>some **markdown**</Info>`
+- As an extension of (1), indentation is fully supported. You can indent the
+  markdown nested in JSX tags. This also means that indenting text with four
+  spaces doesn't make it a code block; explicitly wrap the code block with three
+  backticks instead.
 - `<` and `>` need to be escaped with backslashes; ie. `\<`
 
-Note that JSX comments (`{/* ... */}`) don't work well with Prettier, so use [HTML comments](https://www.w3schools.com/html/html_comments.asp) instead. Internally we map HTML comments to JSX comments before passing the markdown to XDM. Don't worry if you don't understand all of this yet.
+Note that JSX comments (`{/* ... */}`) don't work well with Prettier, so use
+[HTML comments](https://www.w3schools.com/html/html_comments.asp) instead.
+Internally we map HTML comments to JSX comments before passing the markdown to
+XDM. Don't worry if you don't understand all of this yet.
+
 </Optional>
 
 Some components are globally available in every module (without having to be
@@ -320,11 +331,12 @@ author: Nathan Wang
 ```
 
 The ID of the solution frontmatter must be the same as the unique ID of the
-problem. Make sure to also update the `kind` of the `solutionMetadata` to `'internal'` for any
-associated problems. We assume that if there is an internal solution, we should
-use it; therefore, the build will throw an error if there is an internal
-solution but the `solutionMetadata`'s `kind` isn't set to `'internal'`. The
-[next module](/general/adding-solution) describes how to add a new solution.
+problem. Make sure to also update the `kind` of the `solutionMetadata` to
+`'internal'` for any associated problems. We assume that if there is an internal
+solution, we should use it; therefore, the build will throw an error if there is
+an internal solution but the `solutionMetadata`'s `kind` isn't set to
+`'internal'`. The [Adding Solutions module](/general/adding-solution) describes
+how to add a new solution.
 
 ### Focus Problem
 

--- a/content/2_Bronze/Complete_Rec.mdx
+++ b/content/2_Bronze/Complete_Rec.mdx
@@ -1,7 +1,8 @@
 ---
 id: complete-rec
 title: 'Complete Search with Recursion'
-author: Darren Yao, Sam Zhang, Michael Cao, Andrew Wang, Benjamin Qi, Dong Liu, Maggie Liu
+author: Many
+contributors: Darren Yao, Sam Zhang, Michael Cao, Andrew Wang, Benjamin Qi, Dong Liu, Maggie Liu
 description: 'Includes generating subsets and permutations.'
 frequency: 1
 prerequisites:

--- a/content/2_Bronze/Intro_Complete.mdx
+++ b/content/2_Bronze/Intro_Complete.mdx
@@ -2,6 +2,7 @@
 id: intro-complete
 title: 'Basic Complete Search'
 author: Darren Yao, Dong Liu
+contributors: Brad Ma
 description: 'An easy example: iterating through all pairs.'
 frequency: 4
 ---

--- a/content/2_Bronze/Intro_DS.mdx
+++ b/content/2_Bronze/Intro_DS.mdx
@@ -1,7 +1,8 @@
 ---
 id: intro-ds
 title: Introduction to Data Structures
-author: Darren Yao, Benjamin Qi, Nathan Wang, Abutalib Namazov, Allen Li
+author: Darren Yao, Benjamin Qi, Allen Li
+contributors: Nathan Wang, Abutalib Namazov
 description:
   'Introduces the concept of a data structure, (dynamic) arrays, pairs, tuples.'
 ---

--- a/content/2_Bronze/Intro_Sets.mdx
+++ b/content/2_Bronze/Intro_Sets.mdx
@@ -1,7 +1,7 @@
 ---
 id: intro-sets
 title: Introduction to Sets & Maps
-author: Darren Yao, Benjamin Qi, Allen Li, DRGSH
+author: Darren Yao, Benjamin Qi, Allen Li
 description:
   'Maintaining collections of distinct elements in sorted order with ordered
   sets.'

--- a/content/2_Bronze/Rect_Geo.mdx
+++ b/content/2_Bronze/Rect_Geo.mdx
@@ -1,7 +1,8 @@
 ---
 id: rect-geo
 title: 'Rectangle Geometry'
-author: Darren Yao, Michael Cao, Benjamin Qi, Allen Li, Andrew Wang, Dong Liu
+author: Darren Yao, Michael Cao, Benjamin Qi
+contributors: Allen Li, Andrew Wang, Dong Liu
 description:
   'Problems involving rectangles whose sides are parallel to the coordinate
   axes.'

--- a/content/2_Bronze/Simulation.mdx
+++ b/content/2_Bronze/Simulation.mdx
@@ -1,7 +1,8 @@
 ---
 id: simulation
 title: 'Simulation'
-author: Darren Yao, Allen Li, Siyong Huang
+author: Darren Yao
+contributors: Allen Li, Siyong Huang
 description:
   'Directly simulating the problem statement, which many Bronze problems allow
   you to do.'

--- a/content/3_Silver/DFS.mdx
+++ b/content/3_Silver/DFS.mdx
@@ -3,7 +3,8 @@ id: dfs
 redirects:
   - /silver/bipartite
 title: Depth First Search (DFS)
-author: Siyong Huang, Andrew Wang, Jason Chen, Benjamin Qi
+author: Siyong Huang, Benjamin Qi
+contributors: Andrew Wang, Jason Chen
 prerequisites:
   - intro-graphs
   - complete-rec

--- a/content/3_Silver/Flood_Fill.mdx
+++ b/content/3_Silver/Flood_Fill.mdx
@@ -1,7 +1,8 @@
 ---
 id: ff
 title: Flood Fill
-author: Darren Yao, Kevin Sheng
+author: Darren Yao
+contributors: Kevin Sheng
 prerequisites:
   - dfs
 description: 'Finding connected components in a graph represented by a grid.'

--- a/content/3_Silver/Prefix_Sums.mdx
+++ b/content/3_Silver/Prefix_Sums.mdx
@@ -1,7 +1,7 @@
 ---
 id: prefix-sums
 title: 'Introduction to Prefix Sums'
-author: Darren Yao, Eric Wei
+author: Darren Yao
 description:
   'Computing range sum queries in constant time over a fixed 1D array.'
 prerequisites:

--- a/content/3_Silver/Prefix_Sums_2.mdx
+++ b/content/3_Silver/Prefix_Sums_2.mdx
@@ -1,7 +1,8 @@
 ---
 id: prefix-sums-2
 title: 'More on Prefix Sums'
-author: Darren Yao, Eric Wei, Neo Wang, Qi Wang, Jesse Choe, Kevin Sheng, Brad Ma
+author: Darren Yao, Neo Wang, Qi Wang
+contributors: Jesse Choe, Kevin Sheng, Brad Ma
 description:
   'Max subarray sum, prefix sums in two dimensions, and a more complicated
   example.'

--- a/content/4_Gold/All_Roots.mdx
+++ b/content/4_Gold/All_Roots.mdx
@@ -1,7 +1,8 @@
 ---
 id: all-roots
 title: DP on Trees - Solving For All Roots
-author: Benjamin Qi, Andi Qu, Andrew Wang, Dong Liu
+author: Benjamin Qi, Andi Qu, Andrew Wang
+contributors: Dong Liu
 prerequisites:
   - dp-trees
 description: Tree DP that uses the subtree from excluding each node's subtree.

--- a/content/4_Gold/BFS.mdx
+++ b/content/4_Gold/BFS.mdx
@@ -1,7 +1,8 @@
 ---
 id: bfs
 title: 'Breadth First Search (BFS)'
-author: Benjamin Qi, Michael Cao, Andi Qu, Neo Wang, Qi Wang
+author: Benjamin Qi, Andi Qu, Neo Wang 
+contributors: Qi Wang
 prerequisites:
   - dfs
   - ff

--- a/content/4_Gold/DP_Bitmasks.mdx
+++ b/content/4_Gold/DP_Bitmasks.mdx
@@ -1,7 +1,8 @@
 ---
 id: dp-bitmasks
 title: 'Bitmask DP'
-author: Michael Cao, Siyong Huang, Andrew Wang, Neo Wang
+author: Michael Cao, Siyong Huang 
+contributors: Andrew Wang, Neo Wang
 prerequisites:
   - intro-bitwise
   - intro-dp

--- a/content/4_Gold/DSU.mdx
+++ b/content/4_Gold/DSU.mdx
@@ -1,7 +1,8 @@
 ---
 id: dsu
 title: 'Disjoint Set Union'
-author: Benjamin Qi, Michael Cao, Andrew Wang
+author: Benjamin Qi, Andrew Wang
+contributors: Michael Cao
 prerequisites:
   - dfs
 description:

--- a/content/4_Gold/Knapsack_DP.mdx
+++ b/content/4_Gold/Knapsack_DP.mdx
@@ -1,7 +1,8 @@
 ---
 id: knapsack
 title: 'Knapsack DP'
-author: Nathan Chen, Michael Cao, Benjamin Qi, Neo Wang
+author: Nathan Chen, Michael Cao, Benjamin Qi
+contributors: Neo Wang
 prerequisites:
   - intro-dp
 description:

--- a/content/4_Gold/LIS.mdx
+++ b/content/4_Gold/LIS.mdx
@@ -2,8 +2,8 @@
 id: lis
 title: 'Longest Increasing Subsequence'
 author:
-  Michael Cao, Benjamin Qi, Andi Qu, Andrew Wang, Dong Liu, Siyong Huang,
-  Aryansh Shrivastava
+  Michael Cao, Benjamin Qi, Andrew Wang
+contributors: Andi Qu, Dong Liu, Siyong Huang, Aryansh Shrivastava
 prerequisites:
   - intro-dp
 description: Finding and using the longest increasing subsequence of an array.

--- a/content/4_Gold/LIS.mdx
+++ b/content/4_Gold/LIS.mdx
@@ -1,8 +1,7 @@
 ---
 id: lis
 title: 'Longest Increasing Subsequence'
-author:
-  Michael Cao, Benjamin Qi, Andrew Wang
+author: Michael Cao, Benjamin Qi, Andrew Wang
 contributors: Andi Qu, Dong Liu, Siyong Huang, Aryansh Shrivastava
 prerequisites:
   - intro-dp

--- a/content/4_Gold/LIS.mdx
+++ b/content/4_Gold/LIS.mdx
@@ -1,8 +1,8 @@
 ---
 id: lis
 title: 'Longest Increasing Subsequence'
-author: Michael Cao, Benjamin Qi, Andrew Wang
-contributors: Andi Qu, Dong Liu, Siyong Huang, Aryansh Shrivastava
+author: Michael Cao, Benjamin Qi, Andi Qu, Andrew Wang
+contributors: Dong Liu, Siyong Huang, Aryansh Shrivastava
 prerequisites:
   - intro-dp
 description: Finding and using the longest increasing subsequence of an array.
@@ -194,8 +194,6 @@ def find_lis(arr: List[int]) -> int:
 </LanguageSection>
 
 ### Fast Solution (RMQ Data Structures)
-
-(By Aryansh Shrivastava)
 
 **Time Complexity**: $\mathcal O(N \log N)$, but perhaps a constant factor
 slower than binary search.

--- a/content/4_Gold/MST.mdx
+++ b/content/4_Gold/MST.mdx
@@ -1,7 +1,8 @@
 ---
 id: mst
 title: 'Minimum Spanning Trees'
-author: Benjamin Qi, Andrew Wang, Neo Wang
+author: Benjamin Qi, Andrew Wang
+contributors: Neo Wang
 prerequisites:
   - sp
   - dsu

--- a/content/4_Gold/Modular.mdx
+++ b/content/4_Gold/Modular.mdx
@@ -1,7 +1,8 @@
 ---
 id: modular
 title: 'Modular Arithmetic'
-author: Darren Yao, Michael Cao, Andi Qu, Benjamin Qi, Andrew Wang, Kevin Sheng
+author: Darren Yao, Michael Cao, Andi Qu, Benjamin Qi, Andrew Wang
+contributors: Kevin Sheng
 prerequisites:
   - divis
 description: Working with remainders from division.

--- a/content/4_Gold/PURS.mdx
+++ b/content/4_Gold/PURS.mdx
@@ -1,7 +1,8 @@
 ---
 id: PURS
 title: 'Point Update Range Sum'
-author: Benjamin Qi, Andrew Wang, Dong Liu, Nathan Gong
+author: Benjamin Qi, Dong Liu, Nathan Gong
+contributors: Andrew Wang
 prerequisites:
   - prefix-sums
 description:

--- a/content/4_Gold/Paths_Grids.mdx
+++ b/content/4_Gold/Paths_Grids.mdx
@@ -1,7 +1,8 @@
 ---
 id: paths-grids
 title: 'Paths on Grids'
-author: Nathan Chen, Michael Cao, Benjamin Qi, Andrew Wang, Maggie Liu
+author: Nathan Chen, Michael Cao, Benjamin Qi, Andrew Wang
+contributors: Maggie Liu
 prerequisites:
   - intro-dp
 description:

--- a/content/4_Gold/Sliding.mdx
+++ b/content/4_Gold/Sliding.mdx
@@ -1,8 +1,8 @@
 ---
 id: sliding
 title: 'Sliding Window'
-author: Darren Yao, Benjamin Qi
-contributors: Andrew Wang, Andi Qu
+author: Benjamin Qi
+contributors: Darren Yao, Andrew Wang, Andi Qu
 prerequisites:
   - intro-ordered
   - 2P

--- a/content/4_Gold/Sliding.mdx
+++ b/content/4_Gold/Sliding.mdx
@@ -2,7 +2,7 @@
 id: sliding
 title: 'Sliding Window'
 author: Benjamin Qi
-contributors: Darren Yao, Andrew Wang, Andi Qu
+contributors: Darren Yao, Andrew Wang
 prerequisites:
   - intro-ordered
   - 2P

--- a/content/4_Gold/Sliding.mdx
+++ b/content/4_Gold/Sliding.mdx
@@ -1,7 +1,8 @@
 ---
 id: sliding
 title: 'Sliding Window'
-author: Darren Yao, Benjamin Qi, Andrew Wang
+author: Darren Yao, Benjamin Qi
+contributors: Andrew Wang, Andi Qu
 prerequisites:
   - intro-ordered
   - 2P

--- a/content/4_Gold/String_Hashing.mdx
+++ b/content/4_Gold/String_Hashing.mdx
@@ -1,7 +1,8 @@
 ---
 id: string-hashing
 title: 'String Hashing'
-author: Benjamin Qi, Andrew Wang, Andi Qu
+author: Benjamin Qi, Andi Qu
+contributors: Andrew Wang
 description:
   'Quickly test equality of substrings with a small probability of failure.'
 frequency: 1

--- a/content/4_Gold/TopoSort.mdx
+++ b/content/4_Gold/TopoSort.mdx
@@ -1,7 +1,8 @@
 ---
 id: toposort
 title: 'Topological Sort'
-author: Benjamin Qi, Michael Cao, Nathan Chen, Andi Qu, Andrew Wang, Qi Wang, Maggie Liu
+author: Benjamin Qi, Nathan Chen
+contributors: Michael Cao, Andi Qu, Andrew Wang, Qi Wang, Maggie Liu
 prerequisites:
   - bfs
   - intro-dp

--- a/content/4_Gold/Tree_Euler.mdx
+++ b/content/4_Gold/Tree_Euler.mdx
@@ -1,7 +1,7 @@
 ---
 id: tree-euler
 title: 'Euler Tour Technique'
-author: Benjamin Qi, Andi Qu, Andrew Wang, Neo Wang
+author: Benjamin Qi, Andrew Wang, Neo Wang
 prerequisites:
   - intro-tree
   - PURS

--- a/content/4_Gold/Unordered.mdx
+++ b/content/4_Gold/Unordered.mdx
@@ -1,7 +1,8 @@
 ---
 id: unordered
 title: (Optional) Unordered Sets & Maps
-author: Darren Yao, Benjamin Qi, Neo Wang
+author: Darren Yao, Benjamin Qi
+contributors: Neo Wang
 description: 'Maintaining collections of distinct elements with hashing.'
 frequency: 1
 prerequisites:

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -439,6 +439,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       id: String
       title: String
       author: String
+      contributors: String
       description: String
       prerequisites: [String]
       redirects: [String]

--- a/src/components/MarkdownLayout/ModuleHeaders/ModuleHeaders.tsx
+++ b/src/components/MarkdownLayout/ModuleHeaders/ModuleHeaders.tsx
@@ -105,10 +105,17 @@ export default function ModuleHeaders({
             {markdownData.title}
           </h1>
           {markdownData.author && (
-            <p className={`text-gray-500 dark:text-dark-med-emphasis`}>
+            <p className={`text-gray-500 dark:text-dark-med-emphasis mt-1`}>
               Author
               {markdownData.author.indexOf(',') !== -1 ? 's' : ''}:{' '}
               {markdownData.author}
+            </p>
+          )}
+          {markdownData instanceof ModuleInfo && markdownData.contributors && (
+            <p className={`text-gray-500 dark:text-dark-med-emphasis text-xs`}>
+              Contributor
+              {markdownData.contributors.indexOf(',') !== -1 ? 's' : ''}:{' '}
+              {markdownData.contributors}
             </p>
           )}
         </div>

--- a/src/models/module.ts
+++ b/src/models/module.ts
@@ -50,6 +50,7 @@ export class ModuleInfo extends ModuleLinkInfo {
     public title: string,
     public body: any,
     public author: string,
+    public contributors: string,
     public prerequisites: string[],
     public description: string,
     public frequency: ModuleFrequency,

--- a/src/templates/moduleTemplate.tsx
+++ b/src/templates/moduleTemplate.tsx
@@ -71,6 +71,7 @@ export const pageQuery = graphql`
       frontmatter {
         title
         author
+        contributors
         id
         prerequisites
         description

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -37,6 +37,7 @@ export function graphqlToModuleInfo(mdx: any): ModuleInfo {
     mdx.frontmatter.title,
     mdx.body,
     mdx.frontmatter.author,
+    mdx.frontmatter.contributors,
     mdx.frontmatter.prerequisites,
     mdx.frontmatter.description,
     mdx.frontmatter.frequency,


### PR DESCRIPTION
Added new guidelines for who should be added as an author and who should be added as a contributor. Also added a field in the module's frontmatter for contributors.

I will change some of the current authors to contributors once @darren-yao creates a list of the actual authors.