### PR TITLE
Fix java DSU implementation

### DIFF
--- a/content/4_Gold/DSU.mdx
+++ b/content/4_Gold/DSU.mdx
@@ -132,7 +132,7 @@ public class DisjointSets {
 		sizes = new int[size];
 		for (int i = 0; i < size; i++) {
 			parents[i] = i;
-			sizes[i] = -1;
+			sizes[i] = 1;
 		}
 	}
 
@@ -317,7 +317,7 @@ class DisjointSets {
 		sizes = new int[size];
 		for (int i = 0; i < size; i++) {
 			parents[i] = i;
-			sizes[i] = -1;
+			sizes[i] = 1;
 		}
 	}
 


### PR DESCRIPTION
I'm modifying [https://usaco.guide/gold/dsu](https://usaco.guide/gold/dsu)

The java DSU implementation initializes array `sizes` with -1 which is incorrect, should be 1 instead.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
