### PR TITLE
removed '?might work' from usaco.guide/general/contributing

### DIFF
--- a/content/1_General/Contributing.mdx
+++ b/content/1_General/Contributing.mdx
@@ -45,7 +45,7 @@ is useful if you need to use Tailwind CSS classes, which don't work with
    - Install [node.js](https://nodejs.org/en/)
      - [Gatsby docs](https://www.gatsbyjs.org/tutorial/part-zero/#install-nodejs-for-your-appropriate-operating-system)
    - Install [yarn](https://classic.yarnpkg.com/en/)
-     - `npm install -g yarn`? might work
+     - `npm install -g yarn`
 2. Clone repo
    - Via command line:
      `git clone https://github.com/cpinitiative/usaco-guide.git`


### PR DESCRIPTION
Removed `? might work` in contributing portion of website in install yarn step. 

`npm install -g yarn` command does work as expected. 

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
