### PR TITLE
Update COCI-16 Burza documentation

### DIFF
--- a/solutions/gold/coci-16-burza.mdx
+++ b/solutions/gold/coci-16-burza.mdx
@@ -63,11 +63,14 @@ $$
 n_{r+1} \leq (k-r-1)^2 = (k-r)^2 - 2r + 2k - 1
 $$
 
-If we show this, we'll know that $n_r \leq (k-r)^2$ for *all* $r$.
-Setting $r=k$, we get $n_k \leq (k-k)^2=0$, which effectively means that it's possible
-for us to make all nodes invalid after $k$ moves.
+If we show this, we'll know that $n_r \leq (k-r)^2$ for $r\lt k$.
+Substituting $r = k - 1$, we get
+$$
+n_{k-1} \leq (k - (k - 1))^2 = 1
+$$
+This would guarantee that after $k-1$ moves, there is at most one valid node remaining for Stjepan to move to. Since Daniel would be the first to move on turn $k$, he would simply place his final mark on this single remaining node. Stjepan would then be left with zero valid adjacent nodes to step on, preventing his $k$-th move and securing Daniel's win.
 
-To prove this, let's first define a more concrete strategy:
+To prove the inductive step, let's first define a more concrete strategy:
 
 > At each level, cut off the node with the largest subtree size that hasn't been already
 > cut off. If there's multiple nodes with this quality, cut off any of them.


### PR DESCRIPTION
This pull request updates the explanation in the `solutions/gold/coci-16-burza.mdx` file to clarify the induction step in the proof and improve the logical flow. The changes focus on specifying the correct range for $r$, providing a clearer argument for the $r = k-1$ case, and explaining how this leads to Daniel's win.

Clarification and improvement of proof explanation:

* Clarified that $n_r \leq (k-r)^2$ holds for $r < k$ and replaced the $r=k$ case with the more relevant $r=k-1$ case, providing a step-by-step argument for why Daniel wins when only one node remains.
* Improved the induction step explanation by explicitly stating the strategy for the proof and refining the transition into the inductive step.

- [ ] I have tested my code.
- [X] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [X] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [ ] I have linked this PR to any issues that it closes.
