### PR TITLE
Sort Modules and Source filter options alphabetically

### DIFF
--- a/src/pages/problems/index.tsx
+++ b/src/pages/problems/index.tsx
@@ -54,6 +54,7 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
       placeholder: 'Modules',
       searchable: true,
       isMulti: true,
+      sortBy: ['name:asc'],
     },
     {
       attribute: 'source',
@@ -61,6 +62,7 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
       placeholder: 'Source',
       searchable: true,
       isMulti: true,
+      sortBy: ['name:asc'],
     },
     {
       attribute: 'isStarred',


### PR DESCRIPTION
Part of #5841 — the second post asks for the Modules filter to follow "alphabetical order or section order" instead of the current arbitrary order.

The Modules and Source filters on the Problems Page use Algolia's default facet sort (by count), so options appear in a random-looking order. This passes `sortBy: ['name:asc']` to both refinement lists so they read alphabetically.

Follow-up items from the same issue (bookmarkable filter URLs / filters surviving a reload) are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)