### PR TITLE
Provide more descriptive error message and provide error fallback 

### DIFF
--- a/src/mdx-plugins/rehype-math.js
+++ b/src/mdx-plugins/rehype-math.js
@@ -45,7 +45,7 @@ const customRehypeKatex = options => {
         if (typeof file[fn] === 'function') {
           file[fn](error.message, element.position, origin);
         } else {
-          throw error; //throw the error if the file does not have a fail or message function
+          throw error;  // throw the error if the file doesn't have a fail or message function
         }
 
         result = katex(

--- a/src/mdx-plugins/rehype-math.js
+++ b/src/mdx-plugins/rehype-math.js
@@ -42,9 +42,9 @@ const customRehypeKatex = options => {
         const fn = throwOnError ? 'fail' : 'message';
         const origin = [source, error.name.toLowerCase()].join(':');
 
-        if(typeof file[fn] === 'function') {
+        if (typeof file[fn] === 'function') {
           file[fn](error.message, element.position, origin);
-        } else{
+        } else {
           throw error; //throw the error if the file does not have a fail or message function
         }
 
@@ -60,7 +60,10 @@ const customRehypeKatex = options => {
 
       if (element.tagName === 'div') element.tagName = 'MATHDIV';
       else if (element.tagName === 'span') element.tagName = 'MATHSPAN';
-      else throw new Error('Unknown tag encountered in rehype-math.js: ' + element.tagName);
+      else
+        throw new Error(
+          'Unknown tag encountered in rehype-math.js: ' + element.tagName
+        );
 
       element.children = [
         {

--- a/src/mdx-plugins/rehype-math.js
+++ b/src/mdx-plugins/rehype-math.js
@@ -45,7 +45,7 @@ const customRehypeKatex = options => {
         if (typeof file[fn] === 'function') {
           file[fn](error.message, element.position, origin);
         } else {
-          throw error;  // throw the error if the file doesn't have a fail or message function
+          throw error; // throw the error if the file doesn't have a fail or message function
         }
 
         result = katex(

--- a/src/mdx-plugins/rehype-math.js
+++ b/src/mdx-plugins/rehype-math.js
@@ -42,7 +42,11 @@ const customRehypeKatex = options => {
         const fn = throwOnError ? 'fail' : 'message';
         const origin = [source, error.name.toLowerCase()].join(':');
 
-        file[fn](error.message, element.position, origin);
+        if(typeof file[fn] === 'function') {
+          file[fn](error.message, element.position, origin);
+        } else{
+          throw error; //throw the error if the file does not have a fail or message function
+        }
 
         result = katex(
           value,
@@ -56,7 +60,7 @@ const customRehypeKatex = options => {
 
       if (element.tagName === 'div') element.tagName = 'MATHDIV';
       else if (element.tagName === 'span') element.tagName = 'MATHSPAN';
-      else throw 'unknown tag?';
+      else throw new Error('Unknown tag encountered in rehype-math.js: ' + element.tagName);
 
       element.children = [
         {


### PR DESCRIPTION
…n] isnt a function

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

In src/mdx-plugins/rehype-math.js, there's a potential issue with math rendering where the code throws a generic error message "unknown tag?" when encountering an unexpected tag. I improved this by throwing this error:

 `Error('Unknown tag encountered in rehype-math.js: ' + element.tagName);`
 
 Now, the error message is more descriptive and follows proper conventions by throwing an error. Also, I provided a fallback for when file[fn] isn't a function:
 
 ` 
 if(typeof file[fn] === 'function') {
          file[fn](error.message, element.position, origin);
        } else{
          throw error; //throw the error if the file does not have a fail or message function
        }
 `
        
Providing a more descriptive error message will help with future debugging, and the fallback prevents silent errors.
