### PR TITLE
Add missing semicolon for code to work

### DIFF
--- a/solutions/cses-1753.mdx
+++ b/solutions/cses-1753.mdx
@@ -32,7 +32,7 @@ namespace str {
 		vector<int> pi_s(n);
 		for (int i = 1, j; i < n; i++) {
 			while (j > 0 && s[j] != s[i]) {
-				j = pi_s[j - 1]
+				j = pi_s[j - 1];
 			}
 			if (s[i] == s[j]) {
 				j++;


### PR DESCRIPTION
A very tiny change for a page (1 character):
In the Knuth–Morris–Pratt algorithm solution for the CSES String Matching C++ solution, there is a missing semicolon at the end of a statement. Without the semicolon, copy-pasting the code block will result in a fail-to-compile code.

_If any of the below doesn't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which includes the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making them.