### PR TITLE
Fix "medium" difficulty

### DIFF
--- a/content/5_Plat/Geo_Pri.problems.json
+++ b/content/5_Plat/Geo_Pri.problems.json
@@ -6,7 +6,7 @@
       "name": "Polygon Lattice Points",
       "url": "https://cses.fi/problemset/task/2193",
       "source": "CSES",
-      "difficulty": "Medium",
+      "difficulty": "Normal",
       "isStarred": false,
       "tags": ["Geometry"],
       "solutionMetadata": {
@@ -36,7 +36,7 @@
       "name": "Line Segment Intersection",
       "url": "https://cses.fi/problemset/task/2190",
       "source": "CSES",
-      "difficulty": "Medium",
+      "difficulty": "Normal",
       "isStarred": false,
       "tags": ["Geometry"],
       "solutionMetadata": {
@@ -51,7 +51,7 @@
       "name": "Polygon Area",
       "url": "https://cses.fi/problemset/task/2191",
       "source": "CSES",
-      "difficulty": "Medium",
+      "difficulty": "Normal",
       "isStarred": false,
       "tags": ["Geometry", "Math"],
       "solutionMetadata": {
@@ -66,7 +66,7 @@
       "name": "Point in Polygon",
       "url": "https://cses.fi/problemset/task/2192",
       "source": "CSES",
-      "difficulty": "Medium",
+      "difficulty": "Normal",
       "isStarred": false,
       "tags": ["Geometry", "Math"],
       "solutionMetadata": {

--- a/content/5_Plat/Sqrt.problems.json
+++ b/content/5_Plat/Sqrt.problems.json
@@ -5,8 +5,8 @@
       "uniqueId": "ndcp",
       "name": "Hop Sugoroku",
       "url": "https://atcoder.jp/contests/abc335/tasks/abc335_f",
-      "source": "Atcoder",
-      "difficulty": "Medium",
+      "source": "AC",
+      "difficulty": "Normal",
       "isStarred": false,
       "tags": ["Sqrt"],
       "solutionMetadata": {
@@ -51,7 +51,7 @@
       "name": "COT2 - Count on a tree II",
       "url": "https://www.spoj.com/problems/COT2/",
       "source": "SPOJ",
-      "difficulty": "Medium",
+      "difficulty": "Normal",
       "isStarred": false,
       "tags": ["Sqrt", "Mo's Algorithm", "Trees"],
       "solutionMetadata": {


### PR DESCRIPTION
Some problems are erroneously given "Medium" difficulty instead of "Normal". This pull request fixes that as well as a problem being labeled "Atcoder" instead of "AC" that also had the wrong difficulty.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
