### PR TITLE
fix bitwise operators quiz answers format

### DIFF
--- a/content/3_Silver/Intro_Bitwise.mdx
+++ b/content/3_Silver/Intro_Bitwise.mdx
@@ -348,19 +348,19 @@ def prod(a: int, b: int) -> int:
   <Quiz.Question>
     Which of the following will set the kth bit of int x as true? Assume you do not know what the value of the kth bit currently is.
     <Quiz.Answer>
-      `x \&= (1 \<\< k)`
+      `x &= (1 << k)`
       <Quiz.Explanation>
         Incorrect. This will set the number to $1<<k$ if the kth bit was true, and 0 if the kth bit was false.
       </Quiz.Explanation>
     </Quiz.Answer>
     <Quiz.Answer correct>
-      `x |= (1 \<\< k)`
+      `x |= (1 << k)`
       <Quiz.Explanation>
         Correct. This will set the kth bit to true regardless of what it currently is.
       </Quiz.Explanation>
     </Quiz.Answer>
     <Quiz.Answer>
-      `x += (1 \<\< k)`
+      `x += (1 << k)`
       <Quiz.Explanation>
         Incorrect. If the kth bit is already true, it will make the kth bit false and mess up the rest of x.
       </Quiz.Explanation>
@@ -369,25 +369,25 @@ def prod(a: int, b: int) -> int:
   <Quiz.Question>
     Which gives the number of subsets for an array of size n? (Include the empty subset)
     <Quiz.Answer>
-      `n \<\< 1`
+      `n << 1`
       <Quiz.Explanation>
         Incorrect. This will give n*2.
       </Quiz.Explanation>
     </Quiz.Answer>
     <Quiz.Answer correct>
-      `1 \<\< n`
+      `1 << n`
       <Quiz.Explanation>
         Correct. This will give 2^n.
       </Quiz.Explanation>
     </Quiz.Answer>
     <Quiz.Answer>
-      `n \<\< 2`
+      `n << 2`
       <Quiz.Explanation>
         Incorrect. This will give n*4.
       </Quiz.Explanation>
     </Quiz.Answer>
     <Quiz.Answer>
-      `2 \<\< n`
+      `2 << n`
       <Quiz.Explanation>
         Incorrect. This will give 2^(n+1)
       </Quiz.Explanation>
@@ -396,25 +396,25 @@ def prod(a: int, b: int) -> int:
   <Quiz.Question>
     Which checks if the kth bit in int x is true?
     <Quiz.Answer correct>
-      `x \& ( 1\<\< k)`
+      `x & ( 1 << k)`
       <Quiz.Explanation>
         Correct. This will check the kth bit in x.
       </Quiz.Explanation>
     </Quiz.Answer>
     <Quiz.Answer>
-      `x \&\& (1 \<\< k)`
+      `x && (1 << k)`
       <Quiz.Explanation>
         Incorrect. This will be true if x an k are both not 0.
       </Quiz.Explanation>
     </Quiz.Answer>
     <Quiz.Answer>
-      `x | (1 \<\< k)`
+      `x | (1 << k)`
       <Quiz.Explanation>
         Incorrect. This will be true if either x or k is not 0.
       </Quiz.Explanation>
     </Quiz.Answer>
     <Quiz.Answer>
-      `x || (1 \<\< k)`
+      `x || (1 << k)`
       <Quiz.Explanation>
         Incorrect. This will be true if either x or k is not 0.
       </Quiz.Explanation>


### PR DESCRIPTION
I removed the unnecessary backslashes in silver / intro to bitwise operators quiz answers.
![image](https://github.com/cpinitiative/usaco-guide/assets/51521033/b6e4e538-98cd-4ce3-9bed-edfdfa747149)

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
