### PR TITLE
Update content/5_Plat/DC-DP.mdx

### DIFF
--- a/content/5_Plat/DC-DP.mdx
+++ b/content/5_Plat/DC-DP.mdx
@@ -33,8 +33,8 @@ $$
 where $C(i,j)$ is a cost function and you can compute it in $O(1)$ time.
 Furthermore, $dp(i,j) =0$ for $j<0$.
 
-The straightforward implementation gives a runtime of $O(MN^2)$ if $0\leq i <  M$ and $0\leq j < N$.
-Divide & Conquer DP allows this to be optimized to $O(M N \log N)$.
+The straightforward implementation gives a runtime of $O(mn^2)$ if $0\leq i <  m$ and $0\leq j < n$.
+Divide & Conquer DP allows this to be optimized to $O(mn \log n)$.
 
 For each $i,j$, let $\text{opt}(i,j)$ be the value of $k$ that minimizes the right hand side of the equation.
 Divide & Conquer DP **only applies if**
@@ -58,7 +58,7 @@ Similarly, we can compute $\text{opt}(i, 3n/4)$ and recursively split the ranges
 To begin analyzing the complexity of the Divide & Conquer, first note that there are $O(\log{n})$ levels in the recursion. We claim that $O(n)$ steps are being done at each level. Let the total length of the $\text{opt}$ intervals (denoted by $rl$ and $rr$ in the code) in the $k$th level be $S_k$, and observe that any time an interval from level $k$ of length $l$ is split, the resulting interval(s) have total length at most $l + 1$. Furthermore, at level $k$, at most $2^k$ splits are performed, so we have that $S_{k + 1} \leq S_k + 2^k$. Applying the bound inductively with $S_0 = n$ gives that for each level $k$,
 
 $$
-S_k < n + 2^k \in O(n)
+S_k < n + 2^k \in O(n).
 $$
 
 Thus, the complexity of each Divide & Conquer is $O(n\log{n})$, and the complexity of the entire DP computation is $O(mn\log{n})$.


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

**Explanation**:
The original analysis is incorrect because after fixing $i$, it is not necessarily true that each candidate value for $\text{opt}(i, j)$ only $\log{n}$ times. For example, consider the case when $\text{opt}(i, j) = x$ is constant wrt to $j$. Then, $x$ should be considered $n$ times.