### PR TITLE
Rectify solution description for CSES Max Sum Subarray II

### DIFF
--- a/solutions/gold/cses-1644.mdx
+++ b/solutions/gold/cses-1644.mdx
@@ -20,8 +20,8 @@ Therefore, we should construct a prefix sum array to perform these queries.
 <Spoiler title="Solution">
 
 Notice that we are trying to maximize $\textrm{pfx}[i] - \textrm{pfx}[j]$. Since
-$j$ is guaranteed to be within the window $[i-b,i]$, we can construct a sliding
-window of size b, and compute
+$j$ is guaranteed to be within the window $[i-b,i-a]$, we can construct a sliding
+window of size $b-a+1$, and compute
 $\max_{A\le i \le B}(\textrm{pfx}[i]-\textrm{pfx}[j])$.
 
 Implementation using a multiset in C++:
@@ -51,8 +51,8 @@ int main() {
 	ll ret = -LINF;
 	multiset<ll> ms;
 
-	// we can keep a sliding window of size B, then find the lowest pfx[j] using
-	// multiset
+	// we can keep a sliding window of size B - A + 1,
+	// then find the lowest pfx[j] using multiset
 	for (int i = A; i <= N; ++i) {
 		if (i > B)
 			ms.erase(ms.find(pfx[i - B - 1]));  // erase the element if size > B


### PR DESCRIPTION
When maximizing the sum of subarrays between sizes **[A, B]**, the solution text talks about a sliding window of size **B**. Actually the sliding window is of size **B - A + 1**, the difference between the size bounds.

If the sliding window were of size **B**, the problem statement would be different: maximimzing the sum of subarrays **having a max size of B**.

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
