### PR TITLE
sz() function now takes reference to const container

### DIFF
--- a/content/1_General/Generic_Code.mdx
+++ b/content/1_General/Generic_Code.mdx
@@ -432,7 +432,7 @@ but we can easily write a templated function to fix this, handling all types
 of containers at once:
 
 ```cpp
-template <class T> int sz(T &container) { return (int)container.size(); }
+template <class T> int sz(const T &container) { return (int)container.size(); }
 ```
 
 You can call this through typing `sz<vector<int>>(v)` where `v` is a


### PR DESCRIPTION
In the previous pull I made the sz function take reference, but now I realize that const reference also allows to use sz for rvalues, `sz(some_func_returning_vector())`

_If any of the below don't apply to this Pull Request, mark the checkbox as done._

- [x] I have tested my code.
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
