### PR TITLE
Adding more context to the start of the explanation (Counting Liars)

### DIFF
--- a/solutions/bronze/usaco-1228.mdx
+++ b/solutions/bronze/usaco-1228.mdx
@@ -9,7 +9,7 @@ author: Chongtian Ma, Juheon Rhee
 
 ## Explanation
 
-An important observation is that if Bessie is at position $x$, then the number of cows lying are all the
+After we sort the input, an important observation is that if Bessie is at position $x$, then the number of cows lying are all the
 cows with position less than $x$ that says "L" plus all the cows with a position greater than $x$ that says
 "G".
 


### PR DESCRIPTION
In the problem explanation for: [Counting Liars](https://usaco.guide/problems/usaco-1228-counting-liars/solution)

What if we add a little sentence ("after we sort the input") or something similar to the start of the explanation, since I was confused after reading the explanation (solution is not possible without sorting the input) but seeing the code cleared up my doubts, I think it should be mentioned in the explanation that we are sorting the input first before continuing on to explain further steps :)
