### PR TITLE
Add toggle to hide/show the desktop sidebar

### DIFF
--- a/src/components/MarkdownLayout/DesktopSidebar.tsx
+++ b/src/components/MarkdownLayout/DesktopSidebar.tsx
@@ -1,9 +1,36 @@
 import Link from 'next/link';
+import { useMarkdownLayout } from '../../context/MarkdownLayoutContext';
 import Logo from '../Logo';
 import SidebarBottomButtons from './SidebarBottomButtons';
 import { SidebarNav } from './SidebarNav/SidebarNav';
 
 export default function DesktopSidebar() {
+  const { isDesktopSidebarHidden, setIsDesktopSidebarHidden } =
+    useMarkdownLayout();
+
+  if (isDesktopSidebarHidden) {
+    return (
+      <button
+        className="dark:bg-dark-surface fixed top-2 left-2 z-10 hidden rounded-md border border-gray-200 bg-white p-2 text-gray-400 shadow-sm transition duration-150 ease-in-out hover:text-gray-600 lg:block dark:border-gray-800 dark:hover:text-gray-300"
+        aria-label="Show sidebar"
+        title="Show sidebar"
+        onClick={() => setIsDesktopSidebarHidden(false)}
+      >
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+        >
+          <path d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+        </svg>
+      </button>
+    );
+  }
+
   return (
     <div
       className="fixed top-0 bottom-0 left-0 z-10 hidden lg:block"
@@ -14,12 +41,29 @@ export default function DesktopSidebar() {
         style={{ width: '20rem' }}
       >
         <div className="flex h-0 grow flex-col pt-5">
-          <Link
-            className="flex shrink-0 items-center px-4 pb-2"
-            href="/dashboard/"
-          >
-            <Logo />
-          </Link>
+          <div className="flex shrink-0 items-center px-4 pb-2">
+            <Link className="flex flex-1 items-center" href="/dashboard/">
+              <Logo />
+            </Link>
+            <button
+              className="rounded-md p-1 text-gray-400 transition duration-150 ease-in-out hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+              aria-label="Hide sidebar"
+              title="Hide sidebar"
+              onClick={() => setIsDesktopSidebarHidden(true)}
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              >
+                <path d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+              </svg>
+            </button>
+          </div>
           {/* Sidebar component, swap this element with another sidebar if you like */}
           <SidebarNav />
         </div>

--- a/src/components/MarkdownLayout/MarkdownLayout.tsx
+++ b/src/components/MarkdownLayout/MarkdownLayout.tsx
@@ -52,9 +52,19 @@ const ContentContainer = ({ children, tableOfContents, wide = false }) => {
               <TableOfContentsSidebar tableOfContents={tableOfContents} />
             </div>
           )}
+          {/* When the sidebar is hidden, the content's max width grows by the
+              sidebar's width (20rem) so that, since the content stays centered,
+              its right edge stays in the same place as when the sidebar is
+              visible. */}
           <div
             className={`order-2 w-0 min-w-0 flex-1 overflow-x-auto px-4 sm:px-6 lg:px-8 ${
-              wide ? 'max-w-7xl' : 'max-w-4xl'
+              wide
+                ? isDesktopSidebarHidden
+                  ? 'max-w-7xl lg:max-w-[100rem]'
+                  : 'max-w-7xl'
+                : isDesktopSidebarHidden
+                  ? 'max-w-4xl lg:max-w-[76rem]'
+                  : 'max-w-4xl'
             }`}
           >
             <div className="hidden lg:block">

--- a/src/components/MarkdownLayout/MarkdownLayout.tsx
+++ b/src/components/MarkdownLayout/MarkdownLayout.tsx
@@ -6,7 +6,9 @@ import {
 } from '../../../content/ordering';
 import ConfettiContext from '../../context/ConfettiContext';
 import { ContactUsSlideoverProvider } from '../../context/ContactUsSlideoverContext';
-import MarkdownLayoutContext from '../../context/MarkdownLayoutContext';
+import MarkdownLayoutContext, {
+  useMarkdownLayout,
+} from '../../context/MarkdownLayoutContext';
 import { ProblemSolutionContext } from '../../context/ProblemSolutionContext';
 import { ProblemSuggestionModalProvider } from '../../context/ProblemSuggestionModalContext';
 import { useUserLangSetting } from '../../context/UserDataContext/properties/simpleProperties';
@@ -14,6 +16,7 @@ import {
   useSetProgressOnModule,
   useUserProgressOnModules,
 } from '../../context/UserDataContext/properties/userProgress';
+import useStickyState from '../../hooks/useStickyState';
 import { ModuleInfo } from '../../models/module';
 import { SolutionInfo } from '../../models/solution';
 import { MdxFrontmatter } from '../../types/content';
@@ -28,43 +31,48 @@ import NotSignedInWarning from './NotSignedInWarning';
 import TableOfContentsBlock from './TableOfContents/TableOfContentsBlock';
 import TableOfContentsSidebar from './TableOfContents/TableOfContentsSidebar';
 
-const ContentContainer = ({ children, tableOfContents, wide = false }) => (
-  <main
-    className="relative overflow-x-hidden pt-6 focus:outline-hidden lg:pt-2"
-    tabIndex={0}
-  >
-    <div className="mx-auto">
-      <div className="flex justify-center">
-        {/* Placeholder for the sidebar */}
-        <div
-          className="order-1 hidden shrink-0 lg:block"
-          style={{ width: '20rem' }}
-        />
-        {tableOfContents.length > 1 && (
-          <div className="order-3 mt-48 mr-6 ml-6 hidden w-64 shrink-0 2xl:block">
-            <TableOfContentsSidebar tableOfContents={tableOfContents} />
-          </div>
-        )}
-        <div
-          className={`order-2 w-0 min-w-0 flex-1 overflow-x-auto px-4 sm:px-6 lg:px-8 ${
-            wide ? 'max-w-7xl' : 'max-w-4xl'
-          }`}
-        >
-          <div className="hidden lg:block">
-            <NavBar />
-            <div className="h-8" />
-          </div>
+const ContentContainer = ({ children, tableOfContents, wide = false }) => {
+  const { isDesktopSidebarHidden } = useMarkdownLayout();
+  return (
+    <main
+      className="relative overflow-x-hidden pt-6 focus:outline-hidden lg:pt-2"
+      tabIndex={0}
+    >
+      <div className="mx-auto">
+        <div className="flex justify-center">
+          {/* Placeholder for the sidebar */}
+          {!isDesktopSidebarHidden && (
+            <div
+              className="order-1 hidden shrink-0 lg:block"
+              style={{ width: '20rem' }}
+            />
+          )}
+          {tableOfContents.length > 1 && (
+            <div className="order-3 mt-48 mr-6 ml-6 hidden w-64 shrink-0 2xl:block">
+              <TableOfContentsSidebar tableOfContents={tableOfContents} />
+            </div>
+          )}
+          <div
+            className={`order-2 w-0 min-w-0 flex-1 overflow-x-auto px-4 sm:px-6 lg:px-8 ${
+              wide ? 'max-w-7xl' : 'max-w-4xl'
+            }`}
+          >
+            <div className="hidden lg:block">
+              <NavBar />
+              <div className="h-8" />
+            </div>
 
-          {children}
+            {children}
 
-          <div className="pt-4 pb-6">
-            <NavBar alignNavButtonsRight={false} />
+            <div className="pt-4 pb-6">
+              <NavBar alignNavButtonsRight={false} />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </main>
-);
+    </main>
+  );
+};
 
 interface MarkdownLayoutProps {
   frontmatter: MdxFrontmatter[];
@@ -82,6 +90,10 @@ export default function MarkdownLayout({
   const lang = useUserLangSetting();
 
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+  const [isDesktopSidebarHidden, setIsDesktopSidebarHidden] = useStickyState(
+    false,
+    'guide:isDesktopSidebarHidden'
+  );
   const moduleProgress =
     (userProgressOnModules && userProgressOnModules[markdownData.id]) ||
     'Not Started';
@@ -130,6 +142,8 @@ export default function MarkdownLayout({
         uniqueID: null, // legacy, remove when classes is removed
         isMobileNavOpen,
         setIsMobileNavOpen,
+        isDesktopSidebarHidden,
+        setIsDesktopSidebarHidden,
         moduleProgress,
         handleCompletionChange,
       }}

--- a/src/context/MarkdownLayoutContext.tsx
+++ b/src/context/MarkdownLayoutContext.tsx
@@ -17,6 +17,8 @@ const MarkdownLayoutContext = createContext<{
   uniqueID: string | null;
   isMobileNavOpen: boolean;
   setIsMobileNavOpen: (x: boolean) => void;
+  isDesktopSidebarHidden: boolean;
+  setIsDesktopSidebarHidden: (x: boolean) => void;
   moduleProgress: ModuleProgress;
   handleCompletionChange: (x: ModuleProgress) => void;
 } | null>(null);


### PR DESCRIPTION
Closes #3998

Adds manual control over the desktop sidebar on module/solution pages, as requested in #3998:

- A hide button (chevrons) in the sidebar header collapses the sidebar on any screen size.
- When collapsed, a small floating button in the top-left corner brings it back.
- The content column re-centers in the freed space, addressing the original request that content "look much better centre aligned on the screen with some whitespace."
- The preference is persisted per-device in localStorage (via the existing `useStickyState` hook), so it survives page navigation and reloads. It's intentionally not synced to Firebase since the preference is screen-size dependent (e.g. hidden on a laptop, visible on an ultrawide).

Mobile behavior is unchanged.

### Implementation notes

- `isDesktopSidebarHidden` / `setIsDesktopSidebarHidden` are added to `MarkdownLayoutContext`, provided by `MarkdownLayout`.
- `DesktopSidebar` renders either the full sidebar (with the new hide button next to the logo) or the floating show button.
- The sidebar placeholder column in `ContentContainer` is skipped when the sidebar is hidden.

Verified locally in a browser: toggling both directions works, and the hidden state persists across full page loads and client-side navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)