### PR TITLE
Update Vectorization.mdx (Pragmas actually work for USACO)

### DIFF
--- a/content/6_Advanced/Vectorization.mdx
+++ b/content/6_Advanced/Vectorization.mdx
@@ -114,7 +114,7 @@ Whether these pragmas are supported depends on the computer architecture (see
   `#pragma GCC optimize("unroll-loops")` seems to work on InfoArena (compare
   [TLE](https://www.infoarena.ro/job_detail/2641920) and
   [AC](https://www.infoarena.ro/job_detail/2641921)).
-- These have occasionally worked on past USACO problems, such as the unintended quadratic time solution at the end of [this](http://www.usaco.org/current/data/sol_prob3_silver_open22.html).
+- These have occasionally worked on past USACO problems, such as the unintended quadratic time solution at the end of [this problem](http://www.usaco.org/current/data/sol_prob3_silver_open22.html).
 
 ### Why Should I _Not_ Use These?
 

--- a/content/6_Advanced/Vectorization.mdx
+++ b/content/6_Advanced/Vectorization.mdx
@@ -1,7 +1,7 @@
 ---
 id: vectorization
 title: Vectorization in C++
-author: Benjamin Qi
+author: Benjamin Qi, Aryansh Shrivastava
 description: '?'
 ---
 
@@ -114,7 +114,7 @@ Whether these pragmas are supported depends on the computer architecture (see
   `#pragma GCC optimize("unroll-loops")` seems to work on InfoArena (compare
   [TLE](https://www.infoarena.ro/job_detail/2641920) and
   [AC](https://www.infoarena.ro/job_detail/2641921)).
-- I don't have reason to believe that these work for USACO.
+- These have occasionally worked on past USACO problems, such as the unintended quadratic time solution at the end of [this](http://www.usaco.org/current/data/sol_prob3_silver_open22.html).
 
 ### Why Should I _Not_ Use These?
 


### PR DESCRIPTION
It turns out pragmas do work for USACO as mentioned in [a recent editorial](http://www.usaco.org/current/data/sol_prob3_silver_open22.html). Updated this module accordingly.