### PR TITLE
Fix minor bug in standard BCC code

### DIFF
--- a/content/6_Advanced/BCC_2CC.mdx
+++ b/content/6_Advanced/BCC_2CC.mdx
@@ -89,7 +89,7 @@ int main() {
 	}
 
 	for (int node = 0; node < n; node++) {
-		if (id[node] != 0) { dfs(node); }
+		if (id[node] == 0) { dfs(node); }
 	}
 
 	cout << scc << '\n';


### PR DESCRIPTION
Currently, this code checks that a node's preorder ID is not 0 before DFSing on it, but if it was not already visited, then its preorder ID should be 0. Before the change, no nodes are ever traversed. This change was tested on the [associated problem](https://judge.yosupo.jp/problem/two_edge_connected_components).

----

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
