### PR TITLE
Fix typo in gold divisibility module

### DIFF
--- a/content/4_Gold/Divisibility.mdx
+++ b/content/4_Gold/Divisibility.mdx
@@ -556,8 +556,8 @@ $$
 $$
 
 Below is an implementation for factorization in $\mathcal{O}(\sqrt{n})$. It can be a little bit tricky to understand why we subtract $ans/p$ from $ans$. For example
-$ans=p_q \cdot x$ ,where $p$ is a prime factor and $x$ is the rest of the prime factorization. By subtracting $\frac{ans}{p}=p_{q-1} \cdot x$ we end up with:
-$p_q \cdot x - p_{q-1} \cdot x = p_{q-1} \cdot x \cdot (p - 1)$ which is exactly the form of $\phi(n)$ described a few linew above.
+$ans=p_q \cdot x$ ,where $p$ is a prime factor and $x$ is the rest of the prime factorization. By subtracting $\frac{ans}{p}=p^{q-1} \cdot x$ we end up with:
+$p^q \cdot x - p^{q-1} \cdot x = p^{q-1} \cdot x \cdot (p - 1)$ which is exactly the form of $\phi(n)$ described a few linew above.
 
 <LanguageSection>
 <CPPSection>

--- a/content/4_Gold/Divisibility.mdx
+++ b/content/4_Gold/Divisibility.mdx
@@ -556,7 +556,7 @@ $$
 $$
 
 Below is an implementation for factorization in $\mathcal{O}(\sqrt{n})$. It can be a little bit tricky to understand why we subtract $ans/p$ from $ans$. For example
-$ans=p_q \cdot x$ ,where $p$ is a prime factor and $x$ is the rest of the prime factorization. By subtracting $\frac{ans}{p}=p^{q-1} \cdot x$ we end up with:
+$ans=p^q \cdot x$ ,where $p$ is a prime factor and $x$ is the rest of the prime factorization. By subtracting $\frac{ans}{p}=p^{q-1} \cdot x$ we end up with:
 $p^q \cdot x - p^{q-1} \cdot x = p^{q-1} \cdot x \cdot (p - 1)$ which is exactly the form of $\phi(n)$ described a few linew above.
 
 <LanguageSection>


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.


Corrects a typo in the mathematical notation in phi function where an exponent was written as a subscript.

**Before:** `p_q`
**After:** `p^q`