### PR TITLE
docs: explain preorder traversal in tree intro

### DIFF
--- a/content/3_Silver/Intro_Tree.mdx
+++ b/content/3_Silver/Intro_Tree.mdx
@@ -60,6 +60,19 @@ Rooted Tree Terminology:
   - Note: This is easily confused with **subgraph**
 - The **depth**, or **level**, of a node is its distance from the root
 
+### Tree Traversal Order
+
+When we run DFS on a rooted tree, the order in which we process each node can
+matter. There are three common traversal orders:
+
+- **Preorder**: Process the current node before recursively visiting its
+  children. For a binary tree, this means processing the current node, then the
+  left child, then the right child.
+- **Inorder**: Recursively visit the left child, process the current node, then
+  recursively visit the right child. This order is mainly used for binary trees.
+- **Postorder**: Recursively visit all children before processing the current
+  node.
+
 <!-- </Spoiler> -->
 
 ## Example - Subordinates


### PR DESCRIPTION
## Summary

- Adds a short tree traversal order section to the Silver tree introduction.
- Defines preorder traversal before the quiz asks about it.
- Briefly contrasts preorder with inorder and postorder traversal.

Fixes #6367

## Validation

- [x] `corepack yarn prettier --check content/3_Silver/Intro_Tree.mdx`
- [x] `corepack yarn tsx scripts/index-content.ts` (completed successfully; emitted existing KaTeX strict-mode warnings in unrelated content)
- [x] `git diff --check`

## Checklist

- [x] I have tested my code.
- [x] I have added my solution according to the steps here. (N/A: docs-only content clarification, not a solution.)
- [x] I have followed the code conventions mentioned here. (N/A: no solution code.)
- [x] I have linked this PR to any issues that it closes.
