### PR TITLE
Clarify Codeforces rating comparison in USACO FAQ

### DIFF
--- a/content/1_General/USACO_FAQs.mdx
+++ b/content/1_General/USACO_FAQs.mdx
@@ -213,22 +213,16 @@ practice both parts.
 
 ## Q: What Codeforces rating corresponds to each of the USACO divisions?
 
-Codeforces rating and USACO divisions can't be directly compared since CF
-emphasizes solving more problems in a shorter time period (CF contests have 5-8
-problems in 2-3 hours, while USACO contests have 3 problems in 4-5 hours).
-However, here are some _very rough_ estimates:
+Codeforces rating and USACO divisions can't be directly compared since CF emphasizes solving more problems in a shorter time period (CF contests have 5-8 problems in 2-3 hours, while USACO contests have 3 problems in 4-5 hours). The estimates below are only intended as rough comparisons, not exact cutoffs. In particular, CF problem ratings and CF competitor ratings measure different things, and a student may be able to solve a higher-rated CF-style problem in a USACO contest setting because there is more time per problem.
 
-- USACO Bronze competitors are probably \<1300 rated on CF, and Bronze problems
-  correspond to 900-1500 rated CF problems.
-- USACO Silver competitors are probably 1200-1500 rated on CF, and Silver
-  problems correspond to 1200-1900 rated CF problems.
-- USACO Gold competitors are probably 1500-1800 rated on CF, and Gold problems
-  correspond to 1500-2200 rated CF problems.
-- USACO Platinum competitors are probably 1650+ rated on CF, and Platinum
-  problems correspond to 1900+ rated CF problems. (Note that at the Platinum
-  level there is a _lot_ of variation in CF ratings.)
+With that in mind, here are some very rough estimates:
 
-Again, CF problems and contests are _significantly different_ from USACO!
+* USACO Bronze competitors are probably below 1300 rated on CF, and Bronze problems correspond to 900-1500 rated CF problems.
+* USACO Silver competitors are probably 1200-1500 rated on CF, and Silver problems correspond to 1200-1900 rated CF problems.
+* USACO Gold competitors are probably 1500-1800 rated on CF, and Gold problems correspond to 1500-2200 rated CF problems.
+* USACO Platinum competitors are probably 1650+ rated on CF, and Platinum problems correspond to 1900+ rated CF problems. (Note that at the Platinum level there is a lot of variation in CF ratings.)
+
+Again, CF problems and contests are significantly different from USACO, so these ranges should be treated as approximate guidance rather than strict boundaries.
 
 ## Q: Is collaborative work allowed?
 


### PR DESCRIPTION
## Summary

This PR updates the USACO FAQ section that compares Codeforces ratings to USACO divisions.

The change keeps the existing rating ranges but clarifies that they are rough comparisons rather than exact cutoffs. It also explains that Codeforces competitor ratings and Codeforces problem ratings measure different things, and that USACO contests provide more time per problem, so direct comparisons are imperfect.

Addresses #5024.

## Changes

* Clarified that the Codeforces-to-USACO ranges are approximate.
* Clarified that CF problem ratings and CF competitor ratings are different.
* Clarified that USACO's contest format gives more time per problem.
* Reworded `<1300` as `below 1300` to avoid MDX parsing issues.

## Testing

Tested locally with:

```powershell
yarn.cmd dev
```

Then opened:

```text
http://localhost:3000/general/usaco-faq
```

Confirmed that:

* The FAQ page loaded successfully.
* The updated Codeforces rating section rendered correctly.
* The heading and bullet list displayed correctly.
* No unrelated files were included in the commit.

## Notes

I kept this change conservative because the issue discussion includes uncertainty about which rating ranges should change. This PR focuses on making the existing comparison less absolute and less confusing without adding unsupported new rating boundaries.

## Checklist

* [x] I have tested my code.
* [x] I have added my solution according to the steps.
* [x] I have followed the code conventions mentioned by the project.

  * [x] I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  * [x] If changes are requested, I will re-request a review after addressing them.
* [x] I have linked this PR to the issue that it addresses.
