### PR TITLE
Implement mixed problem sets for bronze

### DIFF
--- a/content/2_Bronze/Ad_Hoc.mdx
+++ b/content/2_Bronze/Ad_Hoc.mdx
@@ -127,7 +127,7 @@ print(res)
 
 ## Problems
 
-<Problems problems="general" />
+<Problems problems="general" progressionSet />
 
 ## Quiz
 
@@ -154,3 +154,5 @@ print(res)
     </Quiz.Answer>
   </Quiz.Question>
 </Quiz>
+
+<ReviewProblems />

--- a/content/2_Bronze/Ad_Hoc.problems.json
+++ b/content/2_Bronze/Ad_Hoc.problems.json
@@ -80,5 +80,131 @@
         "hasHints": false
       }
     }
+  ],
+  "review": [
+    {
+      "uniqueId": "usaco-663",
+      "name": "Square Pasture",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=663",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Rectangle"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-916",
+      "name": "The Great Revegetation",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=916",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Coloring"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-831",
+      "name": "Team Tic Tac Toe",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=831",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1013",
+      "name": "Swapity Swap",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1013",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Permutation", "Cycle"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-856",
+      "name": "The Bucket List",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=856",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1324",
+      "name": "Moo Language",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1324",
+      "source": "Bronze",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-857",
+      "name": "Back and Forth",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=857",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Complete Search", "Recursion"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "cf-1808B",
+      "name": "Playing in a Casino",
+      "url": "https://codeforces.com/contest/1808/problem/B",
+      "source": "CF",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Sorting"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-1555B",
+      "name": "B. Two Tables",
+      "url": "https://codeforces.com/problemset/problem/1555/B",
+      "source": "CF",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Rectangle"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-832",
+      "name": "Milking Order",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=832",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Greedy"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Casework.mdx
+++ b/content/2_Bronze/Casework.mdx
@@ -156,4 +156,6 @@ print(f"{minimum}\n{maximum}", file=open("herding.out", "w"))
 
 ## Problems
 
-<Problems problems="casework" />
+<Problems problems="casework" progressionSet />
+
+<ReviewProblems />

--- a/content/2_Bronze/Casework.problems.json
+++ b/content/2_Bronze/Casework.problems.json
@@ -77,5 +77,68 @@
         "usacoId": "1275"
       }
     }
+  ],
+  "review": [
+    {
+      "uniqueId": "usaco-667",
+      "name": "Cities & States",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=667",
+      "source": "Silver",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Map"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1011",
+      "name": "Triangles",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1011",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-760",
+      "name": "The Bovine Shuffle",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=760",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-1209G1",
+      "name": "Into Blocks",
+      "url": "https://codeforces.com/contest/1209/problem/G1",
+      "source": "CF",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Set", "Map"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1493",
+      "name": "Printing Sequences",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1493",
+      "source": "Bronze",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "USACO",
+        "usacoId": "1493"
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Complete_Rec.mdx
+++ b/content/2_Bronze/Complete_Rec.mdx
@@ -1098,7 +1098,7 @@ print(valid_num)
 
 ## Problems
 
-<Problems problems="gen" />
+<Problems problems="gen" progressionSet />
 
 You can find more problems at the CP2 link given above or at
 [USACO Training](https://train.usaco.org/). However, these sorts of problems
@@ -1326,3 +1326,5 @@ appear much less frequently than they once did.
     </CPPSection>
 
  </LanguageSection>
+
+<ReviewProblems />

--- a/content/2_Bronze/Complete_Rec.problems.json
+++ b/content/2_Bronze/Complete_Rec.problems.json
@@ -132,5 +132,55 @@
         "usacoId": "1493"
       }
     }
+  ],
+  "review": [
+    {
+      "uniqueId": "usaco-917",
+      "name": "Measuring Traffic",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=917",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1228",
+      "name": "Counting Liars",
+      "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1228",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Complete Search", "Sorting"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-593",
+      "name": "Mowing the Field",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=593",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-619",
+      "name": "Load Balancing",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=619",
+      "source": "Silver",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Conclusion.mdx
+++ b/content/2_Bronze/Conclusion.mdx
@@ -14,16 +14,9 @@ potentially from a higher division, will show up in future Bronze
 contests.</Asterisk> In order to maximize your chance at promoting, you should
 aim to **practice** by doing more problems.
 
-## Uncategorized Problems
+<AdditionalProblemsDescription />
 
-Below we list some problems that we think are roughly Bronze level but don't
-really fit in previous modules.<Asterisk>either because there were too many
-problems already, or because the problem requires more than one
-concept</Asterisk> The difficulties listed here are relative to the Bronze
-division (difficulty is subjective and isn't always accurate though). We'll be
-expanding this list as we get more problem suggestions.
-
-<Problems problems="problems" />
+<Problems problems="problems" progression="mixed" />
 
 ## Final Thoughts
 

--- a/content/2_Bronze/Conclusion.problems.json
+++ b/content/2_Bronze/Conclusion.problems.json
@@ -159,5 +159,303 @@
         "kind": "internal"
       }
     }
+  ],
+  "mixed": [
+    {
+      "uniqueId": "cf-1873G",
+      "name": "ABBC or BACB",
+      "url": "https://codeforces.com/problemset/problem/1873/G",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Ad Hoc"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-1624D",
+      "name": "Palindromes Coloring",
+      "url": "https://codeforces.com/problemset/problem/1624/D",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Greedy"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cses-3399",
+      "name": "Raab Game I",
+      "url": "https://cses.fi/problemset/task/3399",
+      "source": "CSES",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Ad Hoc", "Greedy"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-1468",
+      "name": "It's Mooin' Time II",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1468",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Map", "Set"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cfgym-104417G",
+      "name": "Matching",
+      "url": "https://codeforces.com/gym/104417/problem/G",
+      "source": "CF",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": [],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-358C",
+      "name": "Dima and Containers",
+      "url": "https://codeforces.com/problemset/problem/358/C",
+      "source": "CF",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-642",
+      "name": "Field Reduction",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=642",
+      "source": "Silver",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Geometry"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-1914C",
+      "name": "Quests",
+      "url": "https://codeforces.com/problemset/problem/1914/C",
+      "source": "CF",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-689",
+      "name": "Cow Tipping",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=689",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Greedy"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1088",
+      "name": "Spaced Out",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1088",
+      "source": "Silver",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Greedy"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": false
+      }
+    },
+    {
+      "uniqueId": "usaco-893",
+      "name": "Guess the Animal",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=893",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-1216C",
+      "name": "D3C - White Sheet",
+      "url": "https://codeforces.com/contest/1216/problem/C",
+      "source": "CF",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Rectangle"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-591",
+      "name": "Promotion Counting",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=591",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": [],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-1772D",
+      "name": "Absolute Sorting",
+      "url": "https://codeforces.com/contest/1772/problem/D",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Complete Search", "Greedy"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-808",
+      "name": "Hoofball",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=808",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Functional Graph"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "cses-2431",
+      "name": "Digit Queries",
+      "url": "https://cses.fi/problemset/task/2431/",
+      "source": "CSES",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": [],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-509",
+      "name": "It's All About the Base",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=509",
+      "source": "Old Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": [],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-892",
+      "name": "Sleepy Cow Sorting",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=892",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": [],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-1275",
+      "name": "Leaders",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1275",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Casework"],
+      "solutionMetadata": {
+        "kind": "USACO",
+        "usacoId": "1275"
+      }
+    },
+    {
+      "uniqueId": "usaco-809",
+      "name": "Taming the Herd",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=809",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": [],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-737",
+      "name": "Modern Art",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=737",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": [],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-1181",
+      "name": "Drought",
+      "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1181",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Greedy"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-1846D",
+      "name": "Rudolph and Christmas Tree",
+      "url": "https://codeforces.com/contest/1846/problem/D",
+      "source": "CF",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Geometry"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "dmoj-spirale",
+      "name": "Spirale",
+      "url": "https://dmoj.ca/problem/coci17c5p2",
+      "source": "COCI",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Intro_Complete.mdx
+++ b/content/2_Bronze/Intro_Complete.mdx
@@ -298,4 +298,6 @@ should stick with integers whenever possible.
 
 ## Problems
 
-<Problems problems="probs" hideSuggestProblemButton />
+<Problems problems="probs" progressionSet hideSuggestProblemButton />
+
+<ReviewProblems />

--- a/content/2_Bronze/Intro_Complete.problems.json
+++ b/content/2_Bronze/Intro_Complete.problems.json
@@ -244,5 +244,31 @@
         "kind": "internal"
       }
     }
+  ],
+  "review": [
+    {
+      "uniqueId": "usaco-1491",
+      "name": "Reflection",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1491",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-761",
+      "name": "Milk Measurement",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=761",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Intro_Graphs.mdx
+++ b/content/2_Bronze/Intro_Graphs.mdx
@@ -614,4 +614,6 @@ with open("lineup.out", "w") as out:
 
 # Problems
 
-<Problems problems="general" />
+<Problems problems="general" progressionSet />
+
+<ReviewProblems />

--- a/content/2_Bronze/Intro_Graphs.problems.json
+++ b/content/2_Bronze/Intro_Graphs.problems.json
@@ -92,5 +92,116 @@
         "kind": "internal"
       }
     }
+  ],
+  "review": [
+    {
+      "uniqueId": "usaco-569",
+      "name": "Contaminated Milk",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=569",
+      "source": "Bronze",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1515",
+      "name": "Hoof Paper Scissors Minus One",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1515",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Casework"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1084",
+      "name": "Even More Odd Photos",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1084",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Greedy"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-1107",
+      "name": "Year of the Cow",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1107",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Map"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-526",
+      "name": "Censoring",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=526",
+      "source": "Old Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "ac-MadeUp",
+      "name": "Made Up",
+      "url": "https://atcoder.jp/contests/abc202/tasks/abc202_c?lang=en",
+      "source": "AC",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Map"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1301",
+      "name": "Watching Mooloo",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1301",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Greedy"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-104520H",
+      "name": "Permutator",
+      "url": "https://codeforces.com/gym/104520/problem/H",
+      "source": "CF",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Greedy", "Sorting"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cses-3175",
+      "name": "Beautiful Permutation II",
+      "url": "https://cses.fi/problemset/task/3175",
+      "source": "CSES",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Complete Search", "Permutation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Intro_Greedy.mdx
+++ b/content/2_Bronze/Intro_Greedy.mdx
@@ -177,7 +177,7 @@ Competitive programmers refer to this as "Proof by AC," or "Proof by Accepted."
 
 ## Problems
 
-<Problems problems="general" />
+<Problems problems="general" progressionSet />
 
 ## Quiz
 
@@ -240,3 +240,5 @@ Competitive programmers refer to this as "Proof by AC," or "Proof by Accepted."
     </Quiz.Answer>
   </Quiz.Question>
 </Quiz>
+
+<ReviewProblems />

--- a/content/2_Bronze/Intro_Greedy.problems.json
+++ b/content/2_Bronze/Intro_Greedy.problems.json
@@ -129,5 +129,79 @@
         "hasHints": true
       }
     }
+  ],
+  "review": [
+    {
+      "uniqueId": "usaco-1035",
+      "name": "Social Distancing I",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1035",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Casework"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-665",
+      "name": "The Cow-Signal",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=665",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1251",
+      "name": "Cow College",
+      "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1251",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Sorting"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-713",
+      "name": "Why Did the Cow Cross the Road III",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=713",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Sorting", "Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cses-1640",
+      "name": "Sum of Two Values",
+      "url": "https://cses.fi/problemset/task/1640",
+      "source": "CSES",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Map"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1060",
+      "name": "Daisy Chains",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1060",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Intro_Sets.mdx
+++ b/content/2_Bronze/Intro_Sets.mdx
@@ -1034,7 +1034,7 @@ for _ in range(int(input())):
 Some of these problems can be solved by sorting alone, though sets or maps could
 make their implementation easier.
 
-<Problems problems="standard" />
+<Problems problems="standard" progressionSet />
 
 # Quiz
 
@@ -1693,3 +1693,5 @@ make their implementation easier.
 </Quiz>
 </PySection>
 </LanguageSection>
+
+<ReviewProblems />

--- a/content/2_Bronze/Intro_Sets.problems.json
+++ b/content/2_Bronze/Intro_Sets.problems.json
@@ -163,5 +163,43 @@
         "kind": "internal"
       }
     }
+  ],
+  "review": [
+    {
+      "uniqueId": "usaco-784",
+      "name": "Lifeguards",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=784",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-592",
+      "name": "Angry Cows",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=592",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Simulation", "Sorting"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-735",
+      "name": "The Lost Cow",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=735",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Intro_Sorting.mdx
+++ b/content/2_Bronze/Intro_Sorting.mdx
@@ -319,7 +319,7 @@ always suffice).
 
 </Warning>
 
-<Problems problems="dis" />
+<Problems problems="dis" progressionSet />
 
 Note: There are some more sorting problems in the
 [Intro to Sets](/bronze/intro-sets) module.
@@ -428,3 +428,5 @@ Note: There are some more sorting problems in the
 
 </Quiz.Question>
 </Quiz>
+
+<ReviewProblems />

--- a/content/2_Bronze/Intro_Sorting.problems.json
+++ b/content/2_Bronze/Intro_Sorting.problems.json
@@ -100,5 +100,43 @@
         "kind": "internal"
       }
     }
+  ],
+  "review": [
+    {
+      "uniqueId": "usaco-615",
+      "name": "Milk Pails",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=615",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1061",
+      "name": "Stuck in a Rut",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1061",
+      "source": "Bronze",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-640",
+      "name": "Bull in a China Shop",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=640",
+      "source": "Bronze",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Rect_Geo.mdx
+++ b/content/2_Bronze/Rect_Geo.mdx
@@ -786,4 +786,6 @@ int interArea(int[] s1, int[] s2) {
 
 ## Problems
 
-<Problems problems="general" />
+<Problems problems="general" progressionSet />
+
+<ReviewProblems />

--- a/content/2_Bronze/Rect_Geo.problems.json
+++ b/content/2_Bronze/Rect_Geo.problems.json
@@ -78,5 +78,105 @@
         "kind": "internal"
       }
     }
+  ],
+  "review": [
+    {
+      "uniqueId": "usaco-616",
+      "name": "Circular Barn",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=616",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Simulation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1323",
+      "name": "FEB",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1323",
+      "source": "Bronze",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Casework", "Greedy"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-639",
+      "name": "Diamond Collector",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=639",
+      "source": "Bronze",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Complete Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-831C",
+      "name": "Jury Marks",
+      "url": "https://codeforces.com/contest/831/problem/C",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Set", "Prefix Sums"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-941",
+      "name": "Cow Evolution",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=941",
+      "source": "Bronze",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Tree"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-1467",
+      "name": "Astral Superposition",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1467",
+      "source": "Bronze",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Greedy"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-833",
+      "name": "Family Tree",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=833",
+      "source": "Bronze",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Tree"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "ccc-twenty-four",
+      "name": "Twenty-four",
+      "url": "https://dmoj.ca/problem/ccc08s4",
+      "source": "CCC",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Complete Search", "Permutation"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    }
   ]
 }

--- a/content/2_Bronze/Simulation.mdx
+++ b/content/2_Bronze/Simulation.mdx
@@ -296,8 +296,8 @@ with open("mixmilk.out", "w") as out:
 
 ### Easier
 
-<Problems problems="easier" hideSuggestProblemButton />
+<Problems problems="easier" progressionSet hideSuggestProblemButton />
 
 ### Harder
 
-<Problems problems="harder" hideSuggestProblemButton />
+<Problems problems="harder" progressionSet hideSuggestProblemButton />

--- a/src/components/Settings/General.tsx
+++ b/src/components/Settings/General.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import {
   useHideDifficultySetting,
   useHideModulesSetting,
+  useProgressionMode,
   useSetHideDifficultySetting,
   useSetHideModulesSetting,
+  useSetProgressionMode,
   useSetShowIgnoredSetting,
   useSetShowTagsSetting,
   useShowIgnoredSetting,
@@ -21,6 +23,8 @@ export default function General(): JSX.Element {
   const setHideDifficulty = useSetHideDifficultySetting();
   const hideModules = useHideModulesSetting();
   const setHideModules = useSetHideModulesSetting();
+  const progressionMode = useProgressionMode();
+  const setProgressionMode = useSetProgressionMode();
   const [isLongPolling, setIsLongPolling] = React.useState<boolean>(false);
   /**
    * For people behind proxies or with terrible internet - behold the power of long polling!
@@ -57,6 +61,20 @@ export default function General(): JSX.Element {
                 className="text-sm font-medium text-gray-500 dark:text-gray-300"
                 id="privacy-option-1-label"
               >
+                Progression Mode
+              </p>
+            </div>
+            <Switch
+              checked={progressionMode}
+              onChange={b => setProgressionMode(b)}
+            />
+          </li>
+          <li className="flex items-center justify-between py-4">
+            <div className="flex flex-col">
+              <p
+                className="text-sm font-medium text-gray-500 dark:text-gray-300"
+                id="privacy-option-2-label"
+              >
                 Problem Lists and Search: Show Tags
               </p>
             </div>
@@ -66,7 +84,7 @@ export default function General(): JSX.Element {
             <div className="flex flex-col">
               <p
                 className="text-sm font-medium text-gray-500 dark:text-gray-300"
-                id="privacy-option-1-label"
+                id="privacy-option-3-label"
               >
                 Problem Lists and Search: Hide Difficulty
               </p>
@@ -80,7 +98,7 @@ export default function General(): JSX.Element {
             <div className="flex flex-col">
               <p
                 className="text-sm font-medium text-gray-500 dark:text-gray-300"
-                id="privacy-option-1-label"
+                id="privacy-option-4-label"
               >
                 Problem Search: Hide Modules
               </p>
@@ -91,7 +109,7 @@ export default function General(): JSX.Element {
             <div className="flex flex-col">
               <p
                 className="text-sm font-medium text-gray-500 dark:text-gray-300"
-                id="privacy-option-2-label"
+                id="privacy-option-5-label"
               >
                 Dashboard: Show Ignored Problems & Modules
               </p>
@@ -102,7 +120,7 @@ export default function General(): JSX.Element {
             <div className="flex flex-col">
               <p
                 className="text-sm font-medium text-gray-500 dark:text-gray-300"
-                id="privacy-option-2-label"
+                id="privacy-option-6-label"
               >
                 Use Long Polling (Close and reopen tab after toggling) -{' '}
                 <span className="font-bold">

--- a/src/components/markdown/AdditionalProblemsDescription.tsx
+++ b/src/components/markdown/AdditionalProblemsDescription.tsx
@@ -31,7 +31,7 @@ export function AdditionalProblemsDescription(): JSX.Element {
       </h2>
       {progressionMode ? (
         <p>
-          Below are a mix of problems that require one more or techniques from
+          Below is a mix of problems that require one more or techniques from
           the previous modules in this section. Try to avoid looking at the
           tags, as determining how to approach a problem is one of the most
           important skills for success in contests.

--- a/src/components/markdown/AdditionalProblemsDescription.tsx
+++ b/src/components/markdown/AdditionalProblemsDescription.tsx
@@ -31,8 +31,8 @@ export function AdditionalProblemsDescription(): JSX.Element {
       </h2>
       {progressionMode ? (
         <p>
-          Below are a mix of problems from that require one more or techniques
-          from the previous modules in this section. Try to avoid looking at the
+          Below are a mix of problems that require one more or techniques from
+          the previous modules in this section. Try to avoid looking at the
           tags, as determining how to approach a problem is one of the most
           important skills for success in contests.
         </p>

--- a/src/components/markdown/AdditionalProblemsDescription.tsx
+++ b/src/components/markdown/AdditionalProblemsDescription.tsx
@@ -1,0 +1,56 @@
+import { useProgressionMode } from '../../context/UserDataContext/properties/simpleProperties';
+import Asterisk from '../Tooltip/Asterisk';
+import { OffsetAnchor } from './HTMLComponents';
+
+export function AdditionalProblemsDescription(): JSX.Element {
+  const progressionMode = useProgressionMode();
+  return (
+    <>
+      <h2 className="dark:text-dark-high-emphasis mt-12 mb-5 text-3xl leading-tight font-bold text-gray-700">
+        <OffsetAnchor id="problems" />
+        <a
+          aria-hidden="true"
+          tabIndex={-1}
+          className="anchor before"
+          href="#problems"
+        >
+          <svg
+            fill="none"
+            height="24"
+            width="24"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+            className="inline-block align-middle"
+          >
+            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+          </svg>
+        </a>
+        {progressionMode ? 'Mixed Practice' : 'Uncategorized Problems'}
+      </h2>
+      {progressionMode ? (
+        <p>
+          Below are a mix of problems from that require one more or techniques
+          from the previous modules in this section. Try to avoid looking at the
+          tags, as determining how to approach a problem is one of the most
+          important skills for success in contests.
+        </p>
+      ) : (
+        <p>
+          Below we list some problems that we think are roughly Bronze level but
+          don't really fit in previous modules.
+          <Asterisk>
+            <>
+              either because there were too many problems already, or because
+              the problem requires more than one concept
+            </>
+          </Asterisk>{' '}
+          The difficulties listed here are relative to the Bronze division
+          (difficulty is subjective and isn't always accurate though). We'll be
+          expanding this list as we get more problem suggestions.
+        </p>
+      )}
+    </>
+  );
+}

--- a/src/components/markdown/MDXComponents.tsx
+++ b/src/components/markdown/MDXComponents.tsx
@@ -1,5 +1,6 @@
 import Asterisk from '../Tooltip/Asterisk';
 import TextTooltip from '../Tooltip/TextTooltip';
+import { AdditionalProblemsDescription } from './AdditionalProblemsDescription';
 import FocusProblem from './FocusProblem';
 import HTMLComponents from './HTMLComponents';
 import { IncompleteSection } from './IncompleteSection';
@@ -18,6 +19,7 @@ import Optional from './Optional';
 import PrefixSumInteractive from './PrefixSumInteractive';
 import DivisionList from './ProblemsList/DivisionList/DivisionList';
 import { ProblemsList } from './ProblemsList/ProblemsList';
+import { ReviewProblems } from './ProblemsList/ReviewProblems';
 import Quiz from './Quiz';
 import { Resource, ResourcesList } from './ResourcesList';
 import Spoiler from './Spoiler';
@@ -49,6 +51,8 @@ export const components = {
   Quiz,
   MATHDIV,
   MATHSPAN,
+  ReviewProblems,
+  AdditionalProblemsDescription,
 
   ...HTMLComponents,
 };

--- a/src/components/markdown/ProblemsList/ProblemsList.tsx
+++ b/src/components/markdown/ProblemsList/ProblemsList.tsx
@@ -5,6 +5,7 @@ import { Fragment } from 'react';
 import { useMarkdownProblemLists } from '../../../context/MarkdownProblemListsContext';
 import {
   useHideDifficultySetting,
+  useProgressionMode,
   useShowTagsSetting,
 } from '../../../context/UserDataContext/properties/simpleProperties';
 import { ProblemInfo } from '../../../models/problem';
@@ -20,6 +21,9 @@ type ProblemsListProps =
       children?: React.ReactNode;
       problems?: string;
       hideSuggestProblemButton?: boolean;
+      progressionSet?: boolean; // only if problems should be filtered in progression mode
+      progression?: string; // only if there is a separate pset for progression mode
+      review?: boolean; // for review sets
     }
   | {
       title?: string;
@@ -27,6 +31,9 @@ type ProblemsListProps =
       problems?: DivisionProblemInfo[]; // normally string; only DivisionProblemInfo[] when it's a division table
       division?: string; // only if is division table
       modules?: boolean; // only if is division table
+      progressionSet?: boolean; // only if problems should be filtered in progression mode
+      progression?: string; // only if there is a separate pset for progression mode
+      review?: boolean; // for review sets
     };
 type AnnotatedProblemsListProps =
   | {
@@ -47,15 +54,21 @@ type AnnotatedProblemsListProps =
     };
 export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
   const markdownProblems = useMarkdownProblemLists()!;
+  const progressionMode = useProgressionMode();
   let problems: ProblemInfo[] | DivisionProblemInfo[];
+  const listId =
+    progressionMode && typeof unannotatedProps.progression === 'string'
+      ? unannotatedProps.progression
+      : unannotatedProps.problems;
   if (typeof unannotatedProps.problems === 'string') {
-    problems = markdownProblems.find(
-      list => list.listId === unannotatedProps.problems
-    )!.problems;
+    problems = markdownProblems.find(list => list.listId === listId)!.problems;
     if (!problems) {
       throw new Error(
         "Couldn't find the problem list with name " + unannotatedProps.problems
       );
+    }
+    if (progressionMode && unannotatedProps.progressionSet) {
+      problems = problems.filter(problem => problem.isStarred);
     }
   } else {
     problems = unannotatedProps.problems as DivisionProblemInfo[];
@@ -69,7 +82,10 @@ export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
     problems,
   } as AnnotatedProblemsListProps;
   const showTags = useShowTagsSetting();
-  const showDifficulty = !useHideDifficultySetting();
+  const showDifficulty =
+    !useHideDifficultySetting() &&
+    !unannotatedProps.review &&
+    (!unannotatedProps.progression || !progressionMode);
 
   const [problem, setProblem] = React.useState<ProblemInfo | null>(null);
   const [showModal, setShowModal] = React.useState(false);
@@ -80,7 +96,7 @@ export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
 
   const path = usePathname();
 
-  return (
+  return problems.length ? (
     <>
       <ListTable
         id={`problemlist-${
@@ -221,5 +237,7 @@ export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
         </div>
       </Transition>
     </>
+  ) : (
+    <p>There will be more practice on this topic in later modules!</p>
   );
 }

--- a/src/components/markdown/ProblemsList/ReviewProblems.tsx
+++ b/src/components/markdown/ProblemsList/ReviewProblems.tsx
@@ -1,0 +1,36 @@
+import { useProgressionMode } from '../../../context/UserDataContext/properties/simpleProperties';
+import { OffsetAnchor } from '../HTMLComponents';
+import { ProblemsList } from './ProblemsList';
+
+export function ReviewProblems(): JSX.Element {
+  const progressionMode = useProgressionMode();
+  if (!progressionMode) return <></>;
+  return (
+    <>
+      <h2 className="dark:text-dark-high-emphasis mt-12 mb-5 text-3xl leading-tight font-bold text-gray-700">
+        <OffsetAnchor id="review" />
+        <a
+          aria-hidden="true"
+          tabIndex={-1}
+          className="anchor before"
+          href="#review"
+        >
+          <svg
+            fill="none"
+            height="24"
+            width="24"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+            className="inline-block align-middle"
+          >
+            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+          </svg>
+        </a>
+        Review
+      </h2>
+      <ProblemsList problems="review" review />
+    </>
+  );
+}

--- a/src/context/UserDataContext/UserDataContext.tsx
+++ b/src/context/UserDataContext/UserDataContext.tsx
@@ -23,6 +23,8 @@ import { UserPermissionsContextProvider } from './UserPermissionsContext';
 // What's actually stored in local storage / firebase
 export type UserData = {
   consecutiveVisits: number;
+  /** Enable spaced repetition with mixed problem sets */
+  progressionMode: boolean;
   /** show tags on problems table */
   showTags: boolean;
   /** hide difficulty on problems table */
@@ -81,6 +83,7 @@ type UserDataContextAPI = {
 export const assignDefaultsToUserData = (data: object): UserData => {
   return {
     consecutiveVisits: 1,
+    progressionMode: false,
     showTags: false,
     hideDifficulty: false,
     hideModules: false,

--- a/src/context/UserDataContext/migration.ts
+++ b/src/context/UserDataContext/migration.ts
@@ -25,6 +25,7 @@ export default function runMigration() {
     // The user has a legacy version of user data. need to migrate it
     const storedUserData: UserData = {
       consecutiveVisits: getLegacy('consecutiveVisits')!,
+      progressionMode: getLegacy('progressionMode')!,
       showTags: getLegacy('showTags')!,
       hideDifficulty: getLegacy('hideDifficulty')!,
       hideModules: getLegacy('hideModules')!,

--- a/src/context/UserDataContext/properties/simpleProperties.ts
+++ b/src/context/UserDataContext/properties/simpleProperties.ts
@@ -1,5 +1,16 @@
 import { createSimpleUserDataMutation, createUserDataGetter } from './hooks';
 
+export const useProgressionMode = createUserDataGetter(userData => {
+  return userData.progressionMode;
+});
+export const useSetProgressionMode = createSimpleUserDataMutation(
+  (userData, progressionMode: boolean) => {
+    return {
+      progressionMode,
+    };
+  }
+);
+
 export const useShowTagsSetting = createUserDataGetter(userData => {
   return userData.showTags;
 });


### PR DESCRIPTION
This is a basic implementation of mixed problem sets for bronze following my proposal in issue #2949. It is enabled with "Progression Mode" in settings (disabled by default, also maybe someone can come up with a better name). Essentially, it incorporates spaced repetition of previous modules by moving unstarred problems to be reviewed in a later module. If this looks good, it might also make sense to add some info about this feature to the General section.

Edit: Also someone with write access might want to link it to the issue in the sidebar, I don't want to put "closes" for now.

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.
