### PR TITLE
Update Data_Types.mdx

### DIFF
--- a/content/1_General/Data_Types.mdx
+++ b/content/1_General/Data_Types.mdx
@@ -37,7 +37,7 @@ prerequisites:
 | ----------------- | ----------------------- | ----------------------- | ------------------------ | -------------------------- | ------------------ | --------------- | ---------------------------- |
 | Description (g++) | 32-bit integer          | 64-bit integer          | Single-precision float   | Double-precision float     | True/False value   | 8-bit character | String (Note: not primitive) |
 | Size (bytes, g++) | 4                       | 8                       | 4                        | 8                          | 1                  | 1               | Variable                     |
-| Range (g++)       | $-2^{32}$ to $2^{32}-1$ | $-2^{64}$ to $2^{64}-1$ | `-3.4E+38` to `+3.4E+38` | `-1.7E+308` to `+1.7E+308` | 0, 1 or true/false | $-128$ to $127$ | Not applicable               |
+| Range (g++)       | $-2^{31}$ to $2^{31}-1$ | $-2^{64}$ to $2^{64}-1$ | `-3.4E+38` to `+3.4E+38` | `-1.7E+308` to `+1.7E+308` | 0, 1 or true/false | $-128$ to $127$ | Not applicable               |
 
 </CPPSection>
 


### PR DESCRIPTION
The range for 32-bit int should be -2^31 to 2^31-1 because the 0th bit is used as the sign bit.