### PR TITLE
Serve empty search results to headless browsers

### DIFF
--- a/src/utils/algoliaLiteSearchClient.ts
+++ b/src/utils/algoliaLiteSearchClient.ts
@@ -5,4 +5,41 @@ const liteSearchClient = liteClient(
   'cdfadff49930ec4dc3327807edd10b8c'
 );
 
-export default liteSearchClient;
+// Headless browsers (navigator.webdriver === true) have been scraping the
+// /problems filter pages through rotating proxy IPs, firing enough live
+// queries to exhaust our Algolia search quota (see #6458). They ignore
+// robots.txt, so serve them empty results locally instead of hitting Algolia.
+const isAutomatedBrowser =
+  typeof navigator !== 'undefined' && navigator.webdriver;
+
+const emptySearchResult = (indexName: string) => ({
+  index: indexName,
+  hits: [],
+  nbHits: 0,
+  nbPages: 0,
+  page: 0,
+  hitsPerPage: 0,
+  facets: {},
+  exhaustiveNbHits: true,
+  processingTimeMS: 0,
+  query: '',
+  params: '',
+});
+
+const searchClient = isAutomatedBrowser
+  ? {
+      ...liteSearchClient,
+      search: (requests => {
+        const requestList = Array.isArray(requests)
+          ? requests
+          : requests.requests;
+        return Promise.resolve({
+          results: requestList.map(request =>
+            emptySearchResult('indexName' in request ? request.indexName : '')
+          ),
+        });
+      }) as typeof liteSearchClient.search,
+    }
+  : liteSearchClient;
+
+export default searchClient;


### PR DESCRIPTION
## Summary

Follow-up to #6458. The robots.txt fix stopped compliant crawlers, but Algolia usage kept climbing (~230K requests on Aug 7 alone, billing period now at 200%). Live Search API Logs show the remaining traffic is a `HeadlessChrome/151.0.0.0` scraper on rotating proxy IPs (US datacenter, Senegal, Vietnam, ...) systematically walking `/problems` tag-filter combinations (`tags:DFS + tags:DP + tags:KRT`, etc.) at 5-16K requests/hour. It ignores robots.txt and nofollow.

This PR stubs out the Algolia lite client when `navigator.webdriver === true` (set by headless/automated browsers, including this scraper, which isn't masking it): `search()` resolves locally with empty results, so no billed request is made. Real users are unaffected; all search surfaces (problems page, search modal, editor modals) share this client.

Not a silver bullet — a scraper that patches `navigator.webdriver` gets past it — but this bot isn't hiding, and this ships without Cloudflare access. A Cloudflare WAF rule (challenge `HeadlessChrome` UAs / `/problems?*`) remains the durable fix.

## Test plan

- `npx tsc --noEmit` passes
- Verify /problems search still works in a normal browser on the preview deploy
- Verify empty results in headless Chrome (`chrome --headless=new --dump-dom https://<preview>/problems`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
