### PR TITLE
CSES Subarray Sums II - Wrong Time Complexity

### DIFF
--- a/solutions/silver/cses-1661.mdx
+++ b/solutions/silver/cses-1661.mdx
@@ -20,7 +20,7 @@ the map.
 
 ## Implementation
 
-**Time Complexity:** $\mathcal{O}(N\text{ log }N)$
+**Time Complexity:** $\mathcal{O}(N\logN)$
 
 <LanguageSection>
 <CPPSection>

--- a/solutions/silver/cses-1661.mdx
+++ b/solutions/silver/cses-1661.mdx
@@ -20,10 +20,10 @@ the map.
 
 ## Implementation
 
-**Time Complexity:** $\mathcal{O}(N)$
-
 <LanguageSection>
 <CPPSection>
+
+**Time Complexity:** $\mathcal{O}(N\log N)$
 
 In C++, because `std::unordered_map` is vulnerable to collisions,
 we use `std::map` at the cost of adding an extra log factor to the complexity.
@@ -65,6 +65,8 @@ int main() {
 
 </CPPSection>
 <JavaSection>
+
+**Time Complexity:** $\mathcal{O}(N\log N)$
 
 ```java
 import java.io.*;
@@ -113,26 +115,35 @@ public class SubarraySumsII {
 </JavaSection>
 <PySection>
 
+**Time Complexity:** $\mathcal{O}(N)$ (expected)
+
 <Warning>
 
-The below solution TLEs due to Python's constant factor.
+Without incorporating randomness, the code below will fail to pass
+cases specifically designed to make Python dict run slowly. See the [Introduction to Sets](/bronze/intro-sets) module for more information.
 
 </Warning>
 
 ```py
+import random
+
+RANDOM = random.randrange(2**62)
+
+
+def Wrapper(x):
+	return x ^ RANDOM
+
+
 def main():
 	N, X = map(int, input().split())
 	prefix, res = 0, 0
-	mp = {0: 1}  # mp[0] = 1
+	mp = {Wrapper(0): 1}  # mp[0] = 1
 
 	for x in input().split():
 		prefix += int(x)
-		res += mp.get(prefix - X, 0)  # if not in dict, return 0
-		mp[prefix] = mp.get(prefix, 0) + 1
+		res += mp.get(Wrapper(prefix - X), 0)  # if not in dict, return 0
+		mp[Wrapper(prefix)] = mp.get(Wrapper(prefix), 0) + 1
 	print(res)
-
-
-main()
 ```
 
 </PySection>

--- a/solutions/silver/cses-1661.mdx
+++ b/solutions/silver/cses-1661.mdx
@@ -20,7 +20,7 @@ the map.
 
 ## Implementation
 
-**Time Complexity:** $\mathcal{O}(N)$
+**Time Complexity:** $\mathcal{O}(N\text{ log }N)$
 
 <LanguageSection>
 <CPPSection>

--- a/solutions/silver/cses-1661.mdx
+++ b/solutions/silver/cses-1661.mdx
@@ -20,7 +20,7 @@ the map.
 
 ## Implementation
 
-**Time Complexity:** $\mathcal{O}(N\logN)$
+**Time Complexity:** $\mathcal{O}(N\log N)$
 
 <LanguageSection>
 <CPPSection>

--- a/solutions/silver/cses-1661.mdx
+++ b/solutions/silver/cses-1661.mdx
@@ -113,6 +113,12 @@ public class SubarraySumsII {
 </JavaSection>
 <PySection>
 
+<Warning>
+
+The below solution TLEs due to Python's constant factor.
+
+</Warning>
+
 ```py
 def main():
 	N, X = map(int, input().split())

--- a/solutions/silver/cses-1661.mdx
+++ b/solutions/silver/cses-1661.mdx
@@ -20,10 +20,13 @@ the map.
 
 ## Implementation
 
-**Time Complexity:** $\mathcal{O}(N\log N)$
+**Time Complexity:** $\mathcal{O}(N)$
 
 <LanguageSection>
 <CPPSection>
+
+In C++, because `std::unordered_map` has a bad constant factor,
+we use `std::map` at the cost of adding an extra log factor to the complexity.
 
 ```cpp
 #include <iostream>

--- a/solutions/silver/cses-1661.mdx
+++ b/solutions/silver/cses-1661.mdx
@@ -25,7 +25,7 @@ the map.
 <LanguageSection>
 <CPPSection>
 
-In C++, because `std::unordered_map` has a bad constant factor,
+In C++, because `std::unordered_map` is vulnerable to collisions,
 we use `std::map` at the cost of adding an extra log factor to the complexity.
 
 ```cpp


### PR DESCRIPTION
[https://usaco.guide/problems/cses-1661-subarray-sums-ii/solution](https://usaco.guide/problems/cses-1661-subarray-sums-ii/solution
)
STL ordered map data structure used for implementation with N accesses.
Each access takes logn.
Time complexity should be O(N log N), is incorrectly denoted O(N).

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
