### PR TITLE
Fix dead Kattis links

### DIFF
--- a/content/6_Advanced/Eulers_Formula.problems.json
+++ b/content/6_Advanced/Eulers_Formula.problems.json
@@ -32,7 +32,7 @@
     {
       "uniqueId": "kattis-IslandArchipelago",
       "name": "Island Archipelago",
-      "url": "https://utipc20s.kattis.com/problems/utipc20s.islandarchipelago",
+      "url": "https://open.kattis.com/problems/islandarchipelago",
       "source": "Kattis",
       "difficulty": "Very Hard",
       "isStarred": false,

--- a/content/6_Advanced/LineContainer.problems.json
+++ b/content/6_Advanced/LineContainer.problems.json
@@ -33,7 +33,7 @@
     {
       "uniqueId": "kattis-MarshlandRescues",
       "name": "Marshland Rescues",
-      "url": "https://maps19.kattis.com/problems/marshlandrescues",
+      "url": "https://open.kattis.com/problems/marshlandrescues",
       "source": "Kattis",
       "difficulty": "Normal",
       "isStarred": false,


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [X] I have tested my code.
- [X] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [X] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [X] I have linked this PR to any issues that it closes.

In general, Kattis has moved away from being able to submit to finished contests. They are now available on open.kattis.com instead. When i grep:ed, I also found a link to https://cornell-hspc19.kattis.com/problems, which would then be replaced by https://open.kattis.com/problem-sources/Cornell%20University%20High%20School%20Programming%20Contest%202019. But it's commented out, so I decided to not change it.
