### PR TITLE
disable removing reviewers for problem suggestions

### DIFF
--- a/src/functions/README.md
+++ b/src/functions/README.md
@@ -1,0 +1,11 @@
+# Deploying a Function
+
+```
+npm install -g firebase-tools
+firebase login --reauth
+firebase projects:list # check that you have access to usaco-guide
+cd src/functions
+npm install
+firebase deploy --only functions:submitContactForm # deploy single function
+# firebase deploy --only functions # deploy all functions
+```


### PR DESCRIPTION
Problem suggestions are now assigned to be reviewed by the corresponding codeowners. Currently they aren't assigned to anyone.

(Alternatively, if we don't want to review problem suggestions, then we can disable problem suggestions altogether.)

_If any of the below don't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions), which include the following: 
  - I understand that if it is clear that I have not attempted to follow these guidelines (ex. if I have not used tabs to indent), my PR will be closed.
  - If changes are requested, I will re-request the review after making the changes.
