### PR TITLE
Fix no underline in warning component

### DIFF
--- a/src/components/markdown/HTMLComponents.tsx
+++ b/src/components/markdown/HTMLComponents.tsx
@@ -58,7 +58,6 @@ const inlineCode = (props): JSX.Element => (
 );
 const a = ({ children, ...props }) => (
   <a
-    className="no-underline"
     target={!props.href || props.href.startsWith('#') ? undefined : '_blank'}
     {...props}
   >

--- a/src/components/markdown/Warning.tsx
+++ b/src/components/markdown/Warning.tsx
@@ -31,7 +31,7 @@ const Warning: React.FC<WarningProps> = ({ children, title }) => (
         <div className="text-sm leading-5 font-medium text-yellow-800 dark:text-yellow-200">
           Warning{title ? ': ' + title : '!'}
         </div>
-        <div className="no-y-margin tailwind-alert tailwind-alert--warning mt-2 text-sm leading-5 text-yellow-700 dark:text-yellow-300">
+        <div className="no-y-margin tailwind-alert tailwind-alert--warning mt-2 text-sm leading-5 text-yellow-700 dark:text-yellow-300 [&_a]:underline">
           {children}
         </div>
       </div>

--- a/src/components/markdown/Warning.tsx
+++ b/src/components/markdown/Warning.tsx
@@ -31,7 +31,7 @@ const Warning: React.FC<WarningProps> = ({ children, title }) => (
         <div className="text-sm leading-5 font-medium text-yellow-800 dark:text-yellow-200">
           Warning{title ? ': ' + title : '!'}
         </div>
-        <div className="no-y-margin tailwind-alert tailwind-alert--warning mt-2 text-sm leading-5 text-yellow-700 dark:text-yellow-300 [&_a]:underline">
+        <div className="no-y-margin tailwind-alert tailwind-alert--warning mt-2 text-sm leading-5 text-yellow-700 dark:text-yellow-300">
           {children}
         </div>
       </div>

--- a/src/styles/generalStyles.css
+++ b/src/styles/generalStyles.css
@@ -76,7 +76,7 @@ html.transitioning-color-scheme * {
 }
 
 .markdown a {
-  @apply font-semibold text-blue-600 underline;
+  @apply font-semibold text-blue-600;
 }
 
 .dark .markdown a {
@@ -301,7 +301,7 @@ html.transitioning-color-scheme * {
 }
 
 .markdown .tailwind-alert--warning a {
-  @apply !text-yellow-700 dark:!text-yellow-300 !underline;
+  @apply !text-yellow-700 dark:!text-yellow-300;
 }
 .tailwind-alert--warning blockquote {
   @apply border-yellow-300 text-yellow-700 dark:border-yellow-500/50 dark:text-yellow-300;

--- a/src/styles/generalStyles.css
+++ b/src/styles/generalStyles.css
@@ -301,7 +301,7 @@ html.transitioning-color-scheme * {
 }
 
 .markdown .tailwind-alert--warning a {
-  @apply dark:text-yellow-200;
+  @apply !text-yellow-700 dark:!text-yellow-300 !underline;
 }
 .tailwind-alert--warning blockquote {
   @apply border-yellow-300 text-yellow-700 dark:border-yellow-500/50 dark:text-yellow-300;

--- a/src/styles/generalStyles.css
+++ b/src/styles/generalStyles.css
@@ -301,7 +301,7 @@ html.transitioning-color-scheme * {
 }
 
 .markdown .tailwind-alert--warning a {
-  @apply !text-yellow-700 dark:!text-yellow-300 !underline;
+  @apply !text-yellow-700 !underline dark:!text-yellow-300;
 }
 .tailwind-alert--warning blockquote {
   @apply border-yellow-300 text-yellow-700 dark:border-yellow-500/50 dark:text-yellow-300;


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [X] I have tested my code.
- [X] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [X] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [X] I have linked this PR to any issues that it closes.


Fixes #6169 

Simply restores underline for the warning component specifically. Let me know if there are any other components that need an override.