### PR TITLE
Add a √n log n time complexity for n ≤ 10¹²

### DIFF
--- a/content/2_Bronze/Time_Comp.mdx
+++ b/content/2_Bronze/Time_Comp.mdx
@@ -418,6 +418,7 @@ check whether an algorithm is viable.
 | $n \le 7 \cdot 10^4$ | $\mathcal{O}(n \sqrt n)$                                         |
 | $n \le 5 \cdot 10^5$ | $\mathcal{O}(n \log n)$                                          |
 | $n \le 5 \cdot 10^6$ | $\mathcal{O}(n)$                                                 |
+| $n \le 10^{12}$      | $\mathcal{O}(\sqrt N \log N)$                                    |
 | $n \le 10^{18}$      | $\mathcal{O}(\log^2 n)$, $\mathcal{O}(\log n)$, $\mathcal{O}(1)$ |
 
 </center>


### PR DESCRIPTION
I was recently looking at some previous USACO Silver problems and stumbled upon [2020 January Contest - Loan Repayment](http://www.usaco.org/index.php?page=viewproblem2&cpid=991), which uses the limit <code>1 ≤ N ≤ 10<sup>12</sup></code>. According to [the editorial](http://www.usaco.org/current/data/sol_loan_silver_jan20.html):
> As the numbers in the statement are up to <code>10<sup>12</sup></code>, not <code>10<sup>18</sup></code>, **this suggests that some sort of √N factor is involved.**

It turns out that the time complexity of the intended solution to that problem is √N log N (using binary search on a function with an O(√N) time complexity).

However, on the [Time Complexity](https://usaco.guide/bronze/time-comp?lang=cpp) page, there is no mention of a <code>10<sup>12</sup></code> time complexity. I feel this will be helpful to include in the chart (even if this might be rare), so here is the pull request! I am not sure if it should be <code>10<sup>12</sup></code> or some higher value, though - I'm just going off of the problem I mentioned above.

_If any of the below doesn't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which includes the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making them.