### PR TITLE
Fix solutions/platinum/ioi-11-race.mdx

### DIFF
--- a/solutions/platinum/ioi-11-race.mdx
+++ b/solutions/platinum/ioi-11-race.mdx
@@ -81,7 +81,6 @@ void small_to_large_merge(int u, int p) {
 }
 
 int best_path(int n, int k, int edges[][2], int weights[]) {
-	if (k == 1) { return 0; }
 	N = n;
 	K = k;
 	ret = INT_MAX;


### PR DESCRIPTION
Returning zero highways does not make sense for this problem. Both original and fixed solutions pass submission tests on oj.uz, probably because there is no test for k=1

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
