### PR TITLE
Update usaco 667

### DIFF
--- a/solutions/usaco-667.mdx
+++ b/solutions/usaco-667.mdx
@@ -55,7 +55,7 @@ $[0,26^4)$ and use an array instead of a map.
 
 using namespace std;
 
-int seen[26 * 26 * 26 * 26];
+int seen[26 * 26 * 26 * 26] = {0};
 
 int index(string s) {
 	int ind = 0;


### PR DESCRIPTION
For solution 2 that uses an `int` array, all elements of the `seen` array should be initialized to `0`. Tested with the official USACO site analysis mode.