### PR TITLE
Exponentiation II Formatting Change

### DIFF
--- a/solutions/gold/cses-1712.mdx
+++ b/solutions/gold/cses-1712.mdx
@@ -7,7 +7,9 @@ author: Ryan Chou
 
 ## Explanation
 
-[Fermat's Little Theorem](/gold/modular) tells us that $a^{p - 1} \equiv 1 \pmod{p}$, so we can calculate $a^{b^c \pmod{1e9 + 7 - 1}} \pmod{1e9+7}$ with modular exponentiation.
+Let $M = 10^{9} + 7$.
+
+[Fermat's Little Theorem](/gold/modular) tells us that $a^{p - 1} \equiv 1 \pmod{p}$, so we can calculate $a^{b^c \pmod{M - 1}} \pmod{M}$ with modular exponentiation.
 
 ## Implementation
 


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

ok i think this file was named incorrectly? i have no clue, but im pretty sure it should be `cses-1712.mdx` and not `cses-1095` (cuz that's Exponentiation I)

also i think using a variable for $10^9 + 7$ looks better cuz i think the current formatting looks a bit ugly
