### PR TITLE
Better time complexity for modular inverses of factorials

### DIFF
--- a/content/4_Gold/Combinatorics.mdx
+++ b/content/4_Gold/Combinatorics.mdx
@@ -172,11 +172,9 @@ $$
 	\binom{n}{k} = \frac{n!}{k!(n-k)!}
 $$
 
-Recall that $\binom{n}{k}$ also represents the number of ways to choose $k$ elements from a set of $n$ elements. One strategy to get all such combinations is to go through all possible permutations of the $n$ elements, and only pick the first $k$ elements out of each permutation. There are $n!$ ways to do so. However, note the the order of the elements inside and outside the subset does not matter, so the result is divided by $k!$ and $(n − k)!$
+Recall that $\binom{n}{k}$ also represents the number of ways to choose $k$ elements from a set of $n$ elements. One strategy to get all such combinations is to go through all possible permutations of the $n$ elements, and only pick the first $k$ elements out of each permutation. There are $n!$ ways to do so. However, note the the order of the elements inside and outside the subset does not matter, so the result is divided by $k!$ and $(n − k)!$.
 
-Since these binomial coefficients are large, problems typically require us to output the answer modulo a large prime $p$ such as $10^9 + 7$.
-
-Fortunately, we can use [modular inverses](/gold/modular) to divide $n!$ by $k!$ and $(n - k)!$ modulo $p$ for any prime $p$. In our case, $MOD = 10^9+7$ is prime, so we can utilize [modular inverses](/gold/modular). However, computing inverse factorials **online** can be very time costly. Instead, we can **precompute** all factorials in $\mathcal{O}(n)$ time and inverse factorials in $\mathcal{O}(n + \log MOD)$. We compute the modular inverse of the largest factorial using binary exponentiation and for the rest we use the fact that $(n!)^{-1} \equiv (n!)^{-1}\times (n+1)^{-1} \times (n+1) \equiv ((n+1)!)^{-1}\times (n+1)$. See the code below for the implementation.
+Since these binomial coefficients are large, problems typically require us to output the answer modulo a large prime $p$ such as $10^9 + 7$. Fortunately, we can use [modular inverses](/gold/modular) to divide $n!$ by $k!$ and $(n - k)!$ modulo $p$ for any prime $p$. Computing inverse factorials **online** can be very time costly. Instead, we can **precompute** all factorials in $\mathcal{O}(n)$ time and inverse factorials in $\mathcal{O}(n + \log MOD)$. First, we compute the modular inverse of the largest factorial using binary exponentiation. For the rest, we use the fact that $(n!)^{-1} \equiv (n!)^{-1}\times (n+1)^{-1} \times (n+1) \equiv ((n+1)!)^{-1}\times (n+1)$. See the code below for the implementation.
 
 <LanguageSection>
 <CPPSection>

--- a/content/4_Gold/Combinatorics.mdx
+++ b/content/4_Gold/Combinatorics.mdx
@@ -176,7 +176,7 @@ Recall that $\binom{n}{k}$ also represents the number of ways to choose $k$ elem
 
 Since these binomial coefficients are large, problems typically require us to output the answer modulo a large prime $p$ such as $10^9 + 7$.
 
-Fortunately, we can use [modular inverses](/gold/modular) to divide $n!$ by $k!$ and $(n - k)!$ modulo $p$ for any prime $p$. In our case, $MOD = 10^9+7$ is prime, so we can utilize [modular inverses](/gold/modular). However, computing inverse factorials **online** can be very time costly. Instead, we can **precompute** all factorials in $\mathcal{O}(n)$ time and inverse factorials in $\mathcal{O}(n + \log MOD)$. We compute the modular inverse of the largest factorial using binary exponentiation and for the rest we use the fact that $(n!)^{-1} \equiv (n!)^{-1}\times (n+1)^{-1} \times (n+1) \equiv ((n+1)!)^{-1}\times (n+1)$ See the code below for the implementation.
+Fortunately, we can use [modular inverses](/gold/modular) to divide $n!$ by $k!$ and $(n - k)!$ modulo $p$ for any prime $p$. In our case, $MOD = 10^9+7$ is prime, so we can utilize [modular inverses](/gold/modular). However, computing inverse factorials **online** can be very time costly. Instead, we can **precompute** all factorials in $\mathcal{O}(n)$ time and inverse factorials in $\mathcal{O}(n + \log MOD)$. We compute the modular inverse of the largest factorial using binary exponentiation and for the rest we use the fact that $(n!)^{-1} \equiv (n!)^{-1}\times (n+1)^{-1} \times (n+1) \equiv ((n+1)!)^{-1}\times (n+1)$. See the code below for the implementation.
 
 <LanguageSection>
 <CPPSection>

--- a/content/4_Gold/Combinatorics.mdx
+++ b/content/4_Gold/Combinatorics.mdx
@@ -162,7 +162,7 @@ int binomial(int n, int k, int p) {
 </CPPSection>
 </LanguageSection>
 
-### Method 2: Factorial Definition (Modular Inverses) - $\mathcal{O}(n\log MOD)$
+### Method 2: Factorial Definition (Modular Inverses) - $\mathcal{O}(n + \log MOD)$
 
 Define $n!$ as $n \times (n - 1) \times (n - 2) \times \ldots 1$. $n!$ represents the number of permutations of a set of $n$ elements. See [this AoPS Article](https://artofproblemsolving.com/wiki/index.php/Factorial) for more details.
 
@@ -176,7 +176,7 @@ Recall that $\binom{n}{k}$ also represents the number of ways to choose $k$ elem
 
 Since these binomial coefficients are large, problems typically require us to output the answer modulo a large prime $p$ such as $10^9 + 7$.
 
-Fortunately, we can use [modular inverses](/gold/modular) to divide $n!$ by $k!$ and $(n - k)!$ modulo $p$ for any prime $p$. In our case, $MOD = 10^9+7$ is prime, so we can utilize [modular inverses](/gold/modular). However, computing inverse factorials **online** can be very time costly. Instead, we can **precompute** all factorials in $\mathcal{O}(n)$ time and inverse factorials in $\mathcal{O}(n\log MOD)$ by taking the inverses of each factorial. See the code below for the implementation.
+Fortunately, we can use [modular inverses](/gold/modular) to divide $n!$ by $k!$ and $(n - k)!$ modulo $p$ for any prime $p$. In our case, $MOD = 10^9+7$ is prime, so we can utilize [modular inverses](/gold/modular). However, computing inverse factorials **online** can be very time costly. Instead, we can **precompute** all factorials in $\mathcal{O}(n)$ time and inverse factorials in $\mathcal{O}(n + \log MOD)$ by taking the inverses of each factorial. See the code below for the implementation.
 
 <LanguageSection>
 <CPPSection>
@@ -207,11 +207,11 @@ void factorial(long long p) {
 	}
 }
 
-/** Precomputes all modular inverse factorials from 0 to MAXN in O(n log p) time */
+/** Precomputes all modular inverse factorials from 0 to MAXN in O(n + log p) time */
 void inverses(long long p) {
-	inv[0] = 1;
-	for (int i = 1; i <= MAXN; i++) {
-		inv[i] = exp(fac[i], p - 2, p);
+	inv[MAXN] = exp(fac[MAXN], p - 2, p);
+	for (int i = MAXN; i >= 1; i--) {
+		inv[i - 1] = inv[i] * i % p;
 	}
 }
 		
@@ -263,9 +263,9 @@ void factorial() {
 }
 
 void inverses() {
-	inv[0] = 1;
-	for (int i = 1; i <= MAXN; i++) {
-		inv[i] = exp(fac[i], MOD - 2, MOD);
+	inv[MAXN] = exp(fac[MAXN], MOD - 2, MOD);
+	for (int i = MAXN; i >= 1; i--) {
+		inv[i - 1] = inv[i] * i % MOD;
 	}
 }
 

--- a/content/4_Gold/Combinatorics.mdx
+++ b/content/4_Gold/Combinatorics.mdx
@@ -287,7 +287,7 @@ int main() {
 </CPPSection>
 </LanguageSection>
 
-### Derangements
+## Derangements
 
 <FocusProblem problem="sample2" />
 

--- a/content/4_Gold/Combinatorics.mdx
+++ b/content/4_Gold/Combinatorics.mdx
@@ -176,7 +176,7 @@ Recall that $\binom{n}{k}$ also represents the number of ways to choose $k$ elem
 
 Since these binomial coefficients are large, problems typically require us to output the answer modulo a large prime $p$ such as $10^9 + 7$.
 
-Fortunately, we can use [modular inverses](/gold/modular) to divide $n!$ by $k!$ and $(n - k)!$ modulo $p$ for any prime $p$. In our case, $MOD = 10^9+7$ is prime, so we can utilize [modular inverses](/gold/modular). However, computing inverse factorials **online** can be very time costly. Instead, we can **precompute** all factorials in $\mathcal{O}(n)$ time and inverse factorials in $\mathcal{O}(n + \log MOD)$ by taking the inverses of each factorial. See the code below for the implementation.
+Fortunately, we can use [modular inverses](/gold/modular) to divide $n!$ by $k!$ and $(n - k)!$ modulo $p$ for any prime $p$. In our case, $MOD = 10^9+7$ is prime, so we can utilize [modular inverses](/gold/modular). However, computing inverse factorials **online** can be very time costly. Instead, we can **precompute** all factorials in $\mathcal{O}(n)$ time and inverse factorials in $\mathcal{O}(n + \log MOD)$. We compute the modular inverse of the largest factorial using binary exponentiation and for the rest we use the fact that $(n!)^{-1} \equiv (n!)^{-1}\times (n+1)^{-1} \times (n+1) \equiv ((n+1)!)^{-1}\times (n+1)$ See the code below for the implementation.
 
 <LanguageSection>
 <CPPSection>


### PR DESCRIPTION
We can calculate the modular inverses of factorials with a time complexity of O(n + log(p)) instead of O(n * log(p)) by using binary exponentiation only on the largest factorial and calculating the rest from there.

_If any of the below don't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which include the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making the changes.
