### PR TITLE
Fixed typo.

### DIFF
--- a/solutions/cses-1196.mdx
+++ b/solutions/cses-1196.mdx
@@ -218,7 +218,7 @@ void setIO(str s = "") {
 
 int n,m,k;
 priority_queue<ll> bes[MX];
-vector<pii> adj[MX];
+vector<pi> adj[MX];
 priority_queue<pair<ll,int>,vector<pair<ll,int>>,greater<pair<ll,int>>> pq;
 
 int main() {


### PR DESCRIPTION
macro was `pi` standing for `pair<int, int>`, not `pii`

hence corrected 
`vector<pii> adj[MX];` 
to 
`vector<pi> adj[MX];`