### PR TITLE
Update Graph_Traversal.mdx

### DIFF
--- a/content/3_Silver/Graph_Traversal.mdx
+++ b/content/3_Silver/Graph_Traversal.mdx
@@ -476,15 +476,15 @@ int main() {
 		if (!visited[i]) {
 			queue<int> q;
 			q.push(i);
-
+			visited[i] = true;
 			while (!q.empty()) {
 				int current_node = q.front();
 				q.pop();
-
-				visited[current_node] = true;
-
 				for (int neighbor : adj[current_node]) {
-					if (!visited[neighbor]) { q.push(neighbor); }
+					if (!visited[neighbor]) { 
+						visited[neighbor] = true;
+						q.push(neighbor); 
+					}
 				}
 			}
 		}

--- a/content/3_Silver/Graph_Traversal.mdx
+++ b/content/3_Silver/Graph_Traversal.mdx
@@ -481,9 +481,9 @@ int main() {
 				int current_node = q.front();
 				q.pop();
 				for (int neighbor : adj[current_node]) {
-					if (!visited[neighbor]) { 
+					if (!visited[neighbor]) {
 						visited[neighbor] = true;
-						q.push(neighbor); 
+						q.push(neighbor);
 					}
 				}
 			}


### PR DESCRIPTION
Refactor BFS algorithm to ensure nodes are visited only once

This commit refines the BFS algorithm implementation to correctly handle cases where a node has multiple parents at the same level. Previously, nodes could be added to the queue multiple times, leading to potential inefficiencies or incorrect traversal results.

Changes include:
- Marking a node as visited immediately after it is added to the queue, ensuring it is not processed again if encountered through another parent at the same level.
- Ensuring that each node is visited exactly once by checking the `visited` status before adding a neighbor to the queue.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [ ] I have linked this PR to any issues that it closes.
