### PR TITLE
updated: fixed "mex" definition

### DIFF
--- a/content/6_Advanced/Game_Theory.mdx
+++ b/content/6_Advanced/Game_Theory.mdx
@@ -256,9 +256,9 @@ $$
 For convenience, we have defined $n$ as the function that reduces game states to
 nimbers.
 
-The $\text{mex}$ function takes a list of numbers and returns the biggest
+The $\text{mex}$ function takes a list of numbers and returns the smallest
 non-negative integer that is _not_ included in the list. Notice that the name is
-a portmanteau of "max" and "excluded".
+a portmanteau of "min" and "excluded".
 
 ### One-pile Example
 


### PR DESCRIPTION
In this page was written that MEX-function is maximum excluded, but it's minimum excluded.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [ ] I have tested my code.
- [ ] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [ ] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [ ] I have linked this PR to any issues that it closes.
