### PR TITLE
Fix Kattis contest links to problems

### DIFF
--- a/content/3_Silver/DFS.problems.json
+++ b/content/3_Silver/DFS.problems.json
@@ -151,7 +151,7 @@
     {
       "uniqueId": "kattis-LaneSwitching",
       "name": "Lane Switching",
-      "url": "https://open.kattis.com/contests/acpc17open/problems/laneswitching",
+      "url": "https://open.kattis.com/problems/laneswitching",
       "source": "Kattis",
       "difficulty": "Very Hard",
       "isStarred": false,

--- a/problemsList.ts
+++ b/problemsList.ts
@@ -11057,15 +11057,15 @@ let data: any = {
               {
                 source: 'Kattis',
                 name: 'Lane Switching',
-                id: 'https://open.kattis.com/contests/acpc17open/problems/laneswitching',
+                id: 'https://open.kattis.com/problems/laneswitching',
                 difficulty: 'Very Hard',
                 starred: false,
                 tags: ['Connected Components', 'Binary Search'],
                 solID: 'kattis-laneswitching',
                 solQuality: 'ok',
-                url: 'https://open.kattis.com/contests/acpc17open/problems/laneswitching',
+                url: 'https://open.kattis.com/problems/laneswitching',
                 uniqueID:
-                  'https://open.kattis.com/contests/acpc17open/problems/laneswitching',
+                  'https://open.kattis.com/problems/laneswitching',
                 tableID: 'general',
               },
               {
@@ -13898,15 +13898,15 @@ let data: any = {
               {
                 source: 'Kattis',
                 name: 'Basketball One on One',
-                id: 'https://open.kattis.com/contests/mcpc19open/problems/basketballoneonone',
+                id: 'https://open.kattis.com/problems/basketballoneonone',
                 difficulty: 'Very Easy',
                 starred: null,
                 tags: null,
                 solID: null,
                 solQuality: 'ok',
-                url: 'https://open.kattis.com/contests/mcpc19open/problems/basketballoneonone',
+                url: 'https://open.kattis.com/problems/basketballoneonone',
                 uniqueID:
-                  'https://open.kattis.com/contests/mcpc19open/problems/basketballoneonone',
+                  'https://open.kattis.com/problems/basketballoneonone',
                 tableID: 'general',
               },
             ],

--- a/src/context/UserDataContext/properties/problemURLToIdMap.tsx
+++ b/src/context/UserDataContext/properties/problemURLToIdMap.tsx
@@ -4,8 +4,7 @@ export default {
   'http://www.usaco.org/index.php?page=viewproblem2&cpid=1059': 'usaco-1059',
   'http://www.usaco.org/index.php?page=viewproblem2&cpid=987': 'usaco-987',
   'http://www.usaco.org/index.php?page=viewproblem2&cpid=939': 'usaco-939',
-  'https://open.kattis.com/contests/mcpc19open/problems/basketballoneonone':
-    'kattis-BasketballOneOnOne',
+  'https://open.kattis.com/problems/basketballoneonone': 'kattis-BasketballOneOnOne',
   'http://www.usaco.org/index.php?page=viewproblem2&cpid=674': 'usaco-674',
   'https://codeforces.com/contest/546/problem/D': 'cf-546D',
   'https://cses.fi/problemset/task/1068': 'cses-1068',
@@ -103,8 +102,7 @@ export default {
   'https://cses.fi/problemset/task/1682': 'cses-1682',
   'http://www.usaco.org/index.php?page=viewproblem2&cpid=669': 'usaco-669',
   'http://www.usaco.org/index.php?page=viewproblem2&cpid=992': 'usaco-992',
-  'https://open.kattis.com/contests/acpc17open/problems/laneswitching':
-    'kattis-LaneSwitching',
+  'https://open.kattis.com/problems/laneswitching': 'kattis-LaneSwitching',
   'https://cses.fi/problemset/task/1668': 'cses-1668',
   'https://codeforces.com/contest/862/problem/B': 'cf-862B',
   'http://www.usaco.org/index.php?page=viewproblem2&cpid=920': 'usaco-920',


### PR DESCRIPTION
The two links changed, https://open.kattis.com/contests/acpc17open/problems/laneswitching and https://open.kattis.com/contests/mcpc19open/problems/basketballoneonone, do not allow submitting (they give an error when submitting). However, the new links, https://open.kattis.com/problems/laneswitching and https://open.kattis.com/problems/basketballoneonone respectively, do allow submitting. The problems are the exact same, just the links are different so they actually allow submitting. 

_If any of the below don't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which include the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making the changes.
