### PR TITLE
Java IO - add warning regarding USACO contests, correct a mistake

### DIFF
--- a/content/1_General/Input_Output.mdx
+++ b/content/1_General/Input_Output.mdx
@@ -325,7 +325,7 @@ The original `Kattio` code had `super(new BufferedOutputStream(o));` on line 23.
 But since `PrintWriter` will automatically wrap an `OutputStream` with a
 `BufferedWriter`
 ([source](https://stackoverflow.com/questions/32177690/is-printwriter-buffered)),
-including `BufferedOutputStream` is necessary.
+including `BufferedOutputStream` is unnecessary.
 
 Similarly, you may see `PrintWriter`s for file output initialized like the
 following (ex.
@@ -335,7 +335,7 @@ following (ex.
 PrintWriter pw = new PrintWriter(new BufferedWriter(new FileWriter("problemname.out")));
 ```
 
-This is equivalent to:
+This is equivalent to what we use in this module:
 
 ```java
 PrintWriter pw = new PrintWriter("problemname.out");

--- a/content/1_General/Input_Output.mdx
+++ b/content/1_General/Input_Output.mdx
@@ -224,6 +224,13 @@ public class Main {
 
 #### Method 3 - I/O Template
 
+<Warning>
+
+Since the code in this section could potentially be considered more than just
+basic Java functionality, you should not refer to this during a USACO contest.
+
+</Warning>
+
 The following template (a shortened version of Kattis's
 [`Kattio.java`](https://open.kattis.com/help/java)) wraps `BufferedReader` and
 `PrintWriter` and takes care of the string processing for you. You may or may
@@ -312,15 +319,12 @@ instance `io`:
 | `io.println(arg)` | Prints `arg` to designated output stream and adds a newline                                                                                                                                                                           |
 | `io.close()`      | Closes the output stream and flushes the output. Make sure to call this (or [`io.flush()`](<https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/io/PrintWriter.html#flush()>)) at the end, or you won't see any output! |
 
-USACO prohibits prewritten code but allows you to consult resources about basic
-functionality such as input / output, so feel free to refer to this module
-during a USACO contest.
-
 <Info title="PrintWriter Buffering">
 
-The original `Kattio` code had `super(new BufferedOutputStream(o));` on line 37.
-But since `PrintWriter`
-[uses buffered output](https://stackoverflow.com/questions/32177690/is-printwriter-buffered),
+The original `Kattio` code had `super(new BufferedOutputStream(o));` on line 23.
+But since `PrintWriter` will automatically wrap an `OutputStream` with a
+`BufferedWriter`
+([source](https://stackoverflow.com/questions/32177690/is-printwriter-buffered)),
 including `BufferedOutputStream` is necessary.
 
 Similarly, you may see `PrintWriter`s for file output initialized like the

--- a/src/mdx-plugins/rehype-snippets.js
+++ b/src/mdx-plugins/rehype-snippets.js
@@ -265,7 +265,6 @@ inline namespace FileIO {
 static class Kattio extends PrintWriter {
 \tprivate BufferedReader r;
 \tprivate StringTokenizer st;
-
 \t// standard input
 \tpublic Kattio() { this(System.in, System.out); }
 \tpublic Kattio(InputStream i, OutputStream o) {
@@ -277,7 +276,6 @@ static class Kattio extends PrintWriter {
 \t\tsuper(problemName + ".out");
 \t\tr = new BufferedReader(new FileReader(problemName + ".in"));
 \t}
-
 \t// returns null if no more input
 \tpublic String next() {
 \t\ttry {
@@ -287,7 +285,6 @@ static class Kattio extends PrintWriter {
 \t\t} catch (Exception e) { }
 \t\treturn null;
 \t}
-
 \tpublic int nextInt() { return Integer.parseInt(next()); }
 \tpublic double nextDouble() { return Double.parseDouble(next()); }
 \tpublic long nextLong() { return Long.parseLong(next()); }


### PR DESCRIPTION
As discussed in https://forum.usaco.guide/t/can-i-use-the-default-starting-code-that-comes-with-every-new-project-on-ide-usaco-guide/2511

_If any of the below doesn't apply to this Pull Request, mark the checkbox as done._

- [ ] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which includes the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making them.