### PR TITLE
Add link to solution metadata for Count_Min [Advanced]

### DIFF
--- a/content/6_Advanced/Count_Min.problems.json
+++ b/content/6_Advanced/Count_Min.problems.json
@@ -39,8 +39,8 @@
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
-        "kind": "link",
-        "url": "https://mbit.mbhs.edu/archive/2020/advanced_editorial.pdf"
+        "kind": "autogen-label-from-site",
+        "site": "CF"
       }
     },
     {


### PR DESCRIPTION
This [problem set](https://drive.google.com/file/d/10253azIZ_X-GTsEF1Ffy8W9W_QtySImZ/view) has available [solution](https://mbit.mbhs.edu/archive/2020/advanced_editorial.pdf).

Since the [permalink](https://usaco.guide/adv/count-min#problem-mbit-ZookeepersGathering) points to [this](https://codeforces.com/gym/102621/problem/L) empty looking page, there is slight confusion. 

Only the last problem is being referred here

I think we can update the question link too. Can you guide me on what to do ?