### PR TITLE
Found erroneous code at line 356

### DIFF
--- a/content/2_Bronze/Time_Comp.mdx
+++ b/content/2_Bronze/Time_Comp.mdx
@@ -353,7 +353,7 @@ for (int i = 1; i <= n; i++) {
 		// constant time code here
 	}
 }
-for (int i = i; j <= m; i++) {
+for (int i = 1; i <= m; i++) {
 	// more constant time code here
 }
 ```


### PR DESCRIPTION
In the Time_Comp.mdx file, from the Bronze section, there is an error in the java code block at line number 356
`for(int i = i; j <= m; i++)` is erroneous and must be changed to `for(int i = 1; i <= m; i++)`

_If any of the below doesn't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which includes the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making them.