### PR TITLE
Fix CSS Import Order Conflicts

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { DarkModeContext } from '../src/context/DarkModeContext';
-import '../src/styles/main.css';
 import './storybook.css';
 
 import { action } from 'storybook/actions';

--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -1,3 +1,8 @@
+import './src/styles/main.css';
+import 'tippy.js/animations/scale-subtle.css';
+import 'easymde/dist/easymde.min.css';
+import 'flatpickr/dist/themes/material_blue.css';
+
 // organize-imports-ignore
 // note that reordering the css file imports will break some styles
 import { wrapRootElement as wrap } from './root-wrapper';

--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -1,5 +1,8 @@
 import './src/styles/main.css';
 import 'tippy.js/animations/scale-subtle.css';
+import 'tippy.js/themes/light.css';
+import 'tippy.js/dist/tippy.css';
+import 'tippy.js/themes/material.css';
 import 'easymde/dist/easymde.min.css';
 import 'flatpickr/dist/themes/material_blue.css';
 

--- a/src/components/Groups/EditPostPage/EditPostPage.tsx
+++ b/src/components/Groups/EditPostPage/EditPostPage.tsx
@@ -1,5 +1,4 @@
 import { Timestamp } from 'firebase/firestore';
-import 'flatpickr/dist/themes/material_blue.css';
 import { Link, navigate } from 'gatsby';
 import * as React from 'react';
 import { useReducer } from 'react';

--- a/src/components/Groups/EditProblemPage/EditProblemPage.tsx
+++ b/src/components/Groups/EditProblemPage/EditProblemPage.tsx
@@ -8,7 +8,6 @@ import {
   query,
   Timestamp,
 } from 'firebase/firestore';
-import 'flatpickr/dist/themes/material_blue.css';
 import { Link, navigate } from 'gatsby';
 import * as React from 'react';
 import { useReducer } from 'react';

--- a/src/components/Groups/JoinLinksPage/EditJoinLinkModal.tsx
+++ b/src/components/Groups/JoinLinksPage/EditJoinLinkModal.tsx
@@ -1,6 +1,5 @@
 import { Transition } from '@headlessui/react';
 import { Timestamp } from 'firebase/firestore';
-import 'flatpickr/dist/themes/material_blue.css';
 import * as React from 'react';
 import Flatpickr from 'react-flatpickr';
 import { JoinGroupLink } from '../../../models/groups/groups';

--- a/src/components/Groups/MarkdownEditor.tsx
+++ b/src/components/Groups/MarkdownEditor.tsx
@@ -1,4 +1,3 @@
-import 'easymde/dist/easymde.min.css';
 import * as React from 'react';
 import SimpleMDE from 'react-simplemde-editor';
 import { useDarkMode } from '../../context/DarkModeContext';

--- a/src/components/Tooltip/Asterisk.tsx
+++ b/src/components/Tooltip/Asterisk.tsx
@@ -1,9 +1,6 @@
 // Heavily inspired by https://joshwcomeau.com/
 
 import * as React from 'react';
-import 'tippy.js/animations/scale-subtle.css';
-import 'tippy.js/dist/tippy.css';
-import 'tippy.js/themes/material.css';
 import Tooltip, { TooltipProps } from './Tooltip';
 
 const Asterisk: React.FC<Omit<TooltipProps, 'type'>> = ({

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -4,9 +4,6 @@ import Tippy, { TippyProps } from '@tippyjs/react';
 import clsx from 'clsx';
 import * as React from 'react';
 import { Placement } from 'tippy.js';
-import 'tippy.js/animations/scale-subtle.css';
-import 'tippy.js/dist/tippy.css';
-import 'tippy.js/themes/material.css';
 
 export interface TooltipProps extends Partial<Omit<TippyProps, 'placement'>> {
   position?: Placement;

--- a/src/components/markdown/ProblemsList/ProblemStatusCheckbox.tsx
+++ b/src/components/markdown/ProblemsList/ProblemStatusCheckbox.tsx
@@ -1,7 +1,6 @@
 import Tippy from '@tippyjs/react';
 import * as React from 'react';
 import { useContext, useRef, useState } from 'react';
-import 'tippy.js/themes/light.css';
 import ConfettiContext from '../../../context/ConfettiContext';
 import { useDarkMode } from '../../../context/DarkModeContext';
 import MarkdownLayoutContext from '../../../context/MarkdownLayoutContext';

--- a/src/components/markdown/ProblemsList/ProblemsList.tsx
+++ b/src/components/markdown/ProblemsList/ProblemsList.tsx
@@ -2,7 +2,6 @@ import { Transition } from '@headlessui/react';
 import { globalHistory } from '@reach/router';
 import * as React from 'react';
 import { Fragment } from 'react';
-import 'tippy.js/themes/light.css';
 import { useMarkdownProblemLists } from '../../../context/MarkdownProblemListsContext';
 import {
   useHideDifficultySetting,

--- a/src/components/markdown/ResourceStatusCheckbox.tsx
+++ b/src/components/markdown/ResourceStatusCheckbox.tsx
@@ -1,7 +1,6 @@
 import Tippy from '@tippyjs/react';
 import * as React from 'react';
 import { useContext, useRef, useState } from 'react';
-import 'tippy.js/themes/light.css';
 import ConfettiContext from '../../context/ConfettiContext';
 import { useDarkMode } from '../../context/DarkModeContext';
 import MarkdownLayoutContext from '../../context/MarkdownLayoutContext';


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

Preface: This is not necessarily an error, but just some code cleanup.

I noticed when running the `yarn dev` command that there would be repeated warning logs about conflicting CSS imports. This was because the global CSS imports were being imported in different components. I fixed this by moving all the global CSS imports to the `gatsby-browser.tsx` file and removing all the global CSS imports from any other files.