### PR TITLE
Remove goormIDE from online coding platforms list due to shutdown

### DIFF
--- a/content/1_General/Running_Code_Online.mdx
+++ b/content/1_General/Running_Code_Online.mdx
@@ -35,8 +35,6 @@ In all of C++, Python, Java. All of these options are free.
 - [repl.it](https://repl.it/)
   - Real-time collaboration.
   - Need to pay to create private repls.
-- [goormIDE](https://ide.goorm.io/)
-  - Real-time collaboration
 
 You can also share code with [pastebin](https://pastebin.com/) or
 [hastebin](https://hastebin.com/).


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x ] I have tested my code.
- [ x ] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [ x ] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [ x ] I have linked this PR to any issues that it closes.
The GroomIDE website talks about its shutdown in korean.

Here's it translated from korean
```
Notice
[Gureum IDE] Notice of Gureum IDE Termination (30 October)
23 September 2025
Notice of Gureum IDE Termination

Hello, this is the Gureum Customer Experience Team.
We sincerely thank all users who have utilised Gureum IDE over the years.
Gureum IDE will cease operations at 2:00 PM (KST) on Thursday, 30 October 2025.


23 September 2025 (Tuesday): Cloud IDE termination notice posted; new annual/monthly membership sign-ups suspended
30 September 2025 (Tuesday) 14:00 (KST): Paid credit top-ups suspended
30 October 2025 (Thursday) 14:00 (KST): Cloud IDE termination
```