### PR TITLE
make dashboard and syllabus progress bars consistent

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -41,13 +41,18 @@ export default function DashboardPage(props: PageProps) {
       const problem = cur.node;
       // ignore problems that don't have an associated module (extraProblems.json)
       if (problem.module) {
-        acc[problem.uniqueId] = {
-          label: `${problem.source}: ${problem.name}`,
+        if (!(problem.uniqueId in acc)) {
+          acc[problem.uniqueId] = {
+            label: `${problem.source}: ${problem.name}`,
+            modules: [],
+          };
+        }
+        acc[problem.uniqueId].modules.push({
           url: `${moduleIDToURLMap[problem.module.frontmatter.id]}/#problem-${
             problem.uniqueId
           }`,
           moduleId: problem.module.frontmatter.id,
-        };
+        });
       }
       return acc;
     }, {});
@@ -60,7 +65,11 @@ export default function DashboardPage(props: PageProps) {
         if (!(id in res)) {
           res[id] = {
             label: `${division}: ${probInfo[2]}`,
-            url: `/general/usaco-monthlies/#problem-${id}`,
+            modules: [
+              {
+                url: `/general/usaco-monthlies/#problem-${id}`,
+              },
+            ],
           };
         }
       }
@@ -114,7 +123,8 @@ export default function DashboardPage(props: PageProps) {
           problemIDMap.hasOwnProperty(x)
       )
       .map(x => ({
-        ...problemIDMap[x],
+        label: problemIDMap[x].label,
+        url: problemIDMap[x].modules[0].url,
         status: userProgressOnProblems[x] as
           | 'Reviewing'
           | 'Solving'
@@ -131,10 +141,10 @@ export default function DashboardPage(props: PageProps) {
   const allModulesProgressInfo = getModulesProgressInfo(moduleProgressIDs);
 
   const problemStatisticsIDs = React.useMemo(() => {
-    return Object.keys(problemIDMap).filter(
-      problemID =>
-        moduleIDToSectionMap[problemIDMap[problemID].moduleId] ===
-        lastViewedSection
+    return Object.keys(problemIDMap).filter(problemID =>
+      problemIDMap[problemID].modules.some(
+        module => moduleIDToSectionMap[module.moduleId] === lastViewedSection
+      )
     );
   }, [problemIDMap, lastViewedSection]);
   const allProblemsProgressInfo = getProblemsProgressInfo(problemStatisticsIDs);

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -143,7 +143,8 @@ export default function DashboardPage(props: PageProps) {
   const problemStatisticsIDs = React.useMemo(() => {
     return Object.keys(problemIDMap).filter(problemID =>
       problemIDMap[problemID].modules.some(
-        module => moduleIDToSectionMap[module.moduleId] === lastViewedSection
+        (module: { url: string; moduleId: string }) =>
+          moduleIDToSectionMap[module.moduleId] === lastViewedSection
       )
     );
   }, [problemIDMap, lastViewedSection]);

--- a/src/templates/syllabusTemplate.tsx
+++ b/src/templates/syllabusTemplate.tsx
@@ -137,7 +137,7 @@ export default function Template(props) {
   );
   const moduleProgressInfo = getModulesProgressInfo(moduleIDs);
   const problemIDs = [
-    ...new Set(data.problems.edges.map(x => x.node.uniqueId)),
+    ...new Set(data.problems.edges.map(x => x.node.uniqueId) as string[]),
   ];
   const problemsProgressInfo = getProblemsProgressInfo(problemIDs);
 

--- a/src/templates/syllabusTemplate.tsx
+++ b/src/templates/syllabusTemplate.tsx
@@ -136,7 +136,9 @@ export default function Template(props) {
     []
   );
   const moduleProgressInfo = getModulesProgressInfo(moduleIDs);
-  const problemIDs = data.problems.edges.map(x => x.node.uniqueId);
+  const problemIDs = [
+    ...new Set(data.problems.edges.map(x => x.node.uniqueId)),
+  ];
   const problemsProgressInfo = getProblemsProgressInfo(problemIDs);
 
   const progressBarForCategory = category => {
@@ -249,7 +251,7 @@ export default function Template(props) {
   );
 }
 export const pageQuery = graphql`
-  query($division: String!) {
+  query ($division: String!) {
     modules: allXdm(
       filter: {
         fileAbsolutePath: { regex: "/content/" }


### PR DESCRIPTION
 - Resolves https://forum.usaco.guide/t/problem-progress-bug/3795. Now marking a problem as skipped should only increase the count by one.
 - Ensures that dashboard problem counts match syllabus problem counts. currently, the dashboard shows fewer problems since it doesn't correctly take into account problems that belong to multiple sections

<img width="626" alt="Screen Shot 2022-12-24 at 3 34 24 PM" src="https://user-images.githubusercontent.com/21228024/209450368-8dbd1691-8ffb-4c0d-bcc9-30278d22a0fc.png">

<img width="617" alt="Screen Shot 2022-12-24 at 3 34 17 PM" src="https://user-images.githubusercontent.com/21228024/209450369-03106765-769d-4eff-b786-04e1be774080.png">

_If any of the below don't apply to this Pull Request, mark the checkbox as done._

- [ ] I have tested my code.
- [ ] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [ ] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which include the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making the changes.
