### PR TITLE
fix: platinum sponsor logo not visible in dark mode

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -538,7 +538,7 @@ export default function IndexPage(): JSX.Element {
             Platinum Sponsors
           </p>
           <div className="my-8 grid grid-cols-2 items-center gap-0.5 text-gray-600 md:grid-cols-3 lg:my-6 lg:grid-cols-4 dark:text-gray-400">
-            <div className="col-span-1 invert-0 dark:invert">
+            <div className="col-span-1">
               <a
                 href="http://non-trivial.org/"
                 target="_blank"


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

The image was unnecessarily inverted for dark mode because the `<NonTrivial />` component already accounts for dark mode, making it the same color as the black background.