### PR TITLE
Remove dead acmicpc.net link from Olympiads

### DIFF
--- a/content/1_General/Olympiads.mdx
+++ b/content/1_General/Olympiads.mdx
@@ -63,7 +63,6 @@ links.
 
 - Older Problems
   - [TJ website](http://tjsct.wikidot.com/usaco/)
-  - [Korean website to submit ...](https://www.acmicpc.net/category/106)
 - [USACO Training](http://train.usaco.org/usacogate)
   - Legacy training system
   - Does not contain some recent topics (e.g. segment tree)


### PR DESCRIPTION
Fixes #6235.

The Korean site for submitting older USACO problems (`acmicpc.net/category/106`) is down indefinitely, so this removes the link. The TJ website link was already `http`, so no change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)