### PR TITLE
Widen content column for the USACO Monthlies page

### DIFF
--- a/content/1_General/USACO_Monthlies.mdx
+++ b/content/1_General/USACO_Monthlies.mdx
@@ -3,6 +3,7 @@ id: usaco-monthlies
 title: USACO Monthlies
 author: Benjamin Qi
 description: 'A table with all recent USACO Monthly Problems.'
+wide: true
 ---
 
 <DivisionList division="Bronze" />

--- a/src/components/MarkdownLayout/MarkdownLayout.tsx
+++ b/src/components/MarkdownLayout/MarkdownLayout.tsx
@@ -28,7 +28,7 @@ import NotSignedInWarning from './NotSignedInWarning';
 import TableOfContentsBlock from './TableOfContents/TableOfContentsBlock';
 import TableOfContentsSidebar from './TableOfContents/TableOfContentsSidebar';
 
-const ContentContainer = ({ children, tableOfContents }) => (
+const ContentContainer = ({ children, tableOfContents, wide = false }) => (
   <main
     className="relative overflow-x-hidden pt-6 focus:outline-hidden lg:pt-2"
     tabIndex={0}
@@ -45,7 +45,11 @@ const ContentContainer = ({ children, tableOfContents }) => (
             <TableOfContentsSidebar tableOfContents={tableOfContents} />
           </div>
         )}
-        <div className="order-2 w-0 max-w-4xl min-w-0 flex-1 overflow-x-auto px-4 sm:px-6 lg:px-8">
+        <div
+          className={`order-2 w-0 min-w-0 flex-1 overflow-x-auto px-4 sm:px-6 lg:px-8 ${
+            wide ? 'max-w-7xl' : 'max-w-4xl'
+          }`}
+        >
           <div className="hidden lg:block">
             <NavBar />
             <div className="h-8" />
@@ -138,7 +142,10 @@ export default function MarkdownLayout({
           <div className="w-full">
             <MobileAppBar />
 
-            <ContentContainer tableOfContents={tableOfContents}>
+            <ContentContainer
+              tableOfContents={tableOfContents}
+              wide={markdownData instanceof ModuleInfo && markdownData.wide}
+            >
               <NotSignedInWarning />
 
               <ModuleHeaders moduleLinks={moduleLinks} />

--- a/src/models/module.ts
+++ b/src/models/module.ts
@@ -60,7 +60,8 @@ export class ModuleInfo extends ModuleLinkInfo {
     public frequency: ModuleFrequency,
     public toc: TableOfContents,
     public fileRelativePath: string,
-    public gitAuthorTime: any
+    public gitAuthorTime: any,
+    public wide: boolean = false
   ) {
     super(id, section, title);
   }

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -30,6 +30,11 @@ export interface MdxFrontmatter {
   isIncomplete?: boolean;
   lastUpdated?: string;
   division?: SectionID;
+  /**
+   * Widens the content column for modules whose content (ex. the USACO
+   * monthlies table) doesn't fit in the default width.
+   */
+  wide?: boolean;
   // Problem-specific fields
   source?: string;
   difficulty?: string;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -36,7 +36,8 @@ export function graphqlToModuleInfo(mdx: MdxContent): ModuleInfo {
     mdx.frontmatter.frequency,
     mdx.toc,
     mdx.fileAbsolutePath,
-    mdx.fields.gitAuthorTime
+    mdx.fields.gitAuthorTime,
+    mdx.frontmatter.wide ?? false
   );
 }
 


### PR DESCRIPTION
Fixes #5164.

The monthlies division table doesn't fit in the standard module content column, so it always renders with a horizontal scrollbar.

Measured natural table widths (all divisions, "All (2015 - 2026)" selected):

| | tags hidden | tags shown |
|---|---|---|
| Bronze | 892px | 983px |
| Silver | 888px | 1050px |
| Gold | 888px | 1076px |
| Platinum | 887px | 983px |

The default `max-w-4xl` content column leaves the table only ~800px after padding, hence the scrollbar in both cases.

### Change

Adds an optional `wide: true` module frontmatter flag that bumps the content column from `max-w-4xl` (56rem) to `max-w-7xl` (80rem), and sets it on `USACO_Monthlies.mdx`. Every other page is untouched — per the discussion on the issue, we don't want wider text columns in general.

`max-w-7xl` rather than `max-w-6xl` because 6xl (72rem) leaves ~1056px of usable table width, which still clips the Gold table when tags are shown.

### Testing

Verified locally that the monthlies table now fits without a horizontal scrollbar for all four divisions, with tags both hidden and shown, and that a normal module page (`/general/using-this-guide`) still renders at the old width. The column is `flex-1 min-w-0`, so `max-w-7xl` is only a cap — narrower viewports are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)