### PR TITLE
Fix dead JOI 2015 Navigation link, drop stale imgur comment and empty file

### DIFF
--- a/content/5_Plat/Sweep_Line.mdx
+++ b/content/5_Plat/Sweep_Line.mdx
@@ -129,8 +129,6 @@ result in 6 points in the corners and sides of the bounding rectangle.
 
 ![Worst-case bounding box arrangement](/content/5_Plat/assets/sweeplineboundingbox.png)
 
-<!--- https://i.imgur.com/FuvFPUR.png -->
-
 To achieve the desired $\mathcal{O}(n)$ complexity per layer, we need to be able
 to efficiently get the points sorted by both x-coordinate (for dividing $P$) and
 y-coordinate (for matching between $L'$ and $R'$). This can be achieved by

--- a/content/6_Advanced/Interactive.problems.json
+++ b/content/6_Advanced/Interactive.problems.json
@@ -257,7 +257,7 @@
     {
       "uniqueId": "joi-15-navigation",
       "name": "2015 - Navigation",
-      "url": "https://dunjudge.me/analysis/problems/762/",
+      "url": "https://qoj.ac/problem/1212",
       "source": "JOI",
       "difficulty": "Normal",
       "isStarred": false,


### PR DESCRIPTION
Three small cleanups found while auditing the link rot reported in #6000.

## 1. `JOI 2015 - Navigation` → QOJ

`https://dunjudge.me/analysis/problems/762/` returns a Cloudflare **525** (origin unreachable), confirmed on two attempts ~20s apart. dunjudge has largely been superseded by codebreaker.xyz, but the problem did **not** migrate — of codebreaker's 2,121 problems, the only two named Navigation are APIO 2026 and JOI Spring Camp 2021, and just 8 problems from the JOI 2014/2015 era exist there at all. It isn't on oj.uz either (`JOI15_navigation` and variants hit oj.uz's soft-404).

It *is* on QOJ with an English statement: https://qoj.ac/problem/1212. Verified as the same task — the statement's routines

```c
void Anna(int K, int N, int T, int A[], int B[])
void Flag(int I, int V)
void Bruno(int K, int S, int F, int L, int P[], int Q[])
void Answer(int X)
```

match `solutions/advanced/joi-15-navigation.mdx` exactly (tree of "IOI Islands", one flag per island, navigate to target `T`). Same problem as JOISC 2015 task J, 道案内, on AtCoder — QOJ is preferred here since AtCoder carries no English statement, and it matches the judge preference discussed in #6000.

Used the bare `/problem/1212` form to match the repo's dominant convention (22 of 32 existing qoj links).

## 2. Stale imgur comment

`content/5_Plat/Sweep_Line.mdx` had `<!--- https://i.imgur.com/FuvFPUR.png -->` sitting directly under the image it was replaced by, which already lives in `content/5_Plat/assets/sweeplineboundingbox.png`.

## 3. Empty `a.txt`

`public/solutions/advanced/ac-GameOnTree/a.txt` is 0 bytes and referenced nowhere — `ac-GameOnTree.mdx:27` only uses `gameontree.png` from that directory, and both were added in the same commit, so it looks like a stray drag-and-drop. It's the only empty tracked file in the repo.

## Verification

`yarn prebuild` indexes cleanly (only pre-existing LaTeX warnings). No generated-file churn included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)