### PR TITLE
Fix string hashing bounds bug

### DIFF
--- a/content/4_Gold/String_Hashing.mdx
+++ b/content/4_Gold/String_Hashing.mdx
@@ -43,7 +43,7 @@ class HashedString {
 
   public:
 	HashedString(const string &s) : p_hash(s.size() + 1) {
-		while (pow.size() < s.size()) { pow.push_back((pow.back() * B) % M); }
+		while (pow.size() <= s.size()) { pow.push_back((pow.back() * B) % M); }
 
 		p_hash[0] = 0;
 		for (int i = 0; i < s.size(); i++) {
@@ -80,7 +80,7 @@ public class HashedString {
 
 	public HashedString(String s) {
 		if (pow.isEmpty()) { pow.add(1L); }
-		while (pow.size() < s.length()) {
+		while (pow.size() <= s.length()) {
 			pow.add((pow.get(pow.size() - 1) * B) % M);
 		}
 
@@ -112,7 +112,7 @@ class HashedString:
 	_pow = [1]
 
 	def __init__(self, s: str):
-		while len(self._pow) < len(s):
+		while len(self._pow) <= len(s):
 			self._pow.append((self._pow[-1] * self.B) % self.M)
 
 		# p_hash[i] is the hash of the first i characters of the given string


### PR DESCRIPTION
Bug arises when trying to get hash of the entire string: `get_hash(0, s.size())`

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
