### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "url": "https://github.com/thecodingwizard/usaco-guide/issues"
   },
   "lint-staged": {
-    "*.{js,ts,jsx,tsx}": "eslint",
+    "*.{js,ts,jsx,tsx}": "eslint --config .eslintrc.js --resolve-plugins-relative-to .",
     "*.{js,jsx,ts,tsx,json,md,mdx}": "prettier --write"
   },
   "babelMacros": {


### PR DESCRIPTION
closes #3518

actually, this has nothing to do with `lint-staged`. it's just that there are two nested `.eslintrc.js` files, so

```
eslint /Users/benq/Dev/usaco-guide/src/functions/src/submitContactForm.ts
```

exits with an error when run from the repo root (but not when run from `src/functions`). not sure if this is the best way to fix this.

_If any of the below don't apply to this Pull Request, mark the checkbox as done._

- [ ] I have tested my code.
- [ ] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [ ] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
