### PR TITLE
Fix empty submission url bug

### DIFF
--- a/src/components/Groups/ProblemPage/ProblemSubmissionInterface.tsx
+++ b/src/components/Groups/ProblemPage/ProblemSubmissionInterface.tsx
@@ -100,8 +100,8 @@ export default function ProblemSubmissionInterface({
     const handleSubmitLink = async e => {
       e.preventDefault();
       //prevent empty URL submission
-      if(!submissionLink.trim()){
-        alert("Cannot submit empty URL");
+      if (!submissionLink.trim()) {
+        alert('Cannot submit empty URL');
         return;
       }
       await submitSubmissionLink(submissionLink, problem.postId, problem.id);

--- a/src/components/Groups/ProblemPage/ProblemSubmissionInterface.tsx
+++ b/src/components/Groups/ProblemPage/ProblemSubmissionInterface.tsx
@@ -99,7 +99,7 @@ export default function ProblemSubmissionInterface({
   if (cannotSubmit) {
     const handleSubmitLink = async e => {
       e.preventDefault();
-      //prevent empty URL submission
+      // prevent empty URL submission
       if (!submissionLink.trim()) {
         alert('Cannot submit empty URL');
         return;

--- a/src/components/Groups/ProblemPage/ProblemSubmissionInterface.tsx
+++ b/src/components/Groups/ProblemPage/ProblemSubmissionInterface.tsx
@@ -99,6 +99,11 @@ export default function ProblemSubmissionInterface({
   if (cannotSubmit) {
     const handleSubmitLink = async e => {
       e.preventDefault();
+      //prevent empty URL submission
+      if(!submissionLink.trim()){
+        alert("Cannot submit empty URL");
+        return;
+      }
       await submitSubmissionLink(submissionLink, problem.postId, problem.id);
       setSubmissionLink('');
     };


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

Issued Link: https://github.com/cpinitiative/usaco-guide/issues/5094

There was a bug where a user could submit an empty URL and still get points. I fixed this issue by adding an if statement inside the handleSubmitLink function to check if the URL is empty. Now, a user can't submit an empty URL and still gain points. 