### PR TITLE
Lazy loading for faster development speed

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -7,11 +7,6 @@
 
 ## Development speedup tips
 
-Delete pages/editor.tsx and pages/groups.tsx (or have them return an empty
-component). These pages have a lot of dependencies that slow down webpack.
-
-On my personal computer, I have hot reload times of ~1.5 seconds.
-
 To make development even faster, you can take advantage of tailwind incremental
 builds (which don't seem to work with the default postcss setup for some
 reason).

--- a/src/components/Editor/EditorPage.tsx
+++ b/src/components/Editor/EditorPage.tsx
@@ -11,7 +11,7 @@
 
 import { PageProps } from 'gatsby';
 import { useAtomValue, useSetAtom } from 'jotai';
-import React, { lazy, Suspense } from 'react';
+import React, { lazy } from 'react';
 import Split from 'react-split';
 import {
   filesListAtom,
@@ -20,15 +20,27 @@ import {
   tokenAtom,
 } from '../../atoms/editor';
 import QuizGeneratorProvider from '../../context/QuizGeneratorContext';
+import { LazyLoad } from '../../utils/lazyLoad';
 import Layout from '../layout';
 import SEO from '../seo';
-import { LazyLoad } from '../../utils/lazyLoad';
 
 // Lazy load heavy components
-const EditorOutput = lazy(() => import('./EditorOutput').then(module => ({ default: module.EditorOutput })));
-const EditorSidebar = lazy(() => import('./EditorSidebar/EditorSidebar').then(module => ({ default: module.EditorSidebar })));
-const EditorTopNav = lazy(() => import('./EditorTopNav').then(module => ({ default: module.EditorTopNav })));
-const MainEditorInterface = lazy(() => import('./MainEditorInterface').then(module => ({ default: module.MainEditorInterface })));
+const EditorOutput = lazy(() =>
+  import('./EditorOutput').then(module => ({ default: module.EditorOutput }))
+);
+const EditorSidebar = lazy(() =>
+  import('./EditorSidebar/EditorSidebar').then(module => ({
+    default: module.EditorSidebar,
+  }))
+);
+const EditorTopNav = lazy(() =>
+  import('./EditorTopNav').then(module => ({ default: module.EditorTopNav }))
+);
+const MainEditorInterface = lazy(() =>
+  import('./MainEditorInterface').then(module => ({
+    default: module.MainEditorInterface,
+  }))
+);
 
 // From https://stackoverflow.com/questions/2090551/parse-query-string-in-javascript
 function getQueryVariable(query, variable) {

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -20,7 +20,7 @@ export default function EditorPageContainer(
   props: PageProps
 ): JSX.Element | null {
   const [hasMounted, setHasMounted] = React.useState(false);
-  
+
   React.useEffect(() => {
     setHasMounted(true);
   }, []);

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -10,16 +10,32 @@
 // }
 
 import { PageProps } from 'gatsby';
-import React, { useEffect, useState } from 'react';
-import EditorPage from '../components/Editor/EditorPage';
+import React, { lazy, Suspense } from 'react';
+import { isDevelopment, lazyLoadConfig } from '../utils/lazyLoad';
+
+// Lazy load the EditorPage component
+const EditorPage = lazy(() => import('../components/Editor/EditorPage'));
 
 export default function EditorPageContainer(
   props: PageProps
 ): JSX.Element | null {
-  const [hasMounted, setHasMounted] = useState(false);
-  useEffect(() => {
+  const [hasMounted, setHasMounted] = React.useState(false);
+  
+  React.useEffect(() => {
     setHasMounted(true);
   }, []);
+
   if (!hasMounted) return null;
+
+  // In development mode, use lazy loading if enabled
+  if (isDevelopment && lazyLoadConfig.editor.enabled) {
+    return (
+      <Suspense fallback={lazyLoadConfig.editor.fallback()}>
+        <EditorPage {...props} />
+      </Suspense>
+    );
+  }
+
+  // In production or if lazy loading is disabled, load normally
   return <EditorPage {...props} />;
 }

--- a/src/utils/lazyLoad.tsx
+++ b/src/utils/lazyLoad.tsx
@@ -25,4 +25,4 @@ export const lazyLoadConfig = {
     enabled: isDevelopment,
     fallback: () => <div>Groups is loading...</div>
   }
-}; 
+};

--- a/src/utils/lazyLoad.tsx
+++ b/src/utils/lazyLoad.tsx
@@ -2,11 +2,7 @@ import React, { Suspense } from 'react';
 
 // Lazy loading wrapper component
 export const LazyLoad = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      {children}
-    </Suspense>
-  );
+  return <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>;
 };
 
 // Development mode check
@@ -19,10 +15,10 @@ console.log('isDevelopment:', isDevelopment);
 export const lazyLoadConfig = {
   editor: {
     enabled: isDevelopment,
-    fallback: () => <div>Editor is loading...</div>
+    fallback: () => <div>Editor is loading...</div>,
   },
   groups: {
     enabled: isDevelopment,
-    fallback: () => <div>Groups is loading...</div>
-  }
+    fallback: () => <div>Groups is loading...</div>,
+  },
 };

--- a/src/utils/lazyLoad.tsx
+++ b/src/utils/lazyLoad.tsx
@@ -11,7 +11,7 @@ console.log('Current NODE_ENV:', process.env.NODE_ENV);
 console.log('isDevelopment:', isDevelopment);
 
 // Lazy loading configuration
-//set enabled to false to disable lazy loading
+// set enabled to false to disable lazy loading
 export const lazyLoadConfig = {
   editor: {
     enabled: isDevelopment,

--- a/src/utils/lazyLoad.tsx
+++ b/src/utils/lazyLoad.tsx
@@ -1,0 +1,28 @@
+import React, { Suspense } from 'react';
+
+// Lazy loading wrapper component
+export const LazyLoad = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      {children}
+    </Suspense>
+  );
+};
+
+// Development mode check
+export const isDevelopment = process.env.NODE_ENV === 'development';
+console.log('Current NODE_ENV:', process.env.NODE_ENV);
+console.log('isDevelopment:', isDevelopment);
+
+// Lazy loading configuration
+//set enabled to false to disable lazy loading
+export const lazyLoadConfig = {
+  editor: {
+    enabled: isDevelopment,
+    fallback: () => <div>Editor is loading...</div>
+  },
+  groups: {
+    enabled: isDevelopment,
+    fallback: () => <div>Groups is loading...</div>
+  }
+}; 


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

I implemented lazy loading for heavy components for faster development speed. In the original src/README.md, it says:

"Delete pages/editor.tsx and pages/groups.tsx (or have them return an empty
component). These pages have a lot of dependencies that slow down webpack.

On my personal computer, I have hot reload times of ~1.5 seconds."

It seemed strange to be deleting files and altering the codebase, so I wrapped the editor.tsx and groups.tsx in lazy components to only load them when necessary. The page now has a hot reload of ~973 ms. The editor and groups components have an Largest Contentful Paint (LCP) score of ~0.91s, an Interaction to Next Paint (INP) of 129ms, and a CLS (Cumulative Layout Shift) score of 0. 
