### PR TITLE
Fix semicolon and uninitialized variable

### DIFF
--- a/solutions/cses-1753.mdx
+++ b/solutions/cses-1753.mdx
@@ -30,9 +30,9 @@ namespace str {
 	vector<int> pi(const string &s) {
 		int n = (int)s.size();
 		vector<int> pi_s(n);
-		for (int i = 1, j; i < n; i++) {
+		for (int i = 1, j = 0; i < n; i++) {
 			while (j > 0 && s[j] != s[i]) {
-				j = pi_s[j - 1]
+				j = pi_s[j - 1];
 			}
 			if (s[i] == s[j]) {
 				j++;


### PR DESCRIPTION
In the Knuth–Morris–Pratt algorithm C++ solution for "String Matching", the code does not work due to:
1. there is a missing semicolon which is an syntax error
2. variable `j` is uninitialized which causes segmentation error on most machines I've tested on.

This small fix makes the code snippet work.

_If any of the below doesn't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which includes the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making them.