### PR TITLE
Fix typo within memset description

### DIFF
--- a/content/2_Bronze/Intro_DS.mdx
+++ b/content/2_Bronze/Intro_DS.mdx
@@ -92,9 +92,9 @@ zero, you have several options:
 [`memset(arr, 0, sizeof arr)`](http://www.cplusplus.com/reference/cstring/memset/)
 will also zero-initialize an array. However, it's important to note that
 `memset` treats the value that is passed to it as an `unsigned char`. So for an
-array of 32-bit integers, `memset(arr, -1, sizeof arr)` will set each element to
-$-1$, as you might expect. On the other hand, `memset(arr, 1, sizeof arr)` will
-set each element to $1+2^8+2^{16}+2^{24}=16843009$, not $1$.
+array of 32-bit integers, `memset(arr, 1, sizeof arr)` will set each element to
+$1$, as you might expect. On the other hand, `memset(arr, -1, sizeof arr)` will
+set each element to $1+2^8+2^{16}+2^{24}=16843009$, not $-1$.
 
 </Warning>
 


### PR DESCRIPTION
memset(arr, 1, sizeof) should set vals to 1 and memset(arr, -1, sizeof) will set vals to 2s complement. Textbook was not consistent with this.


- [ X ] I have tested my code.
- [ X ] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [ X ] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [ X ] I have linked this PR to any issues that it closes.
