### PR TITLE
fix(gold/hashing): warn that XOR Hashing example is hackable under mt19937 linearity

### DIFF
--- a/content/4_Gold/Hashing.mdx
+++ b/content/4_Gold/Hashing.mdx
@@ -435,7 +435,21 @@ Constraints for "Bull in a China Shop" are incorrect, should say $R,C\le 500$. A
 
 <Resources>
   <Resource source="CF" title="XOR Hashing" url="https://codeforces.com/blog/entry/85900"/>
+  <Resource source="CF" title="Hacking Incorrect XOR Hashing with mt19937_64" url="https://codeforces.com/blog/entry/153335"/>
 </Resources>
+
+<Warning>
+
+In contests with open hacking, seeding `mt19937` (or even `mt19937_64`) with a
+predictable value such as `chrono::steady_clock::now().time_since_epoch().count()`
+is unsafe for XOR hashing. Both generators are linear over $\mathbb{F}_2$, which
+lets an adversary construct inputs whose XOR sum is always $0$ regardless of the
+seed (see [this blog](https://codeforces.com/blog/entry/153335)). The
+implementation below works for non-adversarial inputs; for adversarial settings,
+mix the output through a non-linear function (for example `splitmix64`) before
+using it as a hash, and seed from `std::random_device`.
+
+</Warning>
 
 Hashing can also be used to check if sets of elements are equal. To do this, we first randomly generate a hash value for each unique element. Typically, the hash value is an integer in the range $[0, 2^{63}-1]$ since $2^{63}-1$ is the maximum value of a 64-bit signed integer. The hash of a set $S$ is the XOR sum of the hash values of all the elements in $S$. Since $x \oplus x = 0$ for all $x$, we can delete an element $s$ from set $S$ by applying the hash value of $s$ again on the hash. The probability of a collision of $N$ sets is approximately $\frac{N^2}{M}$, where $M$ is the maximum possible hash value.
 


### PR DESCRIPTION
Fixes #6156

The contact form report in #6156 points out that the XOR Hashing example uses `std::mt19937` (and seeds it with `chrono::steady_clock`), which is hackable in adversarial settings. The cited blog ([codeforces.com/blog/entry/153335](https://codeforces.com/blog/entry/153335)) walks through why this is a structural problem with the Mersenne Twister family — both `mt19937` and `mt19937_64` are linear over $\mathbb{F}_2$, so an adversary can pick coefficients that XOR an arbitrary subset of outputs to $0$ regardless of the seed.

## What this PR does

Adds a `<Warning>` block at the top of the **XOR Hashing/Zobrist Hashing** section in `content/4_Gold/Hashing.mdx` that:

1. Links the codeforces blog (also added to the `<Resources>` block alongside the existing entry 85900).
2. Notes that swapping `mt19937` for `mt19937_64` does **not** fix this — the linearity remains.
3. Points readers at the mitigation used in competitive programming circles: mix the output through a non-linear function (e.g. `splitmix64`) and seed from `std::random_device`.

The Warning matches the convention already used in this file for the polynomial-hash section (which links blog entry 60442 for the related "open-hacking" issue).

## What this PR does NOT do

I deliberately left the working example untouched. Rewriting the runnable code in splitmix64 would shift the teaching focus and isn't strictly what the report asked for; the Warning gives readers the right mental model without forcing a code rewrite they may not be ready for. Happy to follow up with a code change if you'd prefer that path.

## Testing

- `mdx` parses cleanly (matching the surrounding `<Warning>` blocks in the same file).
- No other files touched.