### PR TITLE
fix katex warnings

### DIFF
--- a/content/4_Gold/Intro_Bitwise.mdx
+++ b/content/4_Gold/Intro_Bitwise.mdx
@@ -104,10 +104,12 @@ For simplicity, we will use the `sum` functions defined above. If we divide up
 $b$ into $2^{b_1}+2^{b_2}+\dots+2^{b_n}$, we get the following:
 
 $$
-a \times b \\
-= a \times (2^{b_1}+2^{b_2}+\dots+2^{b_n}) \\
-= a2^{b_1}+a2^{b_2}+\dots+a2^{b_n} \\
-= \sum_{\text{bits in b}} {a\texttt{<<}b_i}
+\begin{align*}
+&a \times b \\
+&= a \times (2^{b_1}+2^{b_2}+\dots+2^{b_n}) \\
+&= a2^{b_1}+a2^{b_2}+\dots+a2^{b_n} \\
+&= \sum_{\text{bits in b}} {a\texttt{<<}b_i}
+\end{align*}
 $$
 
 (This same idea is used in binary exponentiation!)

--- a/content/4_Gold/Paths_Grids.mdx
+++ b/content/4_Gold/Paths_Grids.mdx
@@ -119,14 +119,11 @@ normally. But, if cell $(x, y)$ has an asterisk, the dp-value is $0$, because no
 path can end on a trap.
 
 $$
-
   \texttt{dp}[x][y] =
 \begin{cases}
 \texttt{dp}[x-1][y] + \texttt{dp}[x][y-1] & \text{if $(x, y)$ is not a trap} \\
 0, & \text{if $(x, y)$ is a trap}
 \end{cases}
-
-
 $$
 
 The code for the DP recurrence doesn't change much:

--- a/solutions/bronze/usaco-526.mdx
+++ b/solutions/bronze/usaco-526.mdx
@@ -18,8 +18,10 @@ If it does, we remove it from $\texttt{censored}$ by taking off the last few cha
 
 As a demonstration, let's try this on the example case where:
 $$
-s=\texttt{whatthemomooofun} \newline
-t=\texttt{moo}
+\begin{align*}
+s&=\texttt{whatthemomooofun} \\
+t&=\texttt{moo}
+\end{align*}
 $$
 
 Our solution will loop through each character of $s$, appending it to $\texttt{censored}$ until it becomes $\texttt{whatthemomoo}$, when it will cut off the last 3 characters since they equal $t$. This results in $\texttt{censored}$ becoming $\texttt{whatthemo}$.

--- a/solutions/bronze/usaco-941.mdx
+++ b/solutions/bronze/usaco-941.mdx
@@ -15,16 +15,24 @@ author: Jesse Choe, Ryan Chou, Chuyang Wang, Vivian Han
 
 First, it may help to think of an instance where we cannot form a proper evolutionary tree. This would be an instance such that no matter how we form the tree, it would be inevitable that some characteristic would evolve in two distinct places in the tree. It turns out that the minimal such bad example looks like this:
 
-$\texttt{population1: A } \\
-\texttt{population2: B } \\
-\texttt{population3: A B}$
+$$
+\begin{align*}
+&\texttt{population1: A } \\
+&\texttt{population2: B } \\
+&\texttt{population3: A B}
+\end{align*}
+$$
 
 In other words, we have a population with just trait $A$, a population with just trait $B$, and a population with both. If we want to build a tree out of this input, we would need to split on either $A$ or $B$ at the root, but then the remaining two subtrees would both need to have an edge that adds the other characteristic. For example, if the root split into "$A$" and "not $A$" branches, then both branches would need to contain an edge that adds the $B$ trait.
 
 It will help to actually look at things from the viewpoint of the characteristics instead of from the viewpoint of the populations, so let's "transpose" the input above:
 
-$\texttt{A: population1 population3 } \\
-\texttt{B: population2 population3}$
+$$
+\begin{align*}
+\texttt{A: population1 population3} \\
+\texttt{B: population2 population3}
+\end{align*}
+$$
 
 The fundamental problem here is that there are populations in $A$ only, populations in $B$ only, and populations in both $A$ and $B$. If we look at the Venn diagram for the sets $A$ and $B$, the picture therefore looks like this:
 

--- a/solutions/gold/cf-1187E.mdx
+++ b/solutions/gold/cf-1187E.mdx
@@ -35,8 +35,10 @@ the cost of working down and $dp_2$ for the cost of working up and $sz$ for the
 size of a subtree.
 
 $$
-sz[u] = 1 + \sum_{c\in child(u)} sz[c] \newline
-dp_1[u] = sz[u] + \sum_{c\in child(u)} dp_1[c]
+\begin{align*}
+sz[u] &= 1 + \sum_{c\in child(u)} sz[c] \\
+dp_1[u] &= sz[u] + \sum_{c\in child(u)} dp_1[c]
+\end{align*}
 $$
 
 We can calculate this DP array with a single DFS search. Now, for the second DP
@@ -67,8 +69,10 @@ combined till $u$. Then we can calculate $p_1[u]$ and $p_2[u]$ using the
 following recurrence:
 
 $$
-p_1[u] = p_1[p] + sz[p] - sz[u] \newline
-p_2[u] = p_2[p] + p_1[u] + sz[p] - sz[u]
+\begin{align*}
+p_1[u] &= p_1[p] + sz[p] - sz[u] \\
+p_2[u] &= p_2[p] + p_1[u] + sz[p] - sz[u]
+\end{align*}
 $$
 
 ## Implementation


### PR DESCRIPTION
closes #3307

I just looked through all the occurrences of `\\` and `\newline` ... 

is there a better way (e.g., get gatsby to print locations of warnings)? @thecodingwizard 

_If any of the below don't apply to this Pull Request, mark the checkbox as done._

- [ ] I have tested my code.
- [ ] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [ ] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
