### PR TITLE
Expand USACO FAQ

### DIFF
--- a/content/1_General/USACO_FAQs.mdx
+++ b/content/1_General/USACO_FAQs.mdx
@@ -254,18 +254,6 @@ You can probably find the answer at [usaco.org](http://www.usaco.org/index.php) 
 You can also ask a question by submitting the "Contact Us" form on the
 bottom-left of this page, or on the [USACO Forum](https://forum.usaco.guide/).
 
-## Q: Where can I find contest analyses?
-
-Official contest analyses are released after each USACO contest. You can access them from the USACO website by selecting a contest and viewing the analysis for each problem.
-
-The USACO Guide also provides explanations and editorials for many USACO problems through its modules and problem lists.
-
-## Q: Can I practice old USACO contests?
-
-Yes. Past USACO contests are publicly available on the USACO website and are one of the best ways to prepare for future contests.
-
-Many contestants simulate contest conditions by solving all three problems within the original contest time limit before reviewing solutions.
-
 ## Q: Where can I view my contest history and promotions?
 
 You can view your contest history, scores, current division, and promotion status by logging into your USACO account.

--- a/content/1_General/USACO_FAQs.mdx
+++ b/content/1_General/USACO_FAQs.mdx
@@ -235,15 +235,18 @@ Again, CF problems and contests are _significantly different_ from USACO!
 Collaborating with others during the contest is strictly prohibited to maintain fairness and integrity. USACO contests are designed to assess individual problem-solving skills, and collaboration provides an unfair advantage. However, outside of the contest environment, students are encouraged to study and prepare together, sharing knowledge and techniques to improve their skills collectively.
 
 ## Q: What are the constraints on memory and time for C++, Python, and Java programs?
-In USACO contests, programs written in various programming languages are subject to specific constraints to ensure fair and efficient competition. These constraints include both time limits and memory allocations, which vary slightly depending on the language used.
-Time Constraints: Each input test case is allotted a specific time limit for program execution. This time limit typically ranges around 4 seconds, although it can vary depending on the complexity of the problem and the specific contest. Within this time frame, the program must complete its execution and produce the correct output. Exceeding the time limit results in the program being terminated, leading to a verdict of "Time Limit Exceeded".
 
+In USACO contests, programs written in various programming languages are subject to specific constraints to ensure fair and efficient competition. These constraints include both time limits and memory allocations, which vary slightly depending on the language used.
+
+- Time Constraints: Each input test case is allotted a specific time limit for program execution. This time limit typically ranges around 4 seconds, although it can vary depending on the complexity of the problem and the specific contest. Within this time frame, the program must complete its execution and produce the correct output. Exceeding the time limit results in the program being terminated, leading to a verdict of "Time Limit Exceeded".
 - Memory Constraints: Programs are allocated a certain amount of memory for their execution. The allocated memory is used to store variables, data structures, and other program-related information during execution. It's essential for participants to manage memory efficiently to avoid exceeding the allocated memory limit, which would lead to a "Memory Limit Exceeded" verdict.
+
 Here's a table summarizing the constraints for different programming languages in USACO contests:
+
 | Programming Language | Time Limit   | Memory Allocation |
 |----------------------|--------------|-------------------|
-| Java                 | Around 4 sec | Around 256 MB    |
 | C++                  | Around 2 sec | Around 256 MB    |
+| Java                 | Around 4 sec | Around 256 MB    |
 | Python               | Around 4 sec | Around 256 MB    |
 
 

--- a/content/1_General/USACO_FAQs.mdx
+++ b/content/1_General/USACO_FAQs.mdx
@@ -256,7 +256,8 @@ bottom-left of this page, or on the [USACO Forum](https://forum.usaco.guide/).
 
 ## Q: Where can I view my contest history and promotions?
 
-You can view your contest history, scores, current division, and promotion status by logging into your USACO account.
+You can view your past contest scores and current division by logging into your
+USACO account.
 
 After each contest, USACO also publishes official results and promotion
 cutoffs. Public rankings may not be available for every division or contest.

--- a/content/1_General/USACO_FAQs.mdx
+++ b/content/1_General/USACO_FAQs.mdx
@@ -254,6 +254,24 @@ You can probably find the answer at [usaco.org](http://www.usaco.org/index.php) 
 You can also ask a question by submitting the "Contact Us" form on the
 bottom-left of this page, or on the [USACO Forum](https://forum.usaco.guide/).
 
+## Q: Where can I find contest analyses?
+
+Official contest analyses are released after each USACO contest. You can access them from the USACO website by selecting a contest and viewing the analysis for each problem.
+
+The USACO Guide also provides explanations and editorials for many USACO problems through its modules and problem lists.
+
+## Q: Can I practice old USACO contests?
+
+Yes. Past USACO contests are publicly available on the USACO website and are one of the best ways to prepare for future contests.
+
+Many contestants simulate contest conditions by solving all three problems within the original contest time limit before reviewing solutions.
+
+## Q: Where can I view my contest history and promotions?
+
+You can view your contest history, scores, current division, and promotion status by logging into your USACO account.
+
+After each contest, USACO also publishes official results, promotion cutoffs, and rankings.
+
 ## Closing Thoughts
 
 We hope you've found this FAQ useful! Best of luck on your competitive

--- a/content/1_General/USACO_FAQs.mdx
+++ b/content/1_General/USACO_FAQs.mdx
@@ -270,7 +270,8 @@ Many contestants simulate contest conditions by solving all three problems withi
 
 You can view your contest history, scores, current division, and promotion status by logging into your USACO account.
 
-After each contest, USACO also publishes official results, promotion cutoffs, and rankings.
+After each contest, USACO also publishes official results and promotion
+cutoffs. Public rankings may not be available for every division or contest.
 
 ## Closing Thoughts
 

--- a/content/1_General/USACO_FAQs.mdx
+++ b/content/1_General/USACO_FAQs.mdx
@@ -247,13 +247,6 @@ Here's a table summarizing the constraints for different programming languages i
 | Python               | Around 4 sec | Around 256 MB    |
 
 
-## Q: Where can I find the answer to a question that isn't answered here?
-
-You can probably find the answer at [usaco.org](http://www.usaco.org/index.php) or by googling.
-
-You can also ask a question by submitting the "Contact Us" form on the
-bottom-left of this page, or on the [USACO Forum](https://forum.usaco.guide/).
-
 ## Q: Where can I view my contest history and promotions?
 
 You can view your past contest scores and current division by logging into your
@@ -261,6 +254,13 @@ USACO account.
 
 After each contest, USACO also publishes official results and promotion
 cutoffs. Public rankings may not be available for every division or contest.
+
+## Q: Where can I find the answer to a question that isn't answered here?
+
+You can probably find the answer at [usaco.org](http://www.usaco.org/index.php) or by googling.
+
+You can also ask a question by submitting the "Contact Us" form on the
+bottom-left of this page, or on the [USACO Forum](https://forum.usaco.guide/).
 
 ## Closing Thoughts
 


### PR DESCRIPTION
* [x] I have tested my code.
* [ ] I have added my solution according to the steps [[here](https://usaco.guide/general/adding-solution#steps)](https://usaco.guide/general/adding-solution#steps).
* [ ] I have followed the code conventions mentioned [[here](https://usaco.guide/general/adding-solution/#code-conventions)](https://usaco.guide/general/adding-solution/#code-conventions).

  * I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  * If changes are requested, I will re-request a review after addressing them.
* [x] I have linked this PR to any issues that it closes.

## Summary

This PR expands the USACO FAQ by adding a beginner-focused question about viewing contest history, scores, division status, and promotions.

## Changes

* Added a FAQ entry explaining where users can view their contest history, scores, current division, and promotion status.
* Clarified that some public ranking information may not be available for all divisions or contest years.

## Why

Issue #3384 mentions that there are common questions covered by other USACO-related FAQ pages that are not currently answered in the USACO Guide FAQ. This addition addresses a question that was not already covered elsewhere in the FAQ and may be useful for newer contestants.

## Testing

* Verified the FAQ page renders correctly locally.
* Confirmed the new FAQ entry appears in the page content.
* Ran formatting checks on `content/1_General/USACO_FAQs.mdx`.
* Confirmed no other files were modified.

Closes #3384

Closes #6247