### PR TITLE
Fix Sections Dropdown UI

### DIFF
--- a/src/components/SectionsDropdown.tsx
+++ b/src/components/SectionsDropdown.tsx
@@ -37,9 +37,10 @@ export default function SectionsDropdown({
             <MenuItems
               transition
               anchor="top start"
-              className={`absolute left-0 z-20 -ml-4 w-56 rounded-lg bg-white shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 ${
+              className={`absolute left-0 z-[100] -ml-4 w-56 rounded-lg bg-white shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-gray-800 ${
                 sidebarNav ? 'mt-2' : '-mt-2'
               } transition data-[closed]:translate-y-1 data-[closed]:opacity-0 data-[enter]:duration-200 data-[enter]:ease-out data-[leave]:duration-150 data-[leave]:ease-in`}
+              style={{ zIndex: 9999 }}
             >
               <div className="py-1">
                 {SECTIONS.map(section => {


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

The `MenuItems` component of the `SectionsDropdown.tsx` file was appearing behind the `SidebarNav` component whenever the window width was less than 50% of the screen width. I updated the `z-index` of the `MenuItems` component to fix this. 

Before: 
<img width="562" height="546" alt="image" src="https://github.com/user-attachments/assets/e1e67643-0957-4ce7-a338-c6cf30e0d350" />

After: 
<img width="344" height="337" alt="image" src="https://github.com/user-attachments/assets/57d15ce1-6020-4bc2-ba7f-fe3257109a34" />
