### PR TITLE
Fix LCA loop iterating over unsorted array in Virtual Tree template

### DIFF
--- a/content/5_Plat/VTree.mdx
+++ b/content/5_Plat/VTree.mdx
@@ -270,7 +270,7 @@ vector<int> vtree(const vector<int> &key) {
 	sort(res.begin(), res.end(), sort_tin);
 
 	for (int i = 1; i < (int)key.size(); i++) {
-		res.push_back(lca(key[i - 1], key[i]));
+		res.push_back(lca(res[i - 1], res[i]));
 	}
 
 	sort(res.begin(), res.end(), sort_tin);


### PR DESCRIPTION
PR Description:

Closes #6176

Description:
In the Platinum Virtual Tree module (content/5_Plat/VT.mdx), the vtree function correctly copies and sorts the input key vector into `res`. However, the subsequent loop to find the Lowest Common Ancestors (LCAs) of adjacent nodes incorrectly iterates over the original, **unsorted key array** instead of the **freshly sorted res array**.

Because Virtual Tree construction requires finding the LCA of adjacent nodes in DFS order, iterating over the unsorted array breaks the tree structure on **test cases where the input is not strictly ordered by tin**.

This PR changes the for loop to iterate over res instead of key.
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
