### PR TITLE
Fix location of Bitmask DP problem

### DIFF
--- a/content/3_Silver/Intro_Bitwise.problems.json
+++ b/content/3_Silver/Intro_Bitwise.problems.json
@@ -149,19 +149,6 @@
       }
     },
     {
-      "uniqueId": "usaco-1282",
-      "name": "Lights Off",
-      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1282",
-      "source": "Gold",
-      "difficulty": "Hard",
-      "isStarred": false,
-      "tags": ["Bitwise", "DP"],
-      "solutionMetadata": {
-        "kind": "USACO",
-        "usacoId": "1282"
-      }
-    },
-    {
       "uniqueId": "cf-1088D",
       "name": "Ehab and another another xor problem",
       "url": "https://codeforces.com/contest/1088/problem/D",

--- a/content/4_Gold/DP_Bitmasks.problems.json
+++ b/content/4_Gold/DP_Bitmasks.problems.json
@@ -125,6 +125,19 @@
       }
     },
     {
+      "uniqueId": "usaco-1282",
+      "name": "Lights Off",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1282",
+      "source": "Gold",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Bitwise", "DP"],
+      "solutionMetadata": {
+        "kind": "USACO",
+        "usacoId": "1282"
+      }
+    },
+    {
       "uniqueId": "izho-17-LongestBeautifulSequence",
       "name": "2017 - Longest beautiful sequence",
       "url": "https://oj.uz/problem/view/IZhO17_subsequence",


### PR DESCRIPTION
It seems that a 2200-rated (codetiger.me/projects/usaco) Bitmask DP problem in the Intro to Bitwise Operator Silver section 

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
