### PR TITLE
fix: replace broken POI 2011 Tree Rotations problem link

### DIFF
--- a/content/5_Plat/Merging.problems.json
+++ b/content/5_Plat/Merging.problems.json
@@ -54,7 +54,7 @@
     {
       "uniqueId": "poi-11-TreeRotations",
       "name": "2011 - Tree Rotations",
-      "url": "https://oj.uz/problem/view/POI11_rot",
+      "url": "https://szkopul.edu.pl/problemset/problem/sUe3qzxBtasek-RAWmZaxY_p/site/?key=statement",
       "source": "POI",
       "difficulty": "Normal",
       "isStarred": false,


### PR DESCRIPTION
## Summary\n- replace the broken OJ.UZ link for `2011 - Tree Rotations` in the Merging module problem list\n- use the working Szkopuł statement URL suggested by a maintainer in the issue discussion

Closes #5115