### PR TITLE
Sync Problems Page filters with the URL

### DIFF
--- a/src/components/ProblemsPage/SearchBox.tsx
+++ b/src/components/ProblemsPage/SearchBox.tsx
@@ -7,14 +7,16 @@ export default function SearchBox(props: UseSearchBoxProps): JSX.Element {
   // https://stackoverflow.com/questions/53314857/how-to-focus-something-on-next-render-with-react-hooks
   const { query, refine: setQuery } = useSearchBox(props);
   const inputRef = useRef<HTMLInputElement>(null);
-  const [searchTerm, setSearchTerm] = React.useState('');
+  const [searchTerm, setSearchTerm] = React.useState(query);
+  // Don't write the (initially empty) search term to InstantSearch until the
+  // user has typed something, so we don't clobber a query restored from the URL
+  const dirty = useRef(false);
   const debouncedSearchTerm = useDebounce(searchTerm, 200);
   useEffect(() => {
-    if (debouncedSearchTerm) {
-      setQuery(searchTerm);
-    } else {
-      setQuery('');
-    }
+    if (!dirty.current) setSearchTerm(query);
+  }, [query]);
+  useEffect(() => {
+    if (dirty.current) setQuery(debouncedSearchTerm || '');
   }, [debouncedSearchTerm]);
   useEffect(() => {
     if (inputRef.current) inputRef.current.focus();
@@ -41,7 +43,10 @@ export default function SearchBox(props: UseSearchBoxProps): JSX.Element {
         type="search"
         autoComplete="off"
         value={searchTerm}
-        onChange={e => setSearchTerm(e.target.value)}
+        onChange={e => {
+          dirty.current = true;
+          setSearchTerm(e.target.value);
+        }}
         ref={inputRef}
       />
     </div>

--- a/src/components/ProblemsPage/Selection.tsx
+++ b/src/components/ProblemsPage/Selection.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import {
   useInstantSearch,
   useRefinementList,
@@ -12,6 +11,8 @@ export type SelectionProps = UseRefinementListProps & {
   isMulti: boolean;
   transformLabel?: (label: string) => string;
   items?: { label: string; value: string | string[] }[];
+  /** Called with the labels of the selected options whenever they change. */
+  onRefine?: (labels: string[]) => void;
 };
 
 export default function Selection({
@@ -22,6 +23,7 @@ export default function Selection({
   isMulti,
   transformLabel: transform,
   items,
+  onRefine,
   ...props
 }: SelectionProps) {
   const { items: refineItems } = useRefinementList({
@@ -31,35 +33,45 @@ export default function Selection({
   });
   if (!items) items = refineItems;
   for (const key in items) {
-    if (items[key].value instanceof Array) {
-      (items[key].value as string[]).push('null');
+    const value = items[key].value;
+    // 'null' matches nothing; guarantees a non-empty refinement so that
+    // selecting an option with no matches shows zero results
+    if (value instanceof Array && !value.includes('null')) {
+      value.push('null');
     }
   }
-  const [refinements, setRefinements] = useState<string[]>([]);
-  const { setIndexUiState } = useInstantSearch();
-  useEffect(() => {
-    setIndexUiState(prevIndexUiState => ({
-      refinementList: {
-        ...prevIndexUiState.refinementList,
-        [attribute]: refinements,
-      },
-    }));
-  }, [refinements]);
+  const { indexUiState, setIndexUiState } = useInstantSearch();
+  const refinements = indexUiState.refinementList?.[attribute] ?? [];
+  const options = items.map(item => ({
+    ...item,
+    label: transform ? transform(item.label) : item.label,
+  }));
+  const selected = options.filter(option =>
+    option.value instanceof Array
+      ? option.value.length > 1 &&
+        option.value.every(v => refinements.includes(v))
+      : refinements.includes(option.value)
+  );
   return (
     <Select
-      onChange={(items: any) => {
-        if (isMulti) setRefinements(items.map(item => item.value).flat());
-        else if (items) setRefinements([items.value]);
-        else setRefinements([]);
+      onChange={(selection: any) => {
+        const selectedOptions: { label: string; value: string | string[] }[] =
+          isMulti ? selection : selection ? [selection] : [];
+        setIndexUiState(prevIndexUiState => ({
+          ...prevIndexUiState,
+          refinementList: {
+            ...prevIndexUiState.refinementList,
+            [attribute]: selectedOptions.map(option => option.value).flat(),
+          },
+        }));
+        onRefine?.(selectedOptions.map(option => option.label));
       }}
+      value={isMulti ? selected : (selected[0] ?? null)}
       isClearable
       placeholder={placeholder}
       isMulti={isMulti}
       isSearchable={searchable}
-      options={items.map(item => ({
-        ...item,
-        label: transform ? transform(item.label) : item.label,
-      }))}
+      options={options}
       className="text-black dark:text-white"
       classNamePrefix="select"
     />

--- a/src/components/ProblemsPage/routing.ts
+++ b/src/components/ProblemsPage/routing.ts
@@ -1,8 +1,8 @@
 import type { UiState } from 'instantsearch.js';
 import { history } from 'instantsearch.js/es/lib/routers';
 import MODULE_ORDERING, {
-  SectionID,
   SECTION_LABELS,
+  SectionID,
 } from '../../../content/ordering';
 
 export const indexName = `${process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'dev'}_problems`;

--- a/src/components/ProblemsPage/routing.ts
+++ b/src/components/ProblemsPage/routing.ts
@@ -1,0 +1,117 @@
+import type { UiState } from 'instantsearch.js';
+import { history } from 'instantsearch.js/es/lib/routers';
+import MODULE_ORDERING, {
+  SectionID,
+  SECTION_LABELS,
+} from '../../../content/ordering';
+
+export const indexName = `${process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'dev'}_problems`;
+
+type RouteState = Record<string, string | string[] | undefined>;
+
+// URL param <-> refinement attribute for filters that map 1:1
+const REFINEMENT_PARAMS: [param: string, attribute: string][] = [
+  ['difficulty', 'difficulty'],
+  ['modules', 'problemModules.title'],
+  ['source', 'source'],
+  ['tags', 'tags'],
+  ['starred', 'isStarred'],
+];
+
+// `sort` and `status` are managed by the problems page outside of
+// InstantSearch; preserve them when InstantSearch writes the URL.
+const EXTERNAL_PARAMS = ['sort', 'status'];
+
+// Section label -> module IDs, matching the Section filter options
+const sectionModules: Record<string, string[]> = Object.fromEntries(
+  (Object.keys(MODULE_ORDERING) as SectionID[]).map(section => [
+    SECTION_LABELS[section],
+    MODULE_ORDERING[section].flatMap(chapter => chapter.items),
+  ])
+);
+
+const toArray = (x: string | string[] | undefined): string[] | undefined =>
+  x === undefined ? undefined : Array.isArray(x) ? x : [x];
+
+const stateMapping = {
+  stateToRoute(uiState: UiState): RouteState {
+    const state = uiState[indexName] ?? {};
+    const refinementList = state.refinementList ?? {};
+    const route: RouteState = {
+      q: state.query || undefined,
+      page: state.page && state.page > 1 ? String(state.page) : undefined,
+    };
+    for (const [param, attribute] of REFINEMENT_PARAMS) {
+      const values = refinementList[attribute];
+      if (values?.length) route[param] = values;
+    }
+    // The Section filter refines on module IDs; store section labels instead
+    const moduleIds = refinementList['problemModules.id'];
+    if (moduleIds?.length) {
+      route.section = Object.keys(sectionModules).filter(label =>
+        sectionModules[label].every(id => moduleIds.includes(id))
+      );
+    }
+    return route;
+  },
+  routeToState(routeState: RouteState): UiState {
+    const refinementList: Record<string, string[]> = {};
+    for (const [param, attribute] of REFINEMENT_PARAMS) {
+      const values = toArray(routeState[param]);
+      if (values?.length) refinementList[attribute] = values;
+    }
+    const sections = toArray(routeState.section)?.filter(
+      label => sectionModules[label]
+    );
+    if (sections?.length) {
+      // 'null' matches nothing; appended for consistency with Selection,
+      // which pushes it onto every array-valued option
+      refinementList['problemModules.id'] = [
+        ...new Set(sections.flatMap(label => sectionModules[label])),
+        'null',
+      ];
+    }
+    return {
+      [indexName]: {
+        query: typeof routeState.q === 'string' ? routeState.q : undefined,
+        page:
+          typeof routeState.page === 'string'
+            ? Number(routeState.page)
+            : undefined,
+        refinementList,
+      },
+    };
+  },
+};
+
+export function createRouting() {
+  return {
+    router: history<RouteState>({
+      cleanUrlOnDispose: false,
+      createURL({ qsModule, routeState, location }) {
+        // Preserve page-managed params (sort, status) that InstantSearch
+        // doesn't know about
+        const current = qsModule.parse(location.search.slice(1), {
+          arrayLimit: 99,
+        });
+        const preserved: RouteState = {};
+        for (const param of EXTERNAL_PARAMS) {
+          if (current[param]) {
+            preserved[param] = current[param] as string | string[];
+          }
+        }
+        const queryString = qsModule.stringify(
+          { ...routeState, ...preserved },
+          { arrayFormat: 'repeat', addQueryPrefix: true }
+        );
+        return `${location.protocol}//${location.host}${location.pathname}${queryString}${location.hash}`;
+      },
+      parseURL({ qsModule, location }) {
+        return qsModule.parse(location.search.slice(1), {
+          arrayLimit: 99,
+        }) as RouteState;
+      },
+    }),
+    stateMapping,
+  };
+}

--- a/src/pages/problems/index.tsx
+++ b/src/pages/problems/index.tsx
@@ -30,6 +30,15 @@ import TopNavigationBar from '../../components/TopNavigationBar/TopNavigationBar
 import { useUserProgressOnProblems } from '../../context/UserDataContext/properties/userProgress';
 import searchClient from '../../utils/algoliaLiteSearchClient';
 
+// keys of difficultyClasses are in increasing order of difficulty.
+// Defined at module scope so the comparator keeps a stable identity across
+// renders — react-instantsearch deep-compares hook props (functions by
+// reference) and tears down + recreates the refinement-list widget when they
+// change, which drops the active refinement.
+const difficultyOrder = Object.keys(difficultyClasses);
+const sortByDifficulty: SelectionProps['sortBy'] = (a, b) =>
+  difficultyOrder.indexOf(a.name) - difficultyOrder.indexOf(b.name);
+
 const SORT_OPTIONS = [
   'Relevance',
   'Difficulty (Ascending)',
@@ -114,8 +123,6 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
       .filter(status => STATUS_OPTIONS.includes(status));
     if (statusParams.length) setStatuses(statusParams);
   }, []);
-  // keys of difficultyClasses are in increasing order of difficulty
-  const difficultyOrder = Object.keys(difficultyClasses);
   const selectionMetadata: SelectionProps[] = [
     {
       attribute: 'difficulty',
@@ -123,8 +130,7 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
       placeholder: 'Difficulty',
       searchable: false,
       isMulti: true,
-      sortBy: (a, b) =>
-        difficultyOrder.indexOf(a.name) - difficultyOrder.indexOf(b.name),
+      sortBy: sortByDifficulty,
     },
     {
       attribute: 'problemModules.title',

--- a/src/pages/problems/index.tsx
+++ b/src/pages/problems/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Chapter } from '../../../content/ordering';
 
 import {
@@ -6,6 +6,7 @@ import {
   InstantSearch,
   Pagination,
   PoweredBy,
+  useInstantSearch,
 } from 'react-instantsearch';
 
 import { GetStaticProps } from 'next';
@@ -14,6 +15,10 @@ import BlindModeToggle from '../../components/BlindModeToggle';
 import { difficultyClasses } from '../../components/DifficultyBox';
 import Layout from '../../components/layout';
 import ProblemHits from '../../components/ProblemsPage/ProblemHits';
+import {
+  createRouting,
+  indexName,
+} from '../../components/ProblemsPage/routing';
 import SearchBox from '../../components/ProblemsPage/SearchBox';
 import Selection, {
   SelectionProps,
@@ -25,7 +30,65 @@ import TopNavigationBar from '../../components/TopNavigationBar/TopNavigationBar
 import { useUserProgressOnProblems } from '../../context/UserDataContext/properties/userProgress';
 import searchClient from '../../utils/algoliaLiteSearchClient';
 
-const indexName = `${process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'dev'}_problems`;
+const SORT_OPTIONS = [
+  'Relevance',
+  'Difficulty (Ascending)',
+  'Difficulty (Descending)',
+  'Contest (Newer)',
+  'Contest (Older)',
+];
+
+const STATUS_OPTIONS = [
+  'Not Attempted',
+  'Solving',
+  'Reviewing',
+  'Skipped',
+  'Ignored',
+  'Solved',
+];
+
+/** Replaces the given query params in the URL without adding history entries. */
+function updateUrlParams(updates: Record<string, string[]>) {
+  const url = new URL(window.location.href);
+  for (const [param, values] of Object.entries(updates)) {
+    url.searchParams.delete(param);
+    for (const value of values) url.searchParams.append(param, value);
+  }
+  window.history.replaceState(window.history.state, '', url);
+}
+
+/**
+ * Applies the Status filter (a list of status labels) by expanding it into the
+ * matching problem IDs. Runs again when user progress loads / changes, since
+ * the expansion depends on it.
+ */
+function StatusFilterSync({
+  statuses,
+  problemIds,
+}: {
+  statuses: string[];
+  problemIds: string[];
+}) {
+  const userProgress = useUserProgressOnProblems();
+  const { setIndexUiState } = useInstantSearch();
+  useEffect(() => {
+    if (!statuses.length) return;
+    const ids = problemIds.filter(id =>
+      statuses.includes(userProgress[id] ?? 'Not Attempted')
+    );
+    // No matches usually means user progress hasn't loaded yet; leave the
+    // results unfiltered instead of showing zero results
+    if (!ids.length) return;
+    setIndexUiState(prevIndexUiState => ({
+      ...prevIndexUiState,
+      refinementList: {
+        ...prevIndexUiState.refinementList,
+        objectID: [...ids, 'null'],
+      },
+    }));
+  }, [statuses, problemIds, userProgress]);
+  return null;
+}
 
 interface ProblemsPageProps {
   problemIds: string[];
@@ -36,6 +99,21 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
   const [shuffle, sendShuffle] = useState(0);
   const [random, sendRandom] = useState(0);
   const [sort, setSort] = useState('Relevance');
+  // Status labels selected via the URL or the Status dropdown; expanded into
+  // problem IDs by StatusFilterSync
+  const [statuses, setStatuses] = useState<string[]>([]);
+  const routing = useMemo(createRouting, []);
+  useEffect(() => {
+    // Restore the page-managed params (sort, status) from the URL;
+    // InstantSearch's routing handles the rest
+    const params = new URLSearchParams(window.location.search);
+    const sortParam = params.get('sort');
+    if (sortParam && SORT_OPTIONS.includes(sortParam)) setSort(sortParam);
+    const statusParams = params
+      .getAll('status')
+      .filter(status => STATUS_OPTIONS.includes(status));
+    if (statusParams.length) setStatuses(statusParams);
+  }, []);
   // keys of difficultyClasses are in increasing order of difficulty
   const difficultyOrder = Object.keys(difficultyClasses);
   const selectionMetadata: SelectionProps[] = [
@@ -98,14 +176,11 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
       placeholder: 'Status',
       searchable: false,
       isMulti: true,
-      items: [
-        'Not Attempted',
-        'Solving',
-        'Reviewing',
-        'Skipped',
-        'Ignored',
-        'Solved',
-      ].map(label => ({
+      onRefine: labels => {
+        setStatuses(labels);
+        updateUrlParams({ status: labels });
+      },
+      items: STATUS_OPTIONS.map(label => ({
         label,
         value: problemIds.filter(
           id => (userProgress[id] ?? 'Not Attempted') == label
@@ -120,7 +195,12 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
       <div className="dark:bg-dark-surface min-h-screen bg-gray-100">
         <TopNavigationBar />
 
-        <InstantSearch searchClient={searchClient} indexName={indexName}>
+        <InstantSearch
+          searchClient={searchClient}
+          indexName={indexName}
+          routing={routing}
+        >
+          <StatusFilterSync statuses={statuses} problemIds={problemIds} />
           <div className="bg-blue-600 px-5 py-16 dark:bg-blue-900">
             <div className="mx-auto mb-6 max-w-3xl">
               <h1 className="dark:text-dark-high-emphasis mb-6 text-center text-3xl font-bold text-white sm:text-5xl">
@@ -195,15 +275,14 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
                   Random
                 </button>
                 <SortButton
-                  options={[
-                    'Relevance',
-                    'Difficulty (Ascending)',
-                    'Difficulty (Descending)',
-                    'Contest (Newer)',
-                    'Contest (Older)',
-                  ]}
+                  options={SORT_OPTIONS}
                   state={sort}
-                  onChange={newSort => setSort(newSort)}
+                  onChange={newSort => {
+                    setSort(newSort);
+                    updateUrlParams({
+                      sort: newSort === 'Relevance' ? [] : [newSort],
+                    });
+                  }}
                 />
               </div>
               <ProblemHits shuffle={shuffle} random={random} sort={sort} />


### PR DESCRIPTION
Closes #5841 — filter options were lost on reload, and there was no way to bookmark/share a filtered view.

Search query, filters, sort mode, and page number on the Problems Page are now reflected in the URL and restored on load, so filtered views survive reloads and can be bookmarked/shared. Example:

```
/problems?q=knapsack&difficulty=Easy&difficulty=Normal&section=Gold&status=Solved&sort=Difficulty%20(Ascending)&page=2
```

- **`routing.ts` (new)**: InstantSearch routing with a custom state mapping producing short, readable params (`q`, `page`, `difficulty`, `modules`, `source`, `tags`, `starred`, `section`). Multi-value filters use repeated params rather than comma-joins since titles can contain commas. The Section filter is stored as section labels and expanded back into module IDs from `MODULE_ORDERING`, and the custom `createURL` preserves the page-managed `sort`/`status` params that InstantSearch doesn't know about.
- **`Selection.tsx`**: the dropdowns previously kept their own state and pushed it into the InstantSearch UI state via an effect that (a) clobbered URL-restored state on mount and (b) replaced the whole index UI state, wiping the query and page on every filter change. They now derive their value directly from `indexUiState` (making them controlled, so restored filters are visible) and write with the previous state spread in.
- **`SearchBox.tsx`**: same clobber fix for the query — the (initially empty) search term is no longer written to InstantSearch until the user types, and a query restored from the URL is reflected in the input.
- **`index.tsx`**: `sort` and `status` are managed outside InstantSearch, so they're read from / written to the URL directly. `?status=Solved` stores status *labels*; `StatusFilterSync` expands them into matching problem IDs once user progress loads (until then results briefly render unfiltered rather than flashing zero results).

Known limitation: browser back/forward restores the InstantSearch-managed params but not `sort`/`status`, which are only read on initial load.

Verified with `tsc --noEmit`, ESLint (no new warnings beyond pre-existing patterns), and a dev-server smoke test of `/problems` with params (HTTP 200, no server errors). Client-side behavior (restore-on-reload, URL updates while filtering) should be checked in a browser before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)