### PR TITLE
Block crawlers from parameterized /problems URLs to stop Algolia quota burn

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+# /problems filter/tag/pagination URLs (anything with a query string) are an
+# unbounded crawl space; each crawled URL fires live Algolia queries when
+# rendered. Keep bots on the bare /problems page only.
+Disallow: /problems?

--- a/src/components/ProblemsPage/TagsRefinementList.tsx
+++ b/src/components/ProblemsPage/TagsRefinementList.tsx
@@ -16,6 +16,7 @@ export default function TagsRefinementList() {
         <div key={item.label}>
           <a
             href={createURL(item.value)}
+            rel="nofollow"
             className={`${
               item.isRefined
                 ? 'font-medium text-gray-700 dark:text-blue-500'


### PR DESCRIPTION
## Problem

Algolia has been sending quota warnings since ~Aug 3: the app burned 80% of its **Search requests** quota within two days of the Aug 5–Sep 4 usage period starting. The dashboard usage chart shows search requests jumping from a ~2–3K/day baseline (all of July) to ~22K on **Aug 1**, climbing to ~51K/day by Aug 4 — a 15–20× increase. (Distinct from #6069, which was the indexing quota.)

## Cause

Aug 1 is the day #6424 ("Sync Problems Page filters with the URL") merged. Enabling `routing` on `<InstantSearch>` made `createURL` produce real URLs where it previously produced dead `#` links:

- `TagsRefinementList` renders an `<a href>` for every tag (100+ links like `/problems?tags=DP`), and since refining **adds** a tag to the current state, tag links compose into multi-tag URL combinations.
- The `Pagination` widget renders `?page=N` links — ~150 pages per filter state, with `showLast` exposing the deepest ones.

That is a combinatorially unbounded crawl space (a classic faceted-search crawler trap). Search-engine bots render each URL with JavaScript and fire live Algolia queries per page. The multi-day ramp (22K → 42K → 51K) matches a crawl frontier expanding, not a per-user bug — measured interactive behavior is fine (1–2 requests per page load / keystroke burst / filter change, 200ms-debounced search box, no idle loop). The production robots.txt currently contains no directives at all.

## Fix

- Add `public/robots.txt` with `Disallow: /problems?` — blocks any query-string /problems URL (robots.txt prefix matching, `?` is literal) while leaving the bare `/problems` page crawlable. Bots are stopped **before** rendering, so blocked URLs cost zero Algolia queries.
- Add `rel="nofollow"` to the tag links as a belt-and-braces hint (they are `preventDefault`-ed for real users anyway; the href only matters to crawlers and cmd+click).

Search-request volume should fall back toward baseline within a day or two of deploy as crawlers pick up the new robots.txt. Follow-up idea if desired: regenerate the Usage API key so the dashboard Search API Logs page works, to watch bot traffic die off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)