### PR TITLE
Update Max_Flow.mdx

### DIFF
--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -14,7 +14,7 @@ frequency: 1
 
 ### Edmonds-Karp Algorithm
 
-The [Edmonds-Karp](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm) algorithm uses a greedy approach to solve the maximum flow problem. 
+The [Edmonds-Karp](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm) algorithm uses a greedy approach to solve the maximum flow problem.
 
 The download speed (the flow) can be improved as long as we can find a non-negative capacity augmenting path from the source (the server) to the sink (Kotivalo's computer). We use BFS to find this path.
 
@@ -32,7 +32,8 @@ It can be [proven](https://brilliant.org/wiki/edmonds-karp-algorithm/#:~:text=th
 #include <bits/stdc++.h>
 using namespace std;
 
-long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity, int source, int sink) {
+long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
+                   int source, int sink) {
 	int n = adj.size();
 	vector<int> parent(n, -1);
 	// Find a way from the source to sink on a path with non-negative capacities
@@ -42,7 +43,7 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity, 
 		while (!q.empty()) {
 			int node = q.front();
 			q.pop();
-			for (auto son: adj[node]) {
+			for (auto son : adj[node]) {
 				long long w = capacity[node][son];
 				if (w <= 0 || parent[son] != -1) continue;
 				parent[son] = node;

--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -29,9 +29,8 @@ After that, we subtract the minimum capacity on the found path from the edge cap
 #include <bits/stdc++.h>
 using namespace std;
 
-long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
-                   int n, int source, int sink) {
-	long long flow = 0;
+long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity, int source, int sink) {
+	int n = adj.size();
 	vector<int> parent(n, -1);
 
 	// Find a way from the source to sink on a path with non-negative capacities
@@ -41,7 +40,7 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		while (!q.empty()) {
 			int node = q.front();
 			q.pop();
-			for (auto son : adj[node]) {
+			for(auto son: adj[node]) {
 				long long w = capacity[node][son];
 				if (w <= 0 || parent[son] != -1) continue;
 				parent[son] = node;
@@ -50,6 +49,8 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		}
 		return parent[sink] != -1;
 	};
+
+	long long flow = 0;
 
 	// While there is a way from source to sink with non-negative capacities
 	while (reachable()) {
@@ -92,7 +93,7 @@ int main() {
 		capacity[a][b] += c;
 	}
 
-	cout << max_flow(adj, capacity, n, 0, n - 1) << endl;
+	cout << max_flow(adj, capacity, 0, n - 1) << endl;
 }
 ```
 

--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -14,7 +14,7 @@ frequency: 1
 
 ### Edmonds-Karp Algorithm
 
-The [Edmonds-Karp](https://brilliant.org/wiki/edmonds-karp-algorithm/) algorithm uses a greedy approach to solve the maximum flow problem. 
+The [Edmonds-Karp](https://brilliant.org/wiki/edmonds-karp-algorithm/) algorithm uses a greedy approach to solve the maximum flow problem.
 
 The download speed (the flow) can be improved as long as we can find a non-negative capacity path from the source (the server) and the sink (Kotivalo's computer).
 After that, we subtract the minimum capacity on the found path from the edge capacities.
@@ -29,7 +29,8 @@ After that, we subtract the minimum capacity on the found path from the edge cap
 #include <bits/stdc++.h>
 using namespace std;
 
-long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity, int n, int source, int sink) {
+long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
+                   int n, int source, int sink) {
 	long long flow = 0;
 	vector<int> parent(n, -1);
 
@@ -40,7 +41,7 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity, 
 		while (!q.empty()) {
 			int node = q.front();
 			q.pop();
-			for(auto son: adj[node]) {
+			for (auto son : adj[node]) {
 				long long w = capacity[node][son];
 				if (w <= 0 || parent[son] != -1) continue;
 				parent[son] = node;

--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -14,11 +14,14 @@ frequency: 1
 
 ### Edmonds-Karp Algorithm
 
-The [Edmonds-Karp](https://brilliant.org/wiki/edmonds-karp-algorithm/) algorithm uses a greedy approach to solve the maximum flow problem.
+The [Edmonds-Karp](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm) algorithm uses a greedy approach to solve the maximum flow problem. 
 
-The download speed (the flow) can be improved as long as we can find a non-negative capacity path from the source (the server) and the sink (Kotivalo's computer).
-After that, we subtract the minimum capacity on the found path from the edge capacities.
+The download speed (the flow) can be improved as long as we can find a non-negative capacity augmenting path from the source (the server) to the sink (Kotivalo's computer). We use BFS to find this path.
 
+Then, we update the weights of the edges along this augmenting path: Each edge $u$, $v$ loses weight equivalent to its capacity in the augmenting path. Each reverse edge
+$v$, $u$ gains this weight.
+
+It can be [proven](https://brilliant.org/wiki/edmonds-karp-algorithm/#:~:text=the%20source%20vertex.-,Complexity%20Proof,-Edmonds%2DKarp%20relies) that the total number of flow augmentations(BFS calls) is $\mathcal{O}(VE)$. And each BFS call requires $\mathcal{O}(E)$ time.
 
 **Time complexity:** $\mathcal{O}(VE^2)$
 
@@ -29,11 +32,9 @@ After that, we subtract the minimum capacity on the found path from the edge cap
 #include <bits/stdc++.h>
 using namespace std;
 
-long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
-                   int source, int sink) {
+long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity, int source, int sink) {
 	int n = adj.size();
 	vector<int> parent(n, -1);
-
 	// Find a way from the source to sink on a path with non-negative capacities
 	auto reachable = [&]() -> bool {
 		queue<int> q;
@@ -41,7 +42,7 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		while (!q.empty()) {
 			int node = q.front();
 			q.pop();
-			for (auto son : adj[node]) {
+			for (auto son: adj[node]) {
 				long long w = capacity[node][son];
 				if (w <= 0 || parent[son] != -1) continue;
 				parent[son] = node;
@@ -50,13 +51,10 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		}
 		return parent[sink] != -1;
 	};
-
 	long long flow = 0;
-
 	// While there is a way from source to sink with non-negative capacities
 	while (reachable()) {
 		int node = sink;
-
 		// The minimum capacity on the path from source to sink
 		long long curr_flow = LLONG_MAX;
 		while (node != source) {
@@ -74,14 +72,12 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		flow += curr_flow;
 		fill(parent.begin(), parent.end(), -1);
 	}
-
 	return flow;
 }
 
 int main() {
 	int n, m;
 	cin >> n >> m;
-
 	vector<vector<long long>> capacity(n, vector<long long>(n, 0));
 	vector<vector<int>> adj(n);
 	for (int i = 0; i < m; i++) {
@@ -93,7 +89,6 @@ int main() {
 		adj[b].push_back(a);
 		capacity[a][b] += c;
 	}
-
 	cout << max_flow(adj, capacity, 0, n - 1) << endl;
 }
 ```
@@ -239,6 +234,11 @@ int main() {
 	<Resource
 		source="CP2"
 		title="4.6, 4.7.4 - Max Flow, Bipartite Graphs"
+	 />
+	<Resource
+		source="Brilliant"
+		title="Time Complexity Proof for Edmonds-Karp"
+		url = "https://brilliant.org/wiki/edmonds-karp-algorithm/#:~:text=the%20source%20vertex.-,Complexity%20Proof,-Edmonds%2DKarp%20relies"
 	 />
 </Resources>
 

--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -43,7 +43,7 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		while (!q.empty()) {
 			int node = q.front();
 			q.pop();
-			for (auto son: adj[node]) {
+			for (auto son : adj[node]) {
 				long long w = capacity[node][son];
 				if (w <= 0 || parent[son] != -1) continue;
 				parent[son] = node;

--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -29,7 +29,8 @@ After that, we subtract the minimum capacity on the found path from the edge cap
 #include <bits/stdc++.h>
 using namespace std;
 
-long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity, int source, int sink) {
+long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
+                   int source, int sink) {
 	int n = adj.size();
 	vector<int> parent(n, -1);
 
@@ -40,7 +41,7 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity, 
 		while (!q.empty()) {
 			int node = q.front();
 			q.pop();
-			for(auto son: adj[node]) {
+			for (auto son : adj[node]) {
 				long long w = capacity[node][son];
 				if (w <= 0 || parent[son] != -1) continue;
 				parent[son] = node;

--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -236,11 +236,6 @@ int main() {
 		source="CP2"
 		title="4.6, 4.7.4 - Max Flow, Bipartite Graphs"
 	 />
-	<Resource
-		source="Brilliant"
-		title="Time Complexity Proof for Edmonds-Karp"
-		url = "https://brilliant.org/wiki/edmonds-karp-algorithm/#:~:text=the%20source%20vertex.-,Complexity%20Proof,-Edmonds%2DKarp%20relies"
-	 />
 </Resources>
 
 ## Flows

--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -43,7 +43,7 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		while (!q.empty()) {
 			int node = q.front();
 			q.pop();
-			for (auto son : adj[node]) {
+			for (auto son: adj[node]) {
 				long long w = capacity[node][son];
 				if (w <= 0 || parent[son] != -1) continue;
 				parent[son] = node;

--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -12,16 +12,25 @@ frequency: 1
 
 ## Solution
 
-### Edmonds-Karp Algorithm
+### Explanation
 
-The [Edmonds-Karp](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm) algorithm uses a greedy approach to solve the maximum flow problem.
+The [Edmonds-Karp](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm)
+algorithm uses a greedy approach to solve the maximum flow problem.
 
-The download speed (the flow) can be improved as long as we can find a non-negative capacity augmenting path from the source (the server) to the sink (Kotivalo's computer). We use BFS to find this path.
+The download speed (the flow) can be improved as long as we can find
+a non-negative capacity augmenting path from the source (the server) to the sink (Kotivalo's computer).
+We use BFS to find this path.
 
-Then, we update the weights of the edges along this augmenting path: Each edge $u$, $v$ loses weight equivalent to its capacity in the augmenting path. Each reverse edge
-$v$, $u$ gains this weight.
+Then, we update the weights of the edges along this augmenting path.
+Each edge $u$, $v$ loses weight equivalent to its capacity in the augmenting path,
+while each reverse edge $v$, $u$ gains this weight.
 
-It can be [proven](https://brilliant.org/wiki/edmonds-karp-algorithm/#:~:text=the%20source%20vertex.-,Complexity%20Proof,-Edmonds%2DKarp%20relies) that the total number of flow augmentations(BFS calls) is $\mathcal{O}(VE)$. And each BFS call requires $\mathcal{O}(E)$ time.
+It can be
+[proven](https://brilliant.org/wiki/edmonds-karp-algorithm)
+that the total number of flow augmentations(BFS calls) is $\mathcal{O}(VE)$
+and that each BFS call requires $\mathcal{O}(E)$ time.
+
+### Implementation
 
 **Time complexity:** $\mathcal{O}(VE^2)$
 
@@ -43,7 +52,7 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		while (!q.empty()) {
 			int node = q.front();
 			q.pop();
-			for (auto son : adj[node]) {
+			for (int son : adj[node]) {
 				long long w = capacity[node][son];
 				if (w <= 0 || parent[son] != -1) continue;
 				parent[son] = node;
@@ -52,6 +61,7 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		}
 		return parent[sink] != -1;
 	};
+
 	long long flow = 0;
 	// While there is a way from source to sink with non-negative capacities
 	while (reachable()) {
@@ -73,23 +83,24 @@ long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity,
 		flow += curr_flow;
 		fill(parent.begin(), parent.end(), -1);
 	}
+
 	return flow;
 }
 
 int main() {
 	int n, m;
 	cin >> n >> m;
-	vector<vector<long long>> capacity(n, vector<long long>(n, 0));
+
+	vector<vector<long long>> capacity(n, vector<long long>(n));
 	vector<vector<int>> adj(n);
 	for (int i = 0; i < m; i++) {
 		int a, b, c;
 		cin >> a >> b >> c;
-		--a;
-		--b;
-		adj[a].push_back(b);
+		adj[--a].push_back(--b);
 		adj[b].push_back(a);
 		capacity[a][b] += c;
 	}
+
 	cout << max_flow(adj, capacity, 0, n - 1) << endl;
 }
 ```

--- a/content/6_Advanced/Max_Flow.mdx
+++ b/content/6_Advanced/Max_Flow.mdx
@@ -1,7 +1,7 @@
 ---
 id: max-flow
 title: 'Maximum Flow'
-author: Benjamin Qi, Mihnea Brebenel
+author: Benjamin Qi, Mihnea Brebenel, Ahmet Ala
 prerequisites:
   - unweighted-shortest-paths
 description: Introduces maximum flow as well as flow with lower bounds.
@@ -14,10 +14,13 @@ frequency: 1
 
 ### Edmonds-Karp Algorithm
 
-The [Edmonds-Karp](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm) algorithm uses a greedy approach to solve the maximum flow problem.
+The [Edmonds-Karp](https://brilliant.org/wiki/edmonds-karp-algorithm/) algorithm uses a greedy approach to solve the maximum flow problem. 
 
 The download speed (the flow) can be improved as long as we can find a non-negative capacity path from the source (the server) and the sink (Kotivalo's computer).
 After that, we subtract the minimum capacity on the found path from the edge capacities.
+
+
+**Time complexity:** $\mathcal{O}(VE^2)$
 
 <LanguageSection>
 <CPPSection>
@@ -26,7 +29,7 @@ After that, we subtract the minimum capacity on the found path from the edge cap
 #include <bits/stdc++.h>
 using namespace std;
 
-long long max_flow(vector<vector<long long>> g, int n, int source, int sink) {
+long long max_flow(vector<vector<int>> adj, vector<vector<long long>> capacity, int n, int source, int sink) {
 	long long flow = 0;
 	vector<int> parent(n, -1);
 
@@ -37,8 +40,8 @@ long long max_flow(vector<vector<long long>> g, int n, int source, int sink) {
 		while (!q.empty()) {
 			int node = q.front();
 			q.pop();
-			for (int son = 0; son < n; son++) {
-				long long w = g[node][son];
+			for(auto son: adj[node]) {
+				long long w = capacity[node][son];
 				if (w <= 0 || parent[son] != -1) continue;
 				parent[son] = node;
 				q.push(son);
@@ -54,15 +57,15 @@ long long max_flow(vector<vector<long long>> g, int n, int source, int sink) {
 		// The minimum capacity on the path from source to sink
 		long long curr_flow = LLONG_MAX;
 		while (node != source) {
-			curr_flow = min(curr_flow, g[parent[node]][node]);
+			curr_flow = min(curr_flow, capacity[parent[node]][node]);
 			node = parent[node];
 		}
 		node = sink;
 		while (node != source) {
 			// Subtract the capacity from capacity edges
-			g[parent[node]][node] -= curr_flow;
+			capacity[parent[node]][node] -= curr_flow;
 			// Add the current flow to flow backedges
-			g[node][parent[node]] += curr_flow;
+			capacity[node][parent[node]] += curr_flow;
 			node = parent[node];
 		}
 		flow += curr_flow;
@@ -77,13 +80,18 @@ int main() {
 	cin >> n >> m;
 
 	vector<vector<long long>> capacity(n, vector<long long>(n, 0));
+	vector<vector<int>> adj(n);
 	for (int i = 0; i < m; i++) {
-		int x, y, c;
-		cin >> x >> y >> c;
-		capacity[--x][--y] += c;
+		int a, b, c;
+		cin >> a >> b >> c;
+		--a;
+		--b;
+		adj[a].push_back(b);
+		adj[b].push_back(a);
+		capacity[a][b] += c;
 	}
 
-	cout << max_flow(capacity, n, 0, n - 1) << endl;
+	cout << max_flow(adj, capacity, n, 0, n - 1) << endl;
 }
 ```
 


### PR DESCRIPTION
Previous Code for "Download Speed" problem in CSES gets TLE. 

The reason is the for loop in reachable function:
		
for (int son = 0; son < n; son++) {
				long long w = g[node][son];


Here we check every vertex instead of checking every neighbor of 'node'. We should have used adjacency list instead of an adjacency matrix. So, time complexity of every reachable-call(bfs) is O(N*M). Overall we get O(N^2 * M^2) which results in TLE. 

Further, I checked the other codes in "User Solutions"  at https://usaco.guide/problems/cses-1694/user-solutions and some of these solutions also get TLE. I think the this code misleaded many people and caused them to implement a slow Edmonds Karp.

So I updated code, created an adjacency list. I kept the capacity array. I changed the wikipedia link of Edmonds Karp Algorithm with a Brilliant.org link, because on Brilliant there is also an extensive time complexity analysis.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
