### PR TITLE
add obsidian-style image resizing

### DIFF
--- a/src/components/markdown/HTMLComponents.tsx
+++ b/src/components/markdown/HTMLComponents.tsx
@@ -123,9 +123,21 @@ const HTMLComponents = {
   pre,
   a,
   HeaderLink,
-  img: ({ src, alt, title }) => (
-    <MarkdownImage src={src} alt={alt} title={title} />
-  ),
+  img: ({ src, alt, title }) => {
+    const parts = (alt ?? '').split('|').map(s => s.trim());
+    const numericWidth = parts.find(p => /^\d+$/.test(p));
+    const centered = parts.includes('center');
+    const altText = parts.find(p => !/^\d+$/.test(p) && p !== 'center');
+    return (
+      <MarkdownImage
+        src={src}
+        alt={altText}
+        title={title}
+        width={numericWidth ? parseInt(numericWidth, 10) : undefined}
+        centered={centered}
+      />
+    );
+  },
 };
 
 export default HTMLComponents;

--- a/src/components/markdown/MarkdownImage.tsx
+++ b/src/components/markdown/MarkdownImage.tsx
@@ -24,7 +24,11 @@ export default function MarkdownImage({
         width: customWidth,
         height: 'auto',
         maxWidth: '100%',
-        ...(centered && { display: 'block', marginLeft: 'auto', marginRight: 'auto' }),
+        ...(centered && {
+          display: 'block',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+        }),
       }
     : { width: '100%', height: '100%' };
 

--- a/src/components/markdown/MarkdownImage.tsx
+++ b/src/components/markdown/MarkdownImage.tsx
@@ -5,23 +5,38 @@ export default function MarkdownImage({
   alt,
   title,
   style,
+  width: customWidth,
+  centered,
 }: {
   src: string;
   alt?: string;
   title?: string;
   style?: React.CSSProperties;
+  width?: number;
+  centered?: boolean;
 }) {
   const fallBackSvg = `data:image/svg+xml;base64,${Buffer.from(
     `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'/>`
   ).toString('base64')}`;
+
+  const imageStyle: React.CSSProperties = customWidth
+    ? {
+        width: customWidth,
+        height: 'auto',
+        maxWidth: '100%',
+        ...(centered && { display: 'block', marginLeft: 'auto', marginRight: 'auto' }),
+      }
+    : { width: '100%', height: '100%' };
+
   return (
     <ImageBase
       src={src}
-      alt={alt}
+      alt={alt ?? ''}
       title={title}
       width={0}
       height={0}
-      className="m-0 h-full w-full"
+      className="m-0"
+      style={imageStyle}
       sizes="(max-width: 768px) 100vw, 768px"
       placeholder="blur"
       blurDataURL={fallBackSvg}


### PR DESCRIPTION
DISCLAIMER: all code in this PR was generated by Claude. However, I have tested it by writing a solution that requires several images, it appears to work just fine.

Example usage:
`![500|center](/solutions/gold/joi-mergers/recursive.png)` for an image with width 500px and centered.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6216 
- <kbd>&nbsp;1&nbsp;</kbd> #6215 👈 
<!-- GitButler Footer Boundary Bottom -->

