### PR TITLE
Fix Java and Python solutions of "Subsequences Summing to Sevens"

### DIFF
--- a/solutions/silver/usaco-595.mdx
+++ b/solutions/silver/usaco-595.mdx
@@ -77,7 +77,7 @@ public final class Div7 {
 		first[0] = 0;
 
 		int runningMod = 0;
-		for (int c = 0; c < cowNum; c++) {
+		for (int c = 1; c <= cowNum; c++) {
 			int cow = Integer.parseInt(read.readLine());
 			runningMod = (runningMod + cow) % MOD;
 			if (first[runningMod] == -1) {
@@ -113,9 +113,9 @@ for v, c in enumerate(cows):
 	running_mod = (running_mod + c) % MOD
 
 	if first_occ[running_mod] == -1:
-		first_occ[running_mod] = v
+		first_occ[running_mod] = v + 1
 	else:
-		best_photo = max(best_photo, v - first_occ[running_mod])
+		best_photo = max(best_photo, v + 1 - first_occ[running_mod])
 
 print(best_photo)
 print(best_photo, file=open("div7.out", "w"))


### PR DESCRIPTION
I'm modifying this page [https://usaco.guide/problems/usaco-595-subsequences-summing-to-sevens/solution](https://usaco.guide/problems/usaco-595-subsequences-summing-to-sevens/solution)

Even though Java and Python solutions pass all test cases at [https://usaco.org/index.php?page=viewproblem2&cpid=595](https://usaco.org/index.php?page=viewproblem2&cpid=595), they don't pass my own 2 test cases below.

Reason: the current solutions use 0-indexed when computing the subarray's length. We should use 1-indexed instead.

Suggestion: add these test cases to the USACO original problem.

## Test 1: answer = 6
```
7
7
5
1
6
2
14
10
```

## Test 2: answer = 7
```
7
7
5
1
6
2
14
7
```

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
