### PR TITLE
Fix multiple activity counts for the same problem

### DIFF
--- a/src/components/Dashboard/Activity.tsx
+++ b/src/components/Dashboard/Activity.tsx
@@ -15,10 +15,8 @@ export default function Activity() {
     setStartDate(d);
   }, []);
 
-  const {
-    userProgressOnModulesActivity,
-    userProgressOnProblemsActivity,
-  } = useContext(UserDataContext);
+  const { userProgressOnModulesActivity, userProgressOnProblemsActivity } =
+    useContext(UserDataContext);
 
   if (!startDate) return null;
 
@@ -26,6 +24,7 @@ export default function Activity() {
   const moduleActivities = {};
   const problemActivities = {};
 
+  const moduleIDs = [];
   for (const activity of userProgressOnModulesActivity) {
     if (
       activity.moduleProgress === 'Practicing' ||
@@ -33,7 +32,14 @@ export default function Activity() {
     ) {
       const newDate = new Date(activity.timestamp);
       newDate.setHours(0, 0, 0, 0);
-
+      console.log('moduleIDs', moduleIDs);
+      if (
+        moduleIDs.some(
+          m => m[0] === activity.moduleID && m[1] === newDate.getTime()
+        )
+      )
+        continue;
+      moduleIDs.push([activity.moduleID, newDate.getTime()]);
       if (newDate.getTime() in activityCount) {
         activityCount[newDate.getTime()]++;
         moduleActivities[newDate.getTime()].push(activity);
@@ -44,10 +50,18 @@ export default function Activity() {
     }
   }
 
+  const problemIDs = [];
   for (const activity of userProgressOnProblemsActivity) {
     if (activity.problemProgress === 'Solved') {
       const newDate = new Date(activity.timestamp);
       newDate.setHours(0, 0, 0, 0);
+      if (
+        problemIDs.some(
+          p => p[0] === activity.problemID && p[1] === newDate.getTime()
+        )
+      )
+        continue;
+      problemIDs.push([activity.problemID, newDate.getTime()]);
 
       if (newDate.getTime() in activityCount) {
         activityCount[newDate.getTime()]++;

--- a/src/components/Dashboard/Activity.tsx
+++ b/src/components/Dashboard/Activity.tsx
@@ -32,7 +32,6 @@ export default function Activity() {
     ) {
       const newDate = new Date(activity.timestamp);
       newDate.setHours(0, 0, 0, 0);
-      console.log('moduleIDs', moduleIDs);
       if (
         moduleIDs.some(
           m => m[0] === activity.moduleID && m[1] === newDate.getTime()


### PR DESCRIPTION
If you solve a problem and unsolve/solve a few times, the activity in the chart will increase. This pr fixes it so that activity is only counted once per problem or module per day.

This doesn't fix some other problems such as solve + unsolve still counting as a solve, but hopefully makes the calculations a bit more accurate.