### PR TITLE
Infer division from modules when sorting non-USACO problems by difficulty

### DIFF
--- a/src/components/ProblemsPage/ProblemHits.tsx
+++ b/src/components/ProblemsPage/ProblemHits.tsx
@@ -30,6 +30,30 @@ interface ProblemHitProps {
   hit: AlgoliaProblemInfoHit;
 }
 
+const difficultySortOrder = {
+  'Very Easy': 1,
+  Easy: 2,
+  Normal: 3,
+  Hard: 4,
+  'Very Hard': 5,
+  Insane: 6,
+  'N/A': 0,
+};
+const divisionFactor = {
+  Bronze: 0,
+  Silver: 10,
+  Gold: 20,
+  Platinum: 30,
+  Advanced: 40,
+};
+const sectionToDivision = {
+  bronze: 'Bronze',
+  silver: 'Silver',
+  gold: 'Gold',
+  plat: 'Platinum',
+  adv: 'Advanced',
+};
+
 function getContestDateForProblem(
   division: string,
   problemId: string
@@ -49,6 +73,24 @@ function getProblemDivision(problemId: string): string {
     }
   }
   return null;
+}
+/**
+ * The division a problem sorts under: its USACO division if it's a USACO
+ * problem, otherwise the lowest division among the modules it appears in
+ * (modules in the General section don't correspond to a division).
+ */
+function getSortDivision(hit: AlgoliaProblemInfoHit): string | null {
+  const usacoDivision = getProblemDivision(hit.objectID);
+  if (usacoDivision) return usacoDivision;
+
+  let lowest: string | null = null;
+  for (const { id: moduleID } of hit.problemModules ?? []) {
+    const division = sectionToDivision[moduleIDToSectionMap[moduleID]];
+    if (!division) continue;
+    if (lowest === null || divisionFactor[division] < divisionFactor[lowest])
+      lowest = division;
+  }
+  return lowest;
 }
 function getContestURL(source: string) {
   let resultsUrl = '';
@@ -248,22 +290,6 @@ export default function ProblemHits({ shuffle, random, sort }) {
     React.useState<AlgoliaProblemInfoHit[]>(hits);
   const userProgressOnProblems = useUserProgressOnProblems();
 
-  const difficultySortOrder = {
-    'Very Easy': 1,
-    Easy: 2,
-    Normal: 3,
-    Hard: 4,
-    'Very Hard': 5,
-    Insane: 6,
-    'N/A': 0,
-  };
-  const divisionFactor = {
-    Bronze: 0,
-    Silver: 10,
-    Gold: 20,
-    Platinum: 30,
-  };
-
   function shuffleArr(arr: AlgoliaProblemInfoHit[]) {
     const nArr = [...arr];
     let l = nArr.length;
@@ -291,8 +317,8 @@ export default function ProblemHits({ shuffle, random, sort }) {
     }
 
     withoutNA.sort((a, b) => {
-      const aDivision = getProblemDivision(a.objectID);
-      const bDivision = getProblemDivision(b.objectID);
+      const aDivision = getSortDivision(a);
+      const bDivision = getSortDivision(b);
       const aOrder =
         (difficultySortOrder[a.difficulty] || 0) +
         (aDivision ? divisionFactor[aDivision] : 0);


### PR DESCRIPTION
Closes #5681.

## Problem

Sorting the problems page by *Difficulty (Ascending)* keys on `difficultySortOrder[difficulty] + divisionFactor[division]`, but `getProblemDivision` only looks in `div_to_probs.json`, which contains USACO problems only. Every non-USACO problem fell back to offset `0` (Bronze), so it interleaved with Bronze regardless of how advanced the topic is — which visibly breaks the difficulty bands (e.g. on [2D Range Queries](https://usaco.guide/problems?modules=2D%20Range%20Queries&sort=Difficulty%20%28Ascending%29) the Normal-rated problems show up in several disjoint clumps).

## Change

`getSortDivision(hit)` returns the USACO division when there is one, and otherwise the **lowest division among the modules the problem appears in**, resolved through `moduleIDToSectionMap`. An `Advanced` band (offset 40) is added above Platinum for `adv`-section modules.

General-section modules map to no division, so they're skipped when taking the minimum; a problem appearing only in general modules keeps the previous offset of `0`. (In practice only a handful of problems live in general modules, and they're intro-level.)

The difficulty-order and division-offset constants moved to module scope — they're pure constants and the new helper needs them.

## Re: #5681

That issue asked for sorting on the problems page, specifically *"First Section (B/S/G/Plat/Adv) then Difficulty."* The sort dropdown itself landed in 1a6b78b82, and the difficulty sort is section-major by construction — but the section offsets only resolved for USACO problems, so the requested B/S/G/Plat progression didn't actually materialize on module pages dominated by non-USACO problems. This PR makes it hold for those, and adds the `Advanced` band the request named.

Two smaller gaps remain, neither blocking IMO:

- The sort is client-side over the current page of hits (24/32/48), so it orders each page independently rather than globally. Unchanged by this PR.
- There's no standalone "Section" sort option — section ordering is only available bundled into the difficulty sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
