### PR TITLE
Update cses-1750.mdx

### DIFF
--- a/solutions/cses-1750.mdx
+++ b/solutions/cses-1750.mdx
@@ -39,7 +39,8 @@ int jump(int a, int d) {
 
 int main() {
 	ios_base::sync_with_stdio(false);
-        cin.tie(NULL);					
+	cin.tie(NULL);
+
 	cin >> n >> q;
 	for(int i=1; i<=n; i++) {
 		cin >> parent[i][0];


### PR DESCRIPTION
Added Fast IO to CSES Problem 1750 ( Planet Queries). Without Fast IO the code was giving TLE but with it ran in 0.64 seconds.

_If any of the below doesn't apply to this Pull Request, mark the checkbox as
done._

- [X] I have tested my code
- [X] I have followed the code style guidelines mentioned
      [here](https://usaco.guide/general/adding-solution/#code-conventions)
- [X] I have properly formatted the files according to the steps mentioned
      [here](https://usaco.guide/general/adding-solution#steps)
