### PR TITLE
Fix the intersect function's return type

### DIFF
--- a/content/2_Bronze/Rect_Geo.mdx
+++ b/content/2_Bronze/Rect_Geo.mdx
@@ -585,7 +585,7 @@ In all other cases, the rectangles intersect.
 <LanguageSection>
 	<CPPSection>
 		```cpp
-		vector<int> intersect(vector<int> s1, vector<int> s2) {
+		bool intersect(vector<int> s1, vector<int> s2) {
 			int bl_a_x = s1[0], bl_a_y = s1[1], tr_a_x = s1[2], tr_a_y = s1[3];
 			int bl_b_x = s2[0], bl_b_y = s2[1], tr_b_x = s2[2], tr_b_y = s2[3];
 			


### PR DESCRIPTION
Fix the return type of the function that checks if two rectangles intersect. It must be `bool`.
Solving issue #2543

_If any of the below doesn't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which includes the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making them.