### PR TITLE
Sort difficulty filter options by increasing difficulty

### DIFF
--- a/src/pages/problems/index.tsx
+++ b/src/pages/problems/index.tsx
@@ -11,6 +11,7 @@ import {
 import { GetStaticProps } from 'next';
 import SECTIONS from '../../../content/ordering';
 import BlindModeToggle from '../../components/BlindModeToggle';
+import { difficultyClasses } from '../../components/DifficultyBox';
 import Layout from '../../components/layout';
 import ProblemHits from '../../components/ProblemsPage/ProblemHits';
 import SearchBox from '../../components/ProblemsPage/SearchBox';
@@ -35,6 +36,8 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
   const [shuffle, sendShuffle] = useState(0);
   const [random, sendRandom] = useState(0);
   const [sort, setSort] = useState('Relevance');
+  // keys of difficultyClasses are in increasing order of difficulty
+  const difficultyOrder = Object.keys(difficultyClasses);
   const selectionMetadata: SelectionProps[] = [
     {
       attribute: 'difficulty',
@@ -42,6 +45,8 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
       placeholder: 'Difficulty',
       searchable: false,
       isMulti: true,
+      sortBy: (a, b) =>
+        difficultyOrder.indexOf(a.name) - difficultyOrder.indexOf(b.name),
     },
     {
       attribute: 'problemModules.title',


### PR DESCRIPTION
Closes #6421

The Difficulty filter on the Problems Page used Algolia's default facet sort (by count), which rendered as "Normal, Easy, Hard, N/A, Very Hard, Very Easy, Insane".

This passes a `sortBy` comparator to the difficulty refinement list so the options appear in increasing order of difficulty: N/A, Very Easy, Easy, Normal, Hard, Very Hard, Insane. The order comes from the keys of `difficultyClasses` in `DifficultyBox.tsx`, which are already listed in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)