### PR TITLE
prevent accidental user data override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ build.css
 
 **/*.icloud
 *.icloud
+
+.runtimeconfig.json

--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,9 @@
     ],
     "source": "src/functions"
   },
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "emulators": {
     "auth": {
       "port": 9099


### PR DESCRIPTION
closes #534. Also forces users to upload local data to server if they're creating an account for the first time.

If creating an account for the first time, we add a field `CREATING_ACCOUNT_FOR_FIRST_TIME` with value of `serverTimestamp()`. In firebase security rules, we allow user document *creation* as long as user ID matches. for document *updates*, we require `CREATING_ACCOUNT_FOR_FIRST_TIME` to not change. This prevents data writes where the client mistakenly thinks the account is just being created and accidentally overwrites user data.