### PR TITLE
(try to) fix user progress on modules / problems deletion issue

### DIFF
--- a/src/components/markdown/ResourceStatusCheckbox.tsx
+++ b/src/components/markdown/ResourceStatusCheckbox.tsx
@@ -6,6 +6,7 @@ import 'tippy.js/themes/light.css';
 import ConfettiContext from '../../context/ConfettiContext';
 import { useDarkMode } from '../../context/DarkModeContext';
 import MarkdownLayoutContext from '../../context/MarkdownLayoutContext';
+import { replaceIllegalFirebaseCharacters } from '../../context/UserDataContext/properties/userProgressOnResources';
 import UserDataContext from '../../context/UserDataContext/UserDataContext';
 import {
   ResourceInfo,
@@ -20,9 +21,8 @@ const StyledTippy = styled(Tippy)`
 `;
 
 const ProgressDropdown = ({ onProgressSelected, currentProgress }) => {
-  const [activeProgress, setActiveProgress] = useState<ResourceProgress>(
-    currentProgress
-  );
+  const [activeProgress, setActiveProgress] =
+    useState<ResourceProgress>(currentProgress);
 
   const icon = (status: ResourceProgress, equal: boolean) => {
     const colorMap: { [key in ResourceProgress]: string } = {
@@ -137,12 +137,10 @@ export default function ResourcestatusCheckbox({
 }): JSX.Element {
   const darkMode = useDarkMode();
   const markdownLayoutContext = useContext(MarkdownLayoutContext);
-  const { userProgressOnModules, setModuleProgress } = useContext(
-    UserDataContext
-  );
-  const { userProgressOnResources, setUserProgressOnResources } = useContext(
-    UserDataContext
-  );
+  const { userProgressOnModules, setModuleProgress } =
+    useContext(UserDataContext);
+  const { userProgressOnResources, setUserProgressOnResources } =
+    useContext(UserDataContext);
   const updateResourceProgressToPracticing = () => {
     if (
       markdownLayoutContext === null ||
@@ -158,7 +156,8 @@ export default function ResourcestatusCheckbox({
     setModuleProgress(markdownLayoutInfo.id, 'Reading');
   };
   const status: ResourceProgress =
-    userProgressOnResources[resource.url] || 'Not Started';
+    userProgressOnResources[replaceIllegalFirebaseCharacters(resource.url)] ||
+    'Not Started';
   const color: { [key in ResourceProgress]: string } = {
     'Not Started': 'bg-gray-200 dark:bg-gray-700',
     Reading: 'bg-yellow-300 dark:bg-yellow-500',

--- a/src/context/UserDataContext/UserDataContext.tsx
+++ b/src/context/UserDataContext/UserDataContext.tsx
@@ -282,34 +282,28 @@ export const UserDataProvider = ({
         next: snapshot => {
           let data = snapshot.data();
           if (!data) {
-            const lastViewedModule = UserDataContextAPIs.find(
-              x => x instanceof LastViewedModule
-            ).exportValue();
-            const localDataIsNotEmpty = lastViewedModule !== null;
-
-            if (localDataIsNotEmpty) {
-              // sync all local data with firebase if the firebase account doesn't exist yet
-              setDoc(
-                userDoc,
-                UserDataContextAPIs.reduce(
-                  (acc, cur) => {
-                    return {
-                      ...acc,
-                      ...cur.exportValue(),
-                    };
-                  },
-                  {
-                    // this is to prevent us from accidentally overriding the user data
-                    // firebase security rules will have a check to make sure that this is actually the first time
-                    // the user has logged in. occasionally, with poor internet, firebase will glitch and
-                    // we will accidentally override user data.
-                    // see https://github.com/cpinitiative/usaco-guide/issues/534
-                    CREATING_ACCOUNT_FOR_FIRST_TIME: serverTimestamp(),
-                  }
-                ),
-                { merge: true }
-              );
-            }
+            // sync all local data with firebase if the firebase account doesn't exist yet
+            // other APIs use updateDoc() so we need to initialize it with *something*
+            setDoc(
+              userDoc,
+              UserDataContextAPIs.reduce(
+                (acc, cur) => {
+                  return {
+                    ...acc,
+                    ...cur.exportValue(),
+                  };
+                },
+                {
+                  // this is to prevent us from accidentally overriding the user data
+                  // firebase security rules will have a check to make sure that this is actually the first time
+                  // the user has logged in. occasionally, with poor internet, firebase will glitch and
+                  // we will accidentally override user data.
+                  // see https://github.com/cpinitiative/usaco-guide/issues/534
+                  CREATING_ACCOUNT_FOR_FIRST_TIME: serverTimestamp(),
+                }
+              ),
+              { merge: true }
+            );
           }
           data = data || {};
           UserDataContextAPIs.forEach(api => api.importValueFromObject(data));

--- a/src/context/UserDataContext/properties/userProgressOnModules.ts
+++ b/src/context/UserDataContext/properties/userProgressOnModules.ts
@@ -1,4 +1,4 @@
-import { setDoc } from 'firebase/firestore';
+import { arrayUnion } from 'firebase/firestore';
 import { ModuleActivity } from '../../../models/activity';
 import { ModuleProgress } from '../../../models/module';
 import UserDataPropertyAPI from '../userDataPropertyAPI';
@@ -76,31 +76,27 @@ export default class UserProgressOnModulesProperty extends UserDataPropertyAPI {
       userProgressOnModulesActivity: this.activityValue,
 
       setModuleProgress: (moduleID: string, progress: ModuleProgress) => {
-        if (!this.firebaseUserDoc) {
-          // if the user isn't using firebase, it is possible that they
-          // have multiple tabs open, which can result in localStorage
-          // being out of sync.
-          this.initializeFromLocalStorage();
-        }
+        //if (!this.firebaseUserDoc) {
+        // if the user isn't using firebase, it is possible that they
+        // have multiple tabs open, which can result in localStorage
+        // being out of sync.
+        // edit: always do this even though unnecessary bc people keep losing data
+        this.initializeFromLocalStorage();
+        //}
 
-        this.activityValue.push({
+        const newActivityData = {
           timestamp: Date.now(),
           moduleID: moduleID,
           moduleProgress: progress,
-        });
+        };
+        this.activityValue.push(newActivityData);
         this.progressValue[moduleID] = progress;
 
         if (this.firebaseUserDoc) {
-          setDoc(
-            this.firebaseUserDoc,
-            {
-              [this.progressStorageKey]: {
-                [moduleID]: progress,
-              },
-              [this.activityStorageKey]: this.activityValue,
-            },
-            { merge: true }
-          );
+          updateDoc(this.firebaseUserDoc, {
+            [`${this.progressStorageKey}.${moduleID}`]: progress,
+            [this.activityStorageKey]: arrayUnion(newActivityData),
+          });
         }
 
         this.writeValueToLocalStorage();

--- a/src/context/UserDataContext/properties/userProgressOnModules.ts
+++ b/src/context/UserDataContext/properties/userProgressOnModules.ts
@@ -1,4 +1,4 @@
-import { arrayUnion } from 'firebase/firestore';
+import { arrayUnion, updateDoc } from 'firebase/firestore';
 import { ModuleActivity } from '../../../models/activity';
 import { ModuleProgress } from '../../../models/module';
 import UserDataPropertyAPI from '../userDataPropertyAPI';

--- a/src/context/UserDataContext/properties/userProgressOnResources.ts
+++ b/src/context/UserDataContext/properties/userProgressOnResources.ts
@@ -11,6 +11,10 @@ export type UserProgressOnResourcesAPI = {
   ) => void;
 };
 
+export const replaceIllegalFirebaseCharacters = (str: string) => {
+  return str.replace(/[^a-zA-Z0-9]/g, ''); // technically only ~*/[] aren't allowed but whatever
+};
+
 export default class UserProgressOnResourcesProperty extends UserDataPropertyAPI {
   private progressStorageKey = 'userProgressOnResources';
   private progressValue = {};
@@ -52,6 +56,7 @@ export default class UserProgressOnResourcesProperty extends UserDataPropertyAPI
     return {
       userProgressOnResources: this.progressValue,
       setUserProgressOnResources: (problemId, status) => {
+        problemId = replaceIllegalFirebaseCharacters(problemId);
         // if the user isn't using firebase, it is possible that they
         // have multiple tabs open, which can result in localStorage
         // being out of sync.
@@ -69,6 +74,8 @@ export default class UserProgressOnResourcesProperty extends UserDataPropertyAPI
           this.writeValueToLocalStorage();
           this.triggerRerender();
         } catch (e) {
+          console.error(e);
+
           Sentry.captureException(e, {
             extra: {
               status,

--- a/src/context/UserDataContext/properties/userProgressOnResources.ts
+++ b/src/context/UserDataContext/properties/userProgressOnResources.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/browser';
-import { setDoc } from 'firebase/firestore';
+import { updateDoc } from 'firebase/firestore';
 import { ResourceProgress } from '../../../models/resource';
 import UserDataPropertyAPI from '../userDataPropertyAPI';
 
@@ -52,25 +52,18 @@ export default class UserProgressOnResourcesProperty extends UserDataPropertyAPI
     return {
       userProgressOnResources: this.progressValue,
       setUserProgressOnResources: (problemId, status) => {
-        if (!this.firebaseUserDoc) {
-          // if the user isn't using firebase, it is possible that they
-          // have multiple tabs open, which can result in localStorage
-          // being out of sync.
-          this.initializeFromLocalStorage();
-        }
+        // if the user isn't using firebase, it is possible that they
+        // have multiple tabs open, which can result in localStorage
+        // being out of sync.
+        // also bc of data loss let's just do this all the time
+        this.initializeFromLocalStorage();
         try {
           this.progressValue[problemId] = status;
 
           if (this.firebaseUserDoc) {
-            setDoc(
-              this.firebaseUserDoc,
-              {
-                [this.progressStorageKey]: {
-                  [problemId]: status,
-                },
-              },
-              { merge: true }
-            );
+            updateDoc(this.firebaseUserDoc, {
+              [`${this.progressStorageKey}.${problemId}`]: status,
+            });
           }
 
           this.writeValueToLocalStorage();


### PR DESCRIPTION
closes #3396, #3425

I don't actually know if this works lol, but hopefully if data is lost we will only lose the data on that particular problem / module progress which is fine.

I think other places `setDoc` is used include daily # of pageviews, but I don't think it's that bad if that data is lost.

The scary part of using `updateData` is if the doc doesn't exist then it will crash and die. But this would only happen when the user account is first created, and I think once the account is created data is written anyway...