### PR TITLE
Don't render empty frequency dots for modules without a frequency

### DIFF
--- a/src/components/MarkdownLayout/ModuleHeaders/ModuleHeaders.tsx
+++ b/src/components/MarkdownLayout/ModuleHeaders/ModuleHeaders.tsx
@@ -98,10 +98,14 @@ export default function ModuleHeaders({
     <ClientOnly>
       <>
         {markdownData instanceof ModuleInfo &&
-          markdownData.frequency !== null && (
+          (markdownData.frequency != null || problemIDs.length > 0) && (
             <div className="px-0.5">
               <div className="mb-4 space-y-1 sm:flex sm:items-center sm:justify-between sm:space-y-0">
-                <Frequency frequency={markdownData.frequency} />
+                {markdownData.frequency != null ? (
+                  <Frequency frequency={markdownData.frequency} />
+                ) : (
+                  <div />
+                )}
                 {problemIDs.length > 0 && (
                   <DashboardProgressSmall
                     {...problemsProgressInfo}


### PR DESCRIPTION
Fixes #6426

## Problem

`frequency` is optional in module frontmatter, but `ModuleHeaders` guarded the frequency row with `markdownData.frequency !== null`. For a module that simply omits `frequency`, the value is `undefined`, which passes that check — so `<Frequency>` rendered with `count={undefined}`, producing four empty gray dots and an empty label (`FrequencyLabels[undefined]`).

Affected e.g. `/general/choosing-lang`, `/general/intro-cp`, `/bronze/time-comp`.

## Fix

Use a loose `!= null` check so `undefined` is excluded too. The problems progress bar lives in the same row, so the wrapper still renders (with a spacer keeping `justify-between` right-alignment) when a module has problems but no frequency.

## Verification

`yarn check-ts-errors` passes. Checked locally in the dev server:

| Page | Before | After |
| --- | --- | --- |
| `/general/choosing-lang` (no frequency, no problems) | 4 empty dots | row gone |
| `/general/intro-cp` (no frequency, has problems) | 4 empty dots + `0/1` bar | `0/1` bar only, still right-aligned |
| `/silver/binary-search` (has frequency) | dots + label + bar | unchanged |