### PR TITLE
Tag Friendly Spiders as Bipartite

### DIFF
--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -277,7 +277,13 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Number Theory", "Graphs", "BFS", "Shortest Path"],
+      "tags": [
+        "Number Theory",
+        "Graphs",
+        "BFS",
+        "Shortest Path",
+        "Bipartite"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -277,13 +277,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": [
-        "Number Theory",
-        "Graphs",
-        "BFS",
-        "Shortest Path",
-        "Bipartite"
-      ],
+      "tags": ["Number Theory", "Graphs", "BFS", "Shortest Path", "Bipartite"],
       "solutionMetadata": {
         "kind": "internal"
       }


### PR DESCRIPTION
An alternate solution using bipartite is introduced in #5969, this is good practice for bipartite so tagged as so.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
