### PR TITLE
Increased cf-1082E difficulty to normal.

### DIFF
--- a/content/4_Gold/Intro_DP.problems.json
+++ b/content/4_Gold/Intro_DP.problems.json
@@ -29,19 +29,6 @@
       }
     },
     {
-      "uniqueId": "cf-1082E",
-      "name": "Increasing Frequency",
-      "url": "https://codeforces.com/problemset/problem/1082/E",
-      "source": "CF",
-      "difficulty": "Easy",
-      "isStarred": false,
-      "tags": ["DP"],
-      "solutionMetadata": {
-        "kind": "autogen-label-from-site",
-        "site": "CF"
-      }
-    },
-    {
       "uniqueId": "usaco-694",
       "name": "Hoof Paper Scissors",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=694",
@@ -64,6 +51,19 @@
       "solutionMetadata": {
         "kind": "internal",
         "usacoId": "993"
+      }
+    },
+    {
+      "uniqueId": "cf-1082E",
+      "name": "Increasing Frequency",
+      "url": "https://codeforces.com/problemset/problem/1082/E",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["DP"],
+      "solutionMetadata": {
+        "kind": "autogen-label-from-site",
+        "site": "CF"
       }
     },
     {


### PR DESCRIPTION
### Change(s)
Increased cf-1082E difficulty to normal in "Introduction to DP" section.

### Reason 
It took around 45 minutes to solve the problem as compared to 5 minutes for the first problem (cf-1418C). More holistically, the in-contest solving time for the problem ranged from 7 minutes to around 15 minutes for most LGMs/Grandmasters as compared to 2-3 minutes for the first problem.

- [ ] I have tested my code.
- [ ] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [X] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [ ] I have linked this PR to any issues that it closes.
