### PR TITLE
Use rounded squares for resource status markers

### DIFF
--- a/src/components/markdown/ResourceStatusCheckbox.tsx
+++ b/src/components/markdown/ResourceStatusCheckbox.tsx
@@ -217,7 +217,7 @@ export default function ResourcestatusCheckbox({
           className={
             `inline-block ${
               size === 'small' ? 'h-6 w-6' : 'h-8 w-8'
-            } cursor-pointer rounded-full transition duration-100 ease-out ` +
+            } cursor-pointer rounded-md transition duration-100 ease-out ` +
             color[status]
           }
         />


### PR DESCRIPTION
## Summary

Resources and problems previously used identical colored status circles, so when skimming a module it was easy to mistake one for the other (reported in #5532). This changes resource status markers to rounded squares while problems (and module dots) keep their circles — shape now encodes item type, color still encodes status.

One-line change in `ResourceStatusCheckbox.tsx` (`rounded-full` → `rounded-md`), so both the small and large marker sizes pick it up everywhere resources appear. Status dropdown, hover states, and dark mode are unchanged.

Closes #5532

🤖 Generated with [Claude Code](https://claude.com/claude-code)