### PR TITLE
quiz codeblock fix

### DIFF
--- a/src/components/markdown/CodeBlock/CodeBlock.tsx
+++ b/src/components/markdown/CodeBlock/CodeBlock.tsx
@@ -126,6 +126,7 @@ class CodeBlock extends React.Component<
   {
     children: string;
     className: string;
+    copyButton: boolean;
   },
   {
     collapsed: boolean;
@@ -329,18 +330,20 @@ class CodeBlock extends React.Component<
     const rightOffset = String(language.length * 8 + 40) + 'px';
     return (
       <RelativeDiv>
-        <CopyButton
-          type="button"
-          onClick={() => {
-            navigator.clipboard.writeText(code);
-          }}
-          style={{
-            '--right-offset': rightOffset,
-          }}
-          className="focus:outline-none"
-        >
-          Copy
-        </CopyButton>
+        {this.props.copyButton ? (
+          <CopyButton
+            type="button"
+            onClick={() => {
+              navigator.clipboard.writeText(code);
+            }}
+            style={{
+              '--right-offset': rightOffset,
+            }}
+            className="focus:outline-none"
+          >
+            Copy
+          </CopyButton>
+        ) : null}
         <Highlight
           Prism={Prism as any}
           code={code}

--- a/src/components/markdown/CodeBlock/CodeBlock.tsx
+++ b/src/components/markdown/CodeBlock/CodeBlock.tsx
@@ -126,7 +126,7 @@ class CodeBlock extends React.Component<
   {
     children: string;
     className: string;
-    copyButton: boolean;
+    copyButton?: boolean;
   },
   {
     collapsed: boolean;
@@ -135,6 +135,9 @@ class CodeBlock extends React.Component<
 > {
   codeSnips = [];
   static contextType = SpoilerContext;
+  static defaultProps = {
+    copyButton: true,
+  };
 
   constructor(props) {
     super(props);

--- a/src/components/markdown/HTMLComponents.tsx
+++ b/src/components/markdown/HTMLComponents.tsx
@@ -62,10 +62,10 @@ const a = ({ children, ...props }) => (
     {children}
   </a>
 );
-const pre = ({ children, ...props }) => {
+const pre = ({ children, copyButton = true, ...props }) => {
   return (
     <pre {...props}>
-      <CodeBlock {...children.props} />
+      <CodeBlock copyButton={copyButton} {...children.props} />
     </pre>
   );
 };

--- a/src/components/markdown/Quiz.tsx
+++ b/src/components/markdown/Quiz.tsx
@@ -92,12 +92,22 @@ const QuizMCAnswer = props => {
 QuizMCAnswer.displayName = 'QuizMCAnswer';
 
 const QuizQuestion = props => {
-  let num = 0;
-  const correctAnswers = [];
   const setCorrectAnswers = useUpdateAtom(correctAnswersAtom, quizScope);
+  React.useEffect(() => {
+    const correctAnswers = [];
+    let answerNum = 0;
+    React.Children.map(props.children, child => {
+      if (child?.type?.displayName === 'QuizMCAnswer') {
+        if (child.props.correct) correctAnswers.push(answerNum);
+        answerNum++;
+      }
+    });
+    setCorrectAnswers(correctAnswers);
+  }, []);
+
+  let num = 0;
   const answerChoices = React.Children.map(props.children, child => {
     if (child?.type?.displayName === 'QuizMCAnswer') {
-      if (child.props.correct) correctAnswers.push(num);
       return React.cloneElement(child, {
         number: num++,
       });
@@ -105,7 +115,6 @@ const QuizQuestion = props => {
       return child;
     }
   });
-  setCorrectAnswers(correctAnswers);
   return <div className="space-y-2">{answerChoices}</div>;
 };
 QuizQuestion.displayName = 'QuizQuestion';

--- a/src/components/markdown/Quiz.tsx
+++ b/src/components/markdown/Quiz.tsx
@@ -42,8 +42,10 @@ const QuizMCAnswer = props => {
   const correctAnswers = useAtomValue(correctAnswersAtom, quizScope);
   const showVerdict =
     submitted && (isSelected || correctAnswers.includes(selectedAnswer)); //display correctness/explanation
+  const isCorrect = submitted && correctAnswers.includes(selectedAnswer);
+  const Element = isCorrect ? 'div' : 'button';
   return (
-    <button
+    <Element
       className="flex w-full items-start bg-gray-100 dark:bg-gray-900 rounded-2xl px-4 py-3 text-left focus:outline-none"
       onClick={() => {
         if (!showVerdict) {
@@ -83,10 +85,13 @@ const QuizMCAnswer = props => {
               return null;
             }
           }
+          if (!isCorrect && child?.type?.name == 'pre') {
+            return React.cloneElement(child, { copyButton: false });
+          }
           return child;
         })}
       </div>
-    </button>
+    </Element>
   );
 };
 QuizMCAnswer.displayName = 'QuizMCAnswer';


### PR DESCRIPTION
fixes an issue where the intro-ds page would glitch upon reload (thanks @cirex-web for reporting)

basically the dom nesting was invalid because of nested `buttons`, so i just removed the copy button when the right answer hasn't been selected yet