### PR TITLE
Update usaco-967.mdx

### DIFF
--- a/solutions/silver/usaco-967.mdx
+++ b/solutions/silver/usaco-967.mdx
@@ -32,7 +32,7 @@ it will always take on the weight of the leftmost right-going cow
 because that's the cow it will meet last.
 More precisely, it will always take on the weight of the leftmost cow *overall*.
 
-Moving on the the second leftmost left-going cow (if there is one),
+Moving on the second leftmost left-going cow (if there is one),
 it will take on the weight of the second leftmost cow *overall*, because
 the leftmost cow's weight has been taken.
 


### PR DESCRIPTION
changed "the the" to "the"

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x ] I have tested my code.
- [ x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [ x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [ x] I have linked this PR to any issues that it closes.
