### PR TITLE
Groups User Progress Feature

### DIFF
--- a/src/components/Groups/MembersPage/MemberDetail.tsx
+++ b/src/components/Groups/MembersPage/MemberDetail.tsx
@@ -1,22 +1,22 @@
-import { useRouter } from 'next/router';
-import * as React from 'react';
 import type { CollectionReference } from 'firebase/firestore';
 import {
   collection,
+  DocumentData,
   getDocs,
   getFirestore,
   query,
-  DocumentData,
   where,
 } from 'firebase/firestore';
+import { useRouter } from 'next/router';
+import * as React from 'react';
 import toast from 'react-hot-toast';
 import { useFirebaseUser } from '../../../context/UserDataContext/UserDataContext';
 import getPermissionLevel from '../../../functions/src/groups/utils/getPermissionLevel';
 import { useActiveGroup } from '../../../hooks/groups/useActiveGroup';
-import { useFirebaseApp } from '../../../hooks/useFirebase';
 import { useGroupActions } from '../../../hooks/groups/useGroupActions';
 import { useUserLeaderboardData } from '../../../hooks/groups/useLeaderboardData';
 import { MemberInfo } from '../../../hooks/groups/useMemberInfoForGroup';
+import { useFirebaseApp } from '../../../hooks/useFirebase';
 import { PostData } from '../../../models/groups/posts';
 import {
   FirebaseSubmission,
@@ -90,15 +90,15 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
   const [problemNamesByPost, setProblemNamesByPost] = React.useState<
     Record<string, Record<string, string>>
   >({});
-  const [expandedProblemKey, setExpandedProblemKey] = React.useState<string | null>(
-    null
-  );
+  const [expandedProblemKey, setExpandedProblemKey] = React.useState<
+    string | null
+  >(null);
   const [submissionsByProblemKey, setSubmissionsByProblemKey] = React.useState<
     Record<string, FirebaseSubmission[]>
   >({});
-  const [loadingProblemKey, setLoadingProblemKey] = React.useState<string | null>(
-    null
-  );
+  const [loadingProblemKey, setLoadingProblemKey] = React.useState<
+    string | null
+  >(null);
   const showSubmissionAction = useProblemSubmissionPopupAction();
 
   const permissionLevel = getPermissionLevel(
@@ -130,7 +130,10 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
         const hasEarnedEntry =
           typeof leaderboardPostData === 'object' &&
           leaderboardPostData !== null &&
-          Object.prototype.hasOwnProperty.call(leaderboardPostData, problemId) &&
+          Object.prototype.hasOwnProperty.call(
+            leaderboardPostData,
+            problemId
+          ) &&
           typeof leaderboardPostData[problemId] === 'number';
         const earnedPoints =
           typeof leaderboardPostData?.[problemId] === 'number'
@@ -203,7 +206,10 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
   const toggleExpanded = (postId: string) => {
     setExpandedPosts(old => ({ ...old, [postId]: !old[postId] }));
   };
-  const toggleProblemSubmissions = async (postId: string, problemId: string) => {
+  const toggleProblemSubmissions = async (
+    postId: string,
+    problemId: string
+  ) => {
     const problemKey = `${postId}/${problemId}`;
     if (expandedProblemKey === problemKey) {
       setExpandedProblemKey(null);
@@ -237,7 +243,10 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
       const submissions = snap.docs
         .map(doc => ({ ...doc.data(), id: doc.id }) as FirebaseSubmission)
         .sort((a, b) => b.timestamp - a.timestamp);
-      setSubmissionsByProblemKey(old => ({ ...old, [problemKey]: submissions }));
+      setSubmissionsByProblemKey(old => ({
+        ...old,
+        [problemKey]: submissions,
+      }));
     } catch (error: unknown) {
       const message =
         (error as { message?: string })?.message ??
@@ -544,13 +553,17 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                               }`}
                               disabled={!problem.status}
                               onClick={() =>
-                                toggleProblemSubmissions(postId, problem.problemId)
+                                toggleProblemSubmissions(
+                                  postId,
+                                  problem.problemId
+                                )
                               }
                             >
                               <div>
                                 <p className="font-medium text-gray-900 dark:text-gray-100">
-                                  {problemNamesByPost[postId]?.[problem.problemId] ??
-                                    'Problem'}{' '}
+                                  {problemNamesByPost[postId]?.[
+                                    problem.problemId
+                                  ] ?? 'Problem'}{' '}
                                   ({problem.problemId})
                                 </p>
                                 <p className="text-xs text-gray-500 dark:text-gray-400">
@@ -574,15 +587,17 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                                 </span>
                               </div>
                             </button>
-                            {expandedProblemKey === `${postId}/${problem.problemId}` && (
+                            {expandedProblemKey ===
+                              `${postId}/${problem.problemId}` && (
                               <div className="mt-2 border-t border-gray-200 pt-2 dark:border-gray-700">
-                                {loadingProblemKey === `${postId}/${problem.problemId}` ? (
+                                {loadingProblemKey ===
+                                `${postId}/${problem.problemId}` ? (
                                   <p className="text-xs text-gray-500 dark:text-gray-400">
                                     Loading submissions...
                                   </p>
-                                ) : !(submissionsByProblemKey[
+                                ) : !submissionsByProblemKey[
                                     `${postId}/${problem.problemId}`
-                                  ]?.length) ? (
+                                  ]?.length ? (
                                   <p className="text-xs text-gray-500 dark:text-gray-400">
                                     No submissions found.
                                   </p>
@@ -607,13 +622,17 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                                               showSubmissionAction(submission)
                                             }
                                           >
-                                            {getSubmissionTimestampString(submission)}
+                                            {getSubmissionTimestampString(
+                                              submission
+                                            )}
                                           </button>
                                           <div className="flex items-center text-sm font-medium text-gray-500 dark:text-gray-300">
                                             <span
                                               className={`h-5 w-5 ${
                                                 submissionCircleBorderColor[
-                                                  getSubmissionStatus(submission)
+                                                  getSubmissionStatus(
+                                                    submission
+                                                  )
                                                 ]
                                               } flex items-center justify-center rounded-full`}
                                               aria-hidden="true"
@@ -621,7 +640,9 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                                               <span
                                                 className={`h-2.5 w-2.5 ${
                                                   submissionCircleColor[
-                                                    getSubmissionStatus(submission)
+                                                    getSubmissionStatus(
+                                                      submission
+                                                    )
                                                   ]
                                                 } rounded-full`}
                                               />
@@ -629,25 +650,31 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                                             <span
                                               className={`mr-4 ml-2 ${
                                                 submissionTextColor[
-                                                  getSubmissionStatus(submission)
+                                                  getSubmissionStatus(
+                                                    submission
+                                                  )
                                                 ]
                                               }`}
                                             >
-                                              {getSubmissionEarnedPoints(submission, {
-                                                id: problem.problemId,
-                                                postId,
-                                                name:
-                                                  problemNamesByPost[postId]?.[
-                                                    problem.problemId
-                                                  ] ?? 'Problem',
-                                                body: '',
-                                                source: '',
-                                                difficulty: '',
-                                                hints: [],
-                                                solution: null,
-                                                isDeleted: false,
-                                                points: problem.maxPoints,
-                                              })}{' '}
+                                              {getSubmissionEarnedPoints(
+                                                submission,
+                                                {
+                                                  id: problem.problemId,
+                                                  postId,
+                                                  name:
+                                                    problemNamesByPost[
+                                                      postId
+                                                    ]?.[problem.problemId] ??
+                                                    'Problem',
+                                                  body: '',
+                                                  source: '',
+                                                  difficulty: '',
+                                                  hints: [],
+                                                  solution: null,
+                                                  isDeleted: false,
+                                                  points: problem.maxPoints,
+                                                }
+                                              )}{' '}
                                               / {problem.maxPoints}
                                             </span>
                                           </div>

--- a/src/components/Groups/MembersPage/MemberDetail.tsx
+++ b/src/components/Groups/MembersPage/MemberDetail.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import * as React from 'react';
 import toast from 'react-hot-toast';
 import { useFirebaseUser } from '../../../context/UserDataContext/UserDataContext';
 import getPermissionLevel from '../../../functions/src/groups/utils/getPermissionLevel';
@@ -6,6 +7,50 @@ import { useActiveGroup } from '../../../hooks/groups/useActiveGroup';
 import { useGroupActions } from '../../../hooks/groups/useGroupActions';
 import { useUserLeaderboardData } from '../../../hooks/groups/useLeaderboardData';
 import { MemberInfo } from '../../../hooks/groups/useMemberInfoForGroup';
+import { PostData } from '../../../models/groups/posts';
+
+type AssignmentProgress = {
+  post: PostData & { type: 'assignment' };
+  earnedPoints: number;
+  totalPoints: number;
+  completedProblems: number;
+  totalProblems: number;
+  statusCounts: Record<string, number>;
+  problems: {
+    problemId: string;
+    earnedPoints: number;
+    maxPoints: number;
+    status: string | null;
+    updatedAt: number | null;
+  }[];
+};
+
+const statusColorMap: Record<string, string> = {
+  AC: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+  WA: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  TLE: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  MLE: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  RTE: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  CE: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  IE: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  Pending:
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200',
+};
+
+const progressBarColor = (ratio: number) => {
+  if (ratio >= 0.8) {
+    return 'bg-green-500';
+  }
+  if (ratio >= 0.5) {
+    return 'bg-yellow-500';
+  }
+  return 'bg-pink-500';
+};
+
+const formatTimestamp = (millis: number | null) => {
+  if (!millis) return 'No submission yet';
+  return new Date(millis).toLocaleString();
+};
 export default function MemberDetail({ member }: { member: MemberInfo }) {
   const activeGroup = useActiveGroup();
   const { removeMemberFromGroup, updateMemberPermissions } = useGroupActions();
@@ -15,6 +60,10 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
     member.uid
   );
   const router = useRouter();
+  const [sortMode, setSortMode] = React.useState<'due' | 'completion'>('due');
+  const [expandedPosts, setExpandedPosts] = React.useState<
+    Record<string, boolean>
+  >({});
 
   if (!member) {
     return (
@@ -27,6 +76,92 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
     member.uid,
     activeGroup.groupData!
   );
+  const assignmentProgress = React.useMemo<AssignmentProgress[]>(() => {
+    const assignmentPosts = activeGroup.posts.filter(
+      (post): post is PostData & { type: 'assignment' } =>
+        post.type === 'assignment' && !!post.id
+    );
+    return assignmentPosts.map(post => {
+      const leaderboardPostData = userLeaderboardData?.[post.id!];
+      const detailEntries = userLeaderboardData?.details?.[post.id!] ?? {};
+      const problemIds = post.problemOrdering ?? [];
+      const totalPoints = Object.values(post.pointsPerProblem ?? {}).reduce(
+        (acc, cur) => acc + cur,
+        0
+      );
+
+      const problems = problemIds.map(problemId => {
+        const earnedPoints =
+          typeof leaderboardPostData?.[problemId] === 'number'
+            ? leaderboardPostData[problemId]
+            : 0;
+        const maxPoints = post.pointsPerProblem?.[problemId] ?? 0;
+        const detail = detailEntries?.[problemId];
+        const updatedAt =
+          detail?.bestScoreTimestamp &&
+          typeof detail.bestScoreTimestamp.toMillis === 'function'
+            ? detail.bestScoreTimestamp.toMillis()
+            : null;
+        return {
+          problemId,
+          earnedPoints,
+          maxPoints,
+          status: detail?.bestScoreStatus ?? null,
+          updatedAt,
+        };
+      });
+
+      const earnedPoints = problems.reduce(
+        (acc, cur) => acc + cur.earnedPoints,
+        0
+      );
+      const completedProblems = problems.filter(
+        problem => problem.earnedPoints > 0 || !!problem.status
+      ).length;
+      const statusCounts = problems.reduce<Record<string, number>>(
+        (acc, cur) => {
+          if (cur.status) acc[cur.status] = (acc[cur.status] ?? 0) + 1;
+          return acc;
+        },
+        {}
+      );
+      return {
+        post,
+        earnedPoints,
+        totalPoints,
+        completedProblems,
+        totalProblems: problemIds.length,
+        statusCounts,
+        problems,
+      };
+    });
+  }, [activeGroup.posts, userLeaderboardData]);
+
+  const sortedAssignments = React.useMemo(() => {
+    const items = [...assignmentProgress];
+    if (sortMode === 'completion') {
+      items.sort((a, b) => {
+        const ratioA = a.totalProblems
+          ? a.completedProblems / a.totalProblems
+          : 0;
+        const ratioB = b.totalProblems
+          ? b.completedProblems / b.totalProblems
+          : 0;
+        return ratioB - ratioA;
+      });
+      return items;
+    }
+    items.sort((a, b) => {
+      const aDue = a.post.dueTimestamp?.toMillis?.() ?? Number.MAX_SAFE_INTEGER;
+      const bDue = b.post.dueTimestamp?.toMillis?.() ?? Number.MAX_SAFE_INTEGER;
+      return aDue - bDue;
+    });
+    return items;
+  }, [assignmentProgress, sortMode]);
+
+  const toggleExpanded = (postId: string) => {
+    setExpandedPosts(old => ({ ...old, [postId]: !old[postId] }));
+  };
 
   return (
     <article>
@@ -55,7 +190,9 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
               {member.displayName}
             </h1>
             <p className="text-sm font-medium text-gray-500 dark:text-gray-300">
-              {userLeaderboardData?.totalPoints ?? 0} Points Earned
+              {Math.trunc((userLeaderboardData?.totalPoints ?? 0) * 1000) /
+                1000}{' '}
+              Points Earned
             </p>
           </div>
         </div>
@@ -163,7 +300,154 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
           </div>
         )}
         <hr className="my-6 dark:border-gray-700" />
-        <p>Future feature: View user progress on all problems/assignments!</p>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+              Assignment Progress
+            </h2>
+            <div className="flex items-center gap-2">
+              <label
+                htmlFor="assignment-sort"
+                className="text-sm text-gray-600 dark:text-gray-300"
+              >
+                Sort by
+              </label>
+              <select
+                id="assignment-sort"
+                className="rounded-md border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-800"
+                value={sortMode}
+                onChange={e =>
+                  setSortMode(e.target.value as 'due' | 'completion')
+                }
+              >
+                <option value="due">Due date</option>
+                <option value="completion">Completion</option>
+              </select>
+            </div>
+          </div>
+          {sortedAssignments.length === 0 ? (
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              No assignments found for this group.
+            </p>
+          ) : (
+            sortedAssignments.map(assignment => {
+              const postId = assignment.post.id!;
+              const isExpanded = expandedPosts[postId] ?? false;
+              const completionRatio =
+                assignment.totalProblems === 0
+                  ? 0
+                  : assignment.completedProblems / assignment.totalProblems;
+              return (
+                <section
+                  key={postId}
+                  className="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+                >
+                  <button
+                    type="button"
+                    className="w-full px-4 py-3 text-left"
+                    onClick={() => toggleExpanded(postId)}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="font-medium text-gray-900 dark:text-gray-100">
+                          {assignment.post.name}
+                        </h3>
+                        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                          Due:{' '}
+                          {assignment.post.dueTimestamp
+                            ? assignment.post.dueTimestamp
+                                .toDate()
+                                .toLocaleString()
+                            : 'No due date'}{' '}
+                          • {assignment.completedProblems}/
+                          {assignment.totalProblems} problems attempted
+                        </p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                          {assignment.earnedPoints.toFixed(1)} /{' '}
+                          {assignment.totalPoints.toFixed(1)} pts
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {isExpanded ? 'Collapse' : 'Expand'}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="mt-3 h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+                      <div
+                        className={`h-2 rounded-full ${progressBarColor(completionRatio)}`}
+                        style={{
+                          width: `${Math.max(
+                            0,
+                            Math.min(100, completionRatio * 100)
+                          )}%`,
+                        }}
+                      />
+                    </div>
+                  </button>
+                  {isExpanded && (
+                    <div className="border-t border-gray-200 px-4 py-3 dark:border-gray-700">
+                      <div className="mb-3 flex flex-wrap gap-2">
+                        {Object.keys(assignment.statusCounts).length === 0 ? (
+                          <span className="text-xs text-gray-500 dark:text-gray-400">
+                            No submissions yet
+                          </span>
+                        ) : (
+                          Object.entries(assignment.statusCounts).map(
+                            ([status, count]) => (
+                              <span
+                                key={status}
+                                className={`rounded-full px-2 py-1 text-xs font-medium ${
+                                  statusColorMap[status] ??
+                                  'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200'
+                                }`}
+                              >
+                                {status}: {count}
+                              </span>
+                            )
+                          )
+                        )}
+                      </div>
+                      <ul className="space-y-2">
+                        {assignment.problems.map(problem => (
+                          <li
+                            key={problem.problemId}
+                            className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm dark:border-gray-700"
+                          >
+                            <div>
+                              <p className="font-medium text-gray-900 dark:text-gray-100">
+                                {problem.problemId}
+                              </p>
+                              <p className="text-xs text-gray-500 dark:text-gray-400">
+                                {formatTimestamp(problem.updatedAt)}
+                              </p>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <span className="text-gray-700 dark:text-gray-200">
+                                {problem.earnedPoints.toFixed(1)} /{' '}
+                                {problem.maxPoints.toFixed(1)} pts
+                              </span>
+                              <span
+                                className={`rounded-full px-2 py-1 text-xs font-medium ${
+                                  problem.status
+                                    ? (statusColorMap[problem.status] ??
+                                      'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200')
+                                    : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
+                                }`}
+                              >
+                                {problem.status ?? 'Not started'}
+                              </span>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </section>
+              );
+            })
+          )}
+        </div>
       </div>
     </article>
   );

--- a/src/components/Groups/MembersPage/MemberDetail.tsx
+++ b/src/components/Groups/MembersPage/MemberDetail.tsx
@@ -101,13 +101,6 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
   );
   const showSubmissionAction = useProblemSubmissionPopupAction();
 
-  if (!member) {
-    return (
-      <p className="mt-8 text-center text-xl">
-        This member has been removed from the group.
-      </p>
-    );
-  }
   const permissionLevel = getPermissionLevel(
     member.uid,
     activeGroup.groupData!

--- a/src/components/Groups/MembersPage/MemberDetail.tsx
+++ b/src/components/Groups/MembersPage/MemberDetail.tsx
@@ -225,26 +225,39 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
       return;
     }
     setLoadingProblemKey(problemKey);
-    const snap = await getDocs(
-      query(
-        collection(
-          getFirestore(firebaseApp),
-          'groups',
-          activeGroup.activeGroupId!,
-          'posts',
-          postId,
-          'problems',
-          problemId,
-          'submissions'
-        ) as CollectionReference<DocumentData>,
-        where('userID', '==', member.uid)
-      )
-    );
-    const submissions = snap.docs
-      .map(doc => ({ ...doc.data(), id: doc.id }) as FirebaseSubmission)
-      .sort((a, b) => b.timestamp - a.timestamp);
-    setSubmissionsByProblemKey(old => ({ ...old, [problemKey]: submissions }));
-    setLoadingProblemKey(null);
+    try {
+      const snap = await getDocs(
+        query(
+          collection(
+            getFirestore(firebaseApp),
+            'groups',
+            activeGroup.activeGroupId!,
+            'posts',
+            postId,
+            'problems',
+            problemId,
+            'submissions'
+          ) as CollectionReference<DocumentData>,
+          where('userID', '==', member.uid)
+        )
+      );
+      const submissions = snap.docs
+        .map(doc => ({ ...doc.data(), id: doc.id }) as FirebaseSubmission)
+        .sort((a, b) => b.timestamp - a.timestamp);
+      setSubmissionsByProblemKey(old => ({ ...old, [problemKey]: submissions }));
+    } catch (error: unknown) {
+      const message =
+        (error as { message?: string })?.message ??
+        'Unable to load submissions for this member.';
+      if (message.includes('permission-denied')) {
+        toast.error('You do not have permission to view these submissions.');
+      } else {
+        toast.error(message);
+      }
+      setExpandedProblemKey(null);
+    } finally {
+      setLoadingProblemKey(null);
+    }
   };
 
   React.useEffect(() => {

--- a/src/components/Groups/MembersPage/MemberDetail.tsx
+++ b/src/components/Groups/MembersPage/MemberDetail.tsx
@@ -6,6 +6,7 @@ import {
   getDocs,
   getFirestore,
   query,
+  DocumentData,
   where,
 } from 'firebase/firestore';
 import toast from 'react-hot-toast';
@@ -17,7 +18,17 @@ import { useGroupActions } from '../../../hooks/groups/useGroupActions';
 import { useUserLeaderboardData } from '../../../hooks/groups/useLeaderboardData';
 import { MemberInfo } from '../../../hooks/groups/useMemberInfoForGroup';
 import { PostData } from '../../../models/groups/posts';
-import { GroupProblemData } from '../../../models/groups/problem';
+import {
+  FirebaseSubmission,
+  getSubmissionEarnedPoints,
+  getSubmissionStatus,
+  getSubmissionTimestampString,
+  GroupProblemData,
+  submissionCircleBorderColor,
+  submissionCircleColor,
+  submissionTextColor,
+} from '../../../models/groups/problem';
+import { useProblemSubmissionPopupAction } from '../ProblemSubmissionPopup';
 
 type AssignmentProgress = {
   post: PostData & { type: 'assignment' };
@@ -79,6 +90,16 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
   const [problemNamesByPost, setProblemNamesByPost] = React.useState<
     Record<string, Record<string, string>>
   >({});
+  const [expandedProblemKey, setExpandedProblemKey] = React.useState<string | null>(
+    null
+  );
+  const [submissionsByProblemKey, setSubmissionsByProblemKey] = React.useState<
+    Record<string, FirebaseSubmission[]>
+  >({});
+  const [loadingProblemKey, setLoadingProblemKey] = React.useState<string | null>(
+    null
+  );
+  const showSubmissionAction = useProblemSubmissionPopupAction();
 
   if (!member) {
     return (
@@ -188,6 +209,42 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
 
   const toggleExpanded = (postId: string) => {
     setExpandedPosts(old => ({ ...old, [postId]: !old[postId] }));
+  };
+  const toggleProblemSubmissions = async (postId: string, problemId: string) => {
+    const problemKey = `${postId}/${problemId}`;
+    if (expandedProblemKey === problemKey) {
+      setExpandedProblemKey(null);
+      return;
+    }
+
+    setExpandedProblemKey(problemKey);
+    if (submissionsByProblemKey[problemKey]) {
+      return;
+    }
+    if (!firebaseApp || !activeGroup.activeGroupId) {
+      return;
+    }
+    setLoadingProblemKey(problemKey);
+    const snap = await getDocs(
+      query(
+        collection(
+          getFirestore(firebaseApp),
+          'groups',
+          activeGroup.activeGroupId!,
+          'posts',
+          postId,
+          'problems',
+          problemId,
+          'submissions'
+        ) as CollectionReference<DocumentData>,
+        where('userID', '==', member.uid)
+      )
+    );
+    const submissions = snap.docs
+      .map(doc => ({ ...doc.data(), id: doc.id }) as FirebaseSubmission)
+      .sort((a, b) => b.timestamp - a.timestamp);
+    setSubmissionsByProblemKey(old => ({ ...old, [problemKey]: submissions }));
+    setLoadingProblemKey(null);
   };
 
   React.useEffect(() => {
@@ -466,36 +523,135 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                       )}
                       <ul className="space-y-2">
                         {assignment.problems.map(problem => (
+                          // Clickable only when this user has started the problem.
+                          // This mirrors the submission-popup workflow used on Problem pages.
                           <li
                             key={problem.problemId}
-                            className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm dark:border-gray-700"
+                            className="rounded-md border border-gray-200 px-3 py-2 text-sm dark:border-gray-700"
                           >
-                            <div>
-                              <p className="font-medium text-gray-900 dark:text-gray-100">
-                                {problemNamesByPost[postId]?.[problem.problemId] ??
-                                  'Problem'}{' '}
-                                ({problem.problemId})
-                              </p>
-                              <p className="text-xs text-gray-500 dark:text-gray-400">
-                                {formatTimestamp(problem.updatedAt)}
-                              </p>
-                            </div>
-                            <div className="flex items-center gap-2">
-                              <span className="text-gray-700 dark:text-gray-200">
-                                {problem.earnedPoints.toFixed(1)} /{' '}
-                                {problem.maxPoints.toFixed(1)} pts
-                              </span>
-                              <span
-                                className={`rounded-full px-2 py-1 text-xs font-medium ${
-                                  problem.status
-                                    ? (statusColorMap[problem.status] ??
-                                      'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200')
-                                    : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
-                                }`}
-                              >
-                                {problem.status ?? 'Not started'}
-                              </span>
-                            </div>
+                            <button
+                              type="button"
+                              className={`flex w-full items-center justify-between text-left ${
+                                problem.status
+                                  ? 'cursor-pointer'
+                                  : 'cursor-not-allowed opacity-70'
+                              }`}
+                              disabled={!problem.status}
+                              onClick={() =>
+                                toggleProblemSubmissions(postId, problem.problemId)
+                              }
+                            >
+                              <div>
+                                <p className="font-medium text-gray-900 dark:text-gray-100">
+                                  {problemNamesByPost[postId]?.[problem.problemId] ??
+                                    'Problem'}{' '}
+                                  ({problem.problemId})
+                                </p>
+                                <p className="text-xs text-gray-500 dark:text-gray-400">
+                                  {formatTimestamp(problem.updatedAt)}
+                                </p>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <span className="text-gray-700 dark:text-gray-200">
+                                  {problem.earnedPoints.toFixed(1)} /{' '}
+                                  {problem.maxPoints.toFixed(1)} pts
+                                </span>
+                                <span
+                                  className={`rounded-full px-2 py-1 text-xs font-medium ${
+                                    problem.status
+                                      ? (statusColorMap[problem.status] ??
+                                        'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200')
+                                      : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
+                                  }`}
+                                >
+                                  {problem.status ?? 'Not started'}
+                                </span>
+                              </div>
+                            </button>
+                            {expandedProblemKey === `${postId}/${problem.problemId}` && (
+                              <div className="mt-2 border-t border-gray-200 pt-2 dark:border-gray-700">
+                                {loadingProblemKey === `${postId}/${problem.problemId}` ? (
+                                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                                    Loading submissions...
+                                  </p>
+                                ) : !(submissionsByProblemKey[
+                                    `${postId}/${problem.problemId}`
+                                  ]?.length) ? (
+                                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                                    No submissions found.
+                                  </p>
+                                ) : (
+                                  <ul>
+                                    {submissionsByProblemKey[
+                                      `${postId}/${problem.problemId}`
+                                    ].map(submission => (
+                                      <li
+                                        key={
+                                          'submissionID' in submission
+                                            ? submission.submissionID
+                                            : `${submission.timestamp}`
+                                        }
+                                        className="group relative py-2"
+                                      >
+                                        <div className="flex items-center justify-between space-x-4">
+                                          <button
+                                            type="button"
+                                            className="text-sm leading-3 font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+                                            onClick={() =>
+                                              showSubmissionAction(submission)
+                                            }
+                                          >
+                                            {getSubmissionTimestampString(submission)}
+                                          </button>
+                                          <div className="flex items-center text-sm font-medium text-gray-500 dark:text-gray-300">
+                                            <span
+                                              className={`h-5 w-5 ${
+                                                submissionCircleBorderColor[
+                                                  getSubmissionStatus(submission)
+                                                ]
+                                              } flex items-center justify-center rounded-full`}
+                                              aria-hidden="true"
+                                            >
+                                              <span
+                                                className={`h-2.5 w-2.5 ${
+                                                  submissionCircleColor[
+                                                    getSubmissionStatus(submission)
+                                                  ]
+                                                } rounded-full`}
+                                              />
+                                            </span>
+                                            <span
+                                              className={`mr-4 ml-2 ${
+                                                submissionTextColor[
+                                                  getSubmissionStatus(submission)
+                                                ]
+                                              }`}
+                                            >
+                                              {getSubmissionEarnedPoints(submission, {
+                                                id: problem.problemId,
+                                                postId,
+                                                name:
+                                                  problemNamesByPost[postId]?.[
+                                                    problem.problemId
+                                                  ] ?? 'Problem',
+                                                body: '',
+                                                source: '',
+                                                difficulty: '',
+                                                hints: [],
+                                                solution: null,
+                                                isDeleted: false,
+                                                points: problem.maxPoints,
+                                              })}{' '}
+                                              / {problem.maxPoints}
+                                            </span>
+                                          </div>
+                                        </div>
+                                      </li>
+                                    ))}
+                                  </ul>
+                                )}
+                              </div>
+                            )}
                           </li>
                         ))}
                       </ul>

--- a/src/components/Groups/MembersPage/MemberDetail.tsx
+++ b/src/components/Groups/MembersPage/MemberDetail.tsx
@@ -1,13 +1,23 @@
 import { useRouter } from 'next/router';
 import * as React from 'react';
+import type { CollectionReference } from 'firebase/firestore';
+import {
+  collection,
+  getDocs,
+  getFirestore,
+  query,
+  where,
+} from 'firebase/firestore';
 import toast from 'react-hot-toast';
 import { useFirebaseUser } from '../../../context/UserDataContext/UserDataContext';
 import getPermissionLevel from '../../../functions/src/groups/utils/getPermissionLevel';
 import { useActiveGroup } from '../../../hooks/groups/useActiveGroup';
+import { useFirebaseApp } from '../../../hooks/useFirebase';
 import { useGroupActions } from '../../../hooks/groups/useGroupActions';
 import { useUserLeaderboardData } from '../../../hooks/groups/useLeaderboardData';
 import { MemberInfo } from '../../../hooks/groups/useMemberInfoForGroup';
 import { PostData } from '../../../models/groups/posts';
+import { GroupProblemData } from '../../../models/groups/problem';
 
 type AssignmentProgress = {
   post: PostData & { type: 'assignment' };
@@ -22,6 +32,7 @@ type AssignmentProgress = {
     maxPoints: number;
     status: string | null;
     updatedAt: number | null;
+    hasSubmission: boolean;
   }[];
 };
 
@@ -48,10 +59,11 @@ const progressBarColor = (ratio: number) => {
 };
 
 const formatTimestamp = (millis: number | null) => {
-  if (!millis) return 'No submission yet';
+  if (!millis) return '-';
   return new Date(millis).toLocaleString();
 };
 export default function MemberDetail({ member }: { member: MemberInfo }) {
+  const firebaseApp = useFirebaseApp();
   const activeGroup = useActiveGroup();
   const { removeMemberFromGroup, updateMemberPermissions } = useGroupActions();
   const { uid: userId } = useFirebaseUser()!;
@@ -63,6 +75,9 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
   const [sortMode, setSortMode] = React.useState<'due' | 'completion'>('due');
   const [expandedPosts, setExpandedPosts] = React.useState<
     Record<string, boolean>
+  >({});
+  const [problemNamesByPost, setProblemNamesByPost] = React.useState<
+    Record<string, Record<string, string>>
   >({});
 
   if (!member) {
@@ -84,19 +99,30 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
     return assignmentPosts.map(post => {
       const leaderboardPostData = userLeaderboardData?.[post.id!];
       const detailEntries = userLeaderboardData?.details?.[post.id!] ?? {};
-      const problemIds = post.problemOrdering ?? [];
+      const problemIds = Array.from(
+        new Set([
+          ...(post.problemOrdering ?? []),
+          ...Object.keys(post.pointsPerProblem ?? {}),
+          ...Object.keys(detailEntries ?? {}),
+        ])
+      );
       const totalPoints = Object.values(post.pointsPerProblem ?? {}).reduce(
         (acc, cur) => acc + cur,
         0
       );
 
       const problems = problemIds.map(problemId => {
+        const detail = detailEntries?.[problemId];
+        const hasEarnedEntry =
+          typeof leaderboardPostData === 'object' &&
+          leaderboardPostData !== null &&
+          Object.prototype.hasOwnProperty.call(leaderboardPostData, problemId) &&
+          typeof leaderboardPostData[problemId] === 'number';
         const earnedPoints =
           typeof leaderboardPostData?.[problemId] === 'number'
             ? leaderboardPostData[problemId]
             : 0;
         const maxPoints = post.pointsPerProblem?.[problemId] ?? 0;
-        const detail = detailEntries?.[problemId];
         const updatedAt =
           detail?.bestScoreTimestamp &&
           typeof detail.bestScoreTimestamp.toMillis === 'function'
@@ -108,6 +134,7 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
           maxPoints,
           status: detail?.bestScoreStatus ?? null,
           updatedAt,
+          hasSubmission: !!detail || hasEarnedEntry,
         };
       });
 
@@ -116,7 +143,7 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
         0
       );
       const completedProblems = problems.filter(
-        problem => problem.earnedPoints > 0 || !!problem.status
+        problem => problem.hasSubmission
       ).length;
       const statusCounts = problems.reduce<Record<string, number>>(
         (acc, cur) => {
@@ -162,6 +189,39 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
   const toggleExpanded = (postId: string) => {
     setExpandedPosts(old => ({ ...old, [postId]: !old[postId] }));
   };
+
+  React.useEffect(() => {
+    if (!firebaseApp || !activeGroup.activeGroupId) return;
+    const expandedPostIds = Object.keys(expandedPosts).filter(
+      postId => expandedPosts[postId] && !problemNamesByPost[postId]
+    );
+    expandedPostIds.forEach(postId => {
+      getDocs(
+        query(
+          collection(
+            getFirestore(firebaseApp),
+            'groups',
+            activeGroup.activeGroupId!,
+            'posts',
+            postId,
+            'problems'
+          ) as CollectionReference<GroupProblemData>,
+          where('isDeleted', '==', false)
+        )
+      ).then(snap => {
+        const nameMap: Record<string, string> = {};
+        snap.docs.forEach(doc => {
+          nameMap[doc.id] = doc.data().name || 'Problem';
+        });
+        setProblemNamesByPost(old => ({ ...old, [postId]: nameMap }));
+      });
+    });
+  }, [
+    firebaseApp,
+    activeGroup.activeGroupId,
+    expandedPosts,
+    problemNamesByPost,
+  ]);
 
   return (
     <article>
@@ -350,7 +410,7 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <h3 className="font-medium text-gray-900 dark:text-gray-100">
-                          {assignment.post.name}
+                          {assignment.post.name} ({postId})
                         </h3>
                         <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
                           Due:{' '}
@@ -387,13 +447,9 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                   </button>
                   {isExpanded && (
                     <div className="border-t border-gray-200 px-4 py-3 dark:border-gray-700">
-                      <div className="mb-3 flex flex-wrap gap-2">
-                        {Object.keys(assignment.statusCounts).length === 0 ? (
-                          <span className="text-xs text-gray-500 dark:text-gray-400">
-                            No submissions yet
-                          </span>
-                        ) : (
-                          Object.entries(assignment.statusCounts).map(
+                      {Object.keys(assignment.statusCounts).length > 0 && (
+                        <div className="mb-3 flex flex-wrap gap-2">
+                          {Object.entries(assignment.statusCounts).map(
                             ([status, count]) => (
                               <span
                                 key={status}
@@ -405,9 +461,9 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                                 {status}: {count}
                               </span>
                             )
-                          )
-                        )}
-                      </div>
+                          )}
+                        </div>
+                      )}
                       <ul className="space-y-2">
                         {assignment.problems.map(problem => (
                           <li
@@ -416,7 +472,9 @@ export default function MemberDetail({ member }: { member: MemberInfo }) {
                           >
                             <div>
                               <p className="font-medium text-gray-900 dark:text-gray-100">
-                                {problem.problemId}
+                                {problemNamesByPost[postId]?.[problem.problemId] ??
+                                  'Problem'}{' '}
+                                ({problem.problemId})
                               </p>
                               <p className="text-xs text-gray-500 dark:text-gray-400">
                                 {formatTimestamp(problem.updatedAt)}

--- a/src/components/Groups/MembersPage/MembersPage.tsx
+++ b/src/components/Groups/MembersPage/MembersPage.tsx
@@ -144,7 +144,10 @@ export default function MembersPage(): JSX.Element {
                               {member.displayName}
                             </p>
                             <p className="truncate text-sm text-gray-500 dark:text-gray-300">
-                              {getTotalPointsForMember(member.uid)} Points
+                              {Math.trunc(
+                                getTotalPointsForMember(member.uid) * 1000
+                              ) / 1000}{' '}
+                              Points
                             </p>
                           </a>
                         </div>


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

Updated the UI at the `/groups/[id]/members` route to display students' assignment progress. Clicking on an item of the left sidebar indicating a certain student triggers the rendering of their assignment progress in the main display area. Clicking on an assignment will display the users' progress and submissions status on problems.

<img width="1916" height="938" alt="image" src="https://github.com/user-attachments/assets/00c8ad91-f4d2-4813-a7d1-ba365d175d2a" />

A student's assignments can be sorted in order of due date or completion. Clicking on a certain problem of an assignment that contains a submission allows users to see that student's submission for that problem.

<img width="1919" height="926" alt="image" src="https://github.com/user-attachments/assets/bdf510cd-f66a-483c-ace8-02436bb3a003" />