### PR TITLE
#fix 5722 Remove Balkan Olympiad in Informatics link from the Olympiads page

### DIFF
--- a/content/1_General/Olympiads.mdx
+++ b/content/1_General/Olympiads.mdx
@@ -131,7 +131,6 @@ Solutions from POI problems are unfortunately only available in Polish.
 
 - [Italy](https://training.olinfo.it/#/overview)
 - [International Informatics Olympiad in Teams](https://iio.team/)
-- [Balkan Olympiad in Informatics](https://boi2019.epy.gr/)
 - [InfO(1) Cup](http://info1cup.com/)
 
 ## Asia


### PR DESCRIPTION
This PR removes the outdated mention of the Balkan Olympiad in Informatics from the Olympiads page (content/1_General/Olympiads.mdx).
The competition is no longer active, so it should not appear under the current list of major (inter)national olympiads.

Changes Made
Removed the line referencing “Balkan Olympiad in Informatics” under Europe → Other.

Verified that the page builds and displays correctly after modification.

Fixes #5722

 Pull Request Checklist

I have verified that the issue (#5722) still exists on the current main branch.
I have updated the content file (content/1_General/Olympiads.mdx) accordingly.
I have confirmed that the documentation builds and renders without errors.
This change is content-only (no code modifications).
I have followed the contribution guidelines from [Contributing](https://usaco.guide/general/contributing?lang=cpp).

 I have linked this PR to the issue it closes (fixes #5722).