### PR TITLE
Correct solution language

### DIFF
--- a/solutions/usaco-665.mdx
+++ b/solutions/usaco-665.mdx
@@ -5,7 +5,7 @@ title: The Cow-Signal
 author: Benjamin Qi, Jesse Choe
 ---
 
-[Official Analysis (Java)](http://www.usaco.org/current/data/sol_cowsignal_bronze_dec16.html)
+[Official Analysis (C++)](http://www.usaco.org/current/data/sol_cowsignal_bronze_dec16.html)
 
 <LanguageSection>
 <CPPSection>


### PR DESCRIPTION
A small error where the CPP solution is said to be a java solution.