### PR TITLE
Add explanation for CSES 2182 divisor product recurrence

### DIFF
--- a/solutions/gold/cses-2182.mdx
+++ b/solutions/gold/cses-2182.mdx
@@ -53,6 +53,48 @@ This is because $a^b \not \equiv a^{b \bmod p} \pmod{p}$ in general. However, by
 Fermat's little theorem, $a^b \equiv a^{b \bmod (p - 1)} \pmod{p}$ for prime
 $p$, so we can just store $C_i$ modulo $10^9 + 6$ to calculate $P_i$.
 
+<Spoiler title="How do we get this recurrence?">
+
+Clearly
+$$P_1 = x_1^0x_1^1x_1^2\dots x_1^{k_1} = x_1^\frac{k_1(k_1+1)}{2}$$
+since all $x_i$ are prime. Then for $P_2$, we have
+
+$$
+\begin{aligned}
+P_2 = & x_1^1\times x_1^2\times x_1^3\times\dots\times x_1^{k_1} \\
+\times & x_2 \times x_2x_1 \times x_2x_1^2\times\dots\times x_2x_1^{k_1} \\
+\times & x_2^2 \times x_2^2x_1 \times x_2^2x_1^2\times\dots\times x_2^2x_1^{k_1} \\
+\vdots & \\
+\times & x_2^{k_2} \times x_2^{k_2}x_1 \times x_2^{k_2}x_1^2\times\dots\times x_2^{k_2}x_1^{k_1} \\
+= & P_1 \\
+\times & P_1x_2^{k_1+1} \\
+\times & P_1\left(x_2^{k_1+1}\right)^2 \\
+\vdots & \\
+\times & P_1\left(x_2^{k_1+1}\right)^{k_2} \\
+= & P_1^{k_2+1}\left(x_2^{k_1+1}\right)^{k_2(k_2+1)/2} \\
+= & P_1^{k_2+1}\left(x_2^{k_2(k_2+1)/2}\right)^{k_1+1}\text{.}
+\end{aligned}
+$$
+
+To find $P_3$, we multiply each term we separated (each one we multiplied by $x_2^j$) by $x_3^j$.
+It is not hard to see that we will multiply $k_3+1$ copies of $P_3$, since $j$ goes from 0 to $k_3$.
+It is also not hard to see that we will multiply $x_3^j$ $(k_1+1)(k_2+1)$ times for all $j$, and that summing all $j$ will still be $k_3(k_3+1)/2$. Therefore we get
+
+$$
+P_3 = P_2^{k_3+1}\left(x_3^{(k_1+1)(k_2+1)}\right)^{k_3(k_3+1)/2}
+$$
+
+In general, to compute $P_i$, we will multiply $k_i+1$ copies of $P_{i-1}$.
+Notice that increasing $i$ increases the number of $x_i$ we multiply by a factor of $k_3+1$ (visualize adding a "dimension" to the "grid" we created for $P_2$).
+That is, the exponent of $x_i$ is $\prod_{j=1}^{i-1}(k_j+1)$, which is $C_{i-1}$
+Switching the exponents, we arrive at the desired relation of
+
+$$
+P_i = P_{i-1}^{k_i+1}\left(x_i^{k_i(k_i+1)/2}\right)^{C_{i-1}}
+$$
+
+</Spoiler>
+
 <LanguageSection>
 
 <CPPSection>


### PR DESCRIPTION
Add explanation for product of divisors recurrence on the internal solution for CSES problem 2182: Divisor Analysis.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
