### PR TITLE
Remove redundant visited vector from gold milk pumping c++ solution

### DIFF
--- a/solutions/gold/usaco-969.mdx
+++ b/solutions/gold/usaco-969.mdx
@@ -90,7 +90,6 @@ int main() {
 	}
 	cout << ans << '\n';
 }
-
 ```
 
 </CPPSection>


### PR DESCRIPTION
In the previous c++ solution, we initialise a visited vector:

`vector<bool> visited(n, false);`

And while we do check the visited vector on line 24 & 33:

`if (nxt.second != cost[nxt.first] || visited[nxt.first]) { continue; }`

 `if (u.fl < minf || visited[u.v]) { continue; }`

We never change any of its entries, making it redundant. 
This PR removes the visited vector entirely whilst still having code that fully passes.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
