### PR TITLE
Fix time complexity of usaco-760.mdx

### DIFF
--- a/solutions/usaco-760.mdx
+++ b/solutions/usaco-760.mdx
@@ -11,7 +11,7 @@ If the $i$th cow moves to $a_i$ after one shuffle, then the cow at $a_i$ was at 
 
 ## Implementation
 
-**Time Complexity:** $\mathcal{O}(N)$
+**Time Complexity:** $\mathcal{O}(N^2)$
 <LanguageSection>
 <PySection>
 


### PR DESCRIPTION
the `find` method has a for O(n) in it. and `find` function executes in another for loop. So the final time complexity is O(n^2) - Checkout line `83` and `56` of the file

_If any of the below doesn't apply to this Pull Request, mark the checkbox as
done._

- [x] I have tested my code
- [x] I have followed the code style guidelines mentioned
      [here](https://usaco.guide/general/adding-solution/#code-conventions)
- [x] I have properly formatted the files according to the steps mentioned
      [here](https://usaco.guide/general/adding-solution#steps)
