### PR TITLE
Update Problem Explanation - Fix Events Sorting

### DIFF
--- a/solutions/usaco-569.mdx
+++ b/solutions/usaco-569.mdx
@@ -19,7 +19,7 @@ milk types that could have possibly gone bad.
 The main issue is checking if a milk could have been the one that went bad.
 To resolve this, let's treat both a person drinking milk and a person getting sick
 as a type of *event*.
-Then, we can have a list of events sorted by time. The sample case in this format
+Then, we can have a list of events sorted by time. Note that sick events must be before drinking events if they occur at the same time because one can only get sick if they drank the milk at a *strictly* earlier point in time. The sample case in this format
 would be as follows:
 
 <center>
@@ -29,8 +29,8 @@ would be as follows:
 |1|1|1|
 |1|1|4|
 |2|1|2|
-|3|3|1|
 |3|1|NA|
+|3|3|1|
 |4|1|3|
 |5|2|1|
 |7|2|2|


### PR DESCRIPTION
Sick events must be before drinking events if they occur at the same time.

_If any of the below doesn't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which include the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making them.