### PR TITLE
Fix negative time in daily streak component by clamping delta time to 0

### DIFF
--- a/src/components/Dashboard/DailyStreak.tsx
+++ b/src/components/Dashboard/DailyStreak.tsx
@@ -13,15 +13,16 @@ const ComeBackTimer = ({ tomorrowMilliseconds }) => {
 
   React.useEffect(() => {
     const interval = setInterval(() => {
-      setMilliseconds(tomorrowMilliseconds - Date.now());
+      setMilliseconds(Math.max(0, tomorrowMilliseconds - Date.now()));
     }, 1000);
     return () => clearInterval(interval);
   }, []);
 
-  const days = Math.floor(milliseconds / 1000 / 60 / 60 / 24);
-  const hours = Math.floor((milliseconds / 1000 / 60 / 60) % 24);
-  const minutes = Math.floor((milliseconds / 1000 / 60) % 60);
-  const seconds = Math.floor((milliseconds / 1000) % 60);
+  const ms = Math.max(0, milliseconds); // Clamp to zero
+  const days = Math.floor(ms / 1000 / 60 / 60 / 24);
+  const hours = Math.floor((ms / 1000 / 60 / 60) % 24);
+  const minutes = Math.floor((ms / 1000 / 60) % 60);
+  const seconds = Math.floor((ms / 1000) % 60);
 
   return (
     <div>


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

Linked issue: https://github.com/cpinitiative/usaco-guide/issues/5348

The negative time issue occurred because Date.now() in the useEffect hook could sometimes be greater than tomorrowMilliseconds, causing a negative delta and rendering negative time in the countdown. I fixed this by clamping the minimum value of the delta to zero, which prevents the countdown from displaying negative values.
