### PR TITLE
Install broken-link-checker from registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "algoliasearch": "^4.10.3",
     "babel-plugin-remove-graphql-queries": "^3.9.0",
     "babel-plugin-styled-components": "^1.13.2",
-    "broken-link-checker": "https://github.com/alexlouden/broken-link-checker",
+    "broken-link-checker": "^0.7.8",
     "classnames": "^2.3.1",
     "cssnano": "^5.0.6",
     "dayjs": "^1.10.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6754,9 +6754,10 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-"broken-link-checker@https://github.com/alexlouden/broken-link-checker":
+broken-link-checker@^0.7.8:
   version "0.7.8"
-  resolved "https://github.com/alexlouden/broken-link-checker#3777fa1593cc017fa5a1e9c78932d73214af3a70"
+  resolved "https://registry.yarnpkg.com/broken-link-checker/-/broken-link-checker-0.7.8.tgz#47ea837e1b43ec2feac220207dc3f44c03b49ec0"
+  integrity sha512-/zH4/nLMNKDeDH5nVuf/R6WYd0Yjnar1NpcdAO2+VlwjGKzJa6y42C03UO+imBSHwe6BefSkVi82fImE2Rb7yg==
   dependencies:
     bhttp "^1.2.1"
     calmcard "~0.1.1"


### PR DESCRIPTION
I think vercel is unable to install broken-link-checker from github for some reason...