### PR TITLE
Incorrect value for gp_hash_table

### DIFF
--- a/content/4_Gold/Hashmaps.mdx
+++ b/content/4_Gold/Hashmaps.mdx
@@ -356,7 +356,7 @@ We can modify the declaration of `gp_hash_table` so that it supports the
 ```cpp
 template <class K, class V>
 using ht = gp_hash_table<
-    K, null_type, hash<K>, equal_to<K>, direct_mask_range_hashing<>,
+    K, V, hash<K>, equal_to<K>, direct_mask_range_hashing<>,
     linear_probe_fn<>,
     hash_standard_resize_policy<hash_exponential_size_policy<>,
                                 hash_load_check_resize_trigger<>, true>>;

--- a/content/4_Gold/Hashmaps.mdx
+++ b/content/4_Gold/Hashmaps.mdx
@@ -356,8 +356,7 @@ We can modify the declaration of `gp_hash_table` so that it supports the
 ```cpp
 template <class K, class V>
 using ht = gp_hash_table<
-    K, V, hash<K>, equal_to<K>, direct_mask_range_hashing<>,
-    linear_probe_fn<>,
+    K, V, hash<K>, equal_to<K>, direct_mask_range_hashing<>, linear_probe_fn<>,
     hash_standard_resize_policy<hash_exponential_size_policy<>,
                                 hash_load_check_resize_trigger<>, true>>;
 ```


### PR DESCRIPTION
Should have the value V (instead of null_type) for generic hash table.

_If any of the below don't apply to this Pull Request, mark the checkbox as done._

- [ ] I have tested my code.
- [ ] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [ ] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
