### PR TITLE
Feat: filter problems by USACO contest year

### DIFF
--- a/src/components/ProblemsPage/Selection.tsx
+++ b/src/components/ProblemsPage/Selection.tsx
@@ -11,8 +11,6 @@ export type SelectionProps = UseRefinementListProps & {
   isMulti: boolean;
   transformLabel?: (label: string) => string;
   items?: { label: string; value: string | string[] }[];
-  /** Called with the labels of the selected options whenever they change. */
-  onRefine?: (labels: string[]) => void;
 };
 
 export default function Selection({
@@ -23,7 +21,6 @@ export default function Selection({
   isMulti,
   transformLabel: transform,
   items,
-  onRefine,
   ...props
 }: SelectionProps) {
   const { items: refineItems } = useRefinementList({
@@ -64,7 +61,6 @@ export default function Selection({
             [attribute]: selectedOptions.map(option => option.value).flat(),
           },
         }));
-        onRefine?.(selectedOptions.map(option => option.label));
       }}
       value={isMulti ? selected : (selected[0] ?? null)}
       isClearable

--- a/src/components/ProblemsPage/contestYears.ts
+++ b/src/components/ProblemsPage/contestYears.ts
@@ -1,0 +1,34 @@
+import divToProbs from '../markdown/ProblemsList/DivisionList/div_to_probs.json';
+
+// div_to_probs.json holds, per division, [USACO problem id, contest, name]
+// triples. The contest is the same string shown as "Contest: 2020 January" on
+// each hit, and always starts with the four-digit year.
+const contestYearByProblemId = new Map<string, number>();
+for (const problems of Object.values(divToProbs)) {
+  for (const [id, contest] of problems) {
+    const year = Number(contest.slice(0, 4));
+    if (!Number.isNaN(year)) contestYearByProblemId.set(`usaco-${id}`, year);
+  }
+}
+
+/** Every USACO contest year, ascending. */
+export const CONTEST_YEARS = [...new Set(contestYearByProblemId.values())].sort(
+  (a, b) => a - b
+);
+
+/**
+ * IDs of the USACO problems whose contest falls within [from, to]; a null bound
+ * is open-ended. Non-USACO problems have no contest year, so they never match.
+ */
+export function usacoProblemIdsInYearRange(
+  from: number | null,
+  to: number | null
+): Set<string> {
+  const ids = new Set<string>();
+  for (const [id, year] of contestYearByProblemId) {
+    if ((from === null || year >= from) && (to === null || year <= to)) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}

--- a/src/components/ProblemsPage/routing.ts
+++ b/src/components/ProblemsPage/routing.ts
@@ -18,9 +18,9 @@ const REFINEMENT_PARAMS: [param: string, attribute: string][] = [
   ['starred', 'isStarred'],
 ];
 
-// `sort` and `status` are managed by the problems page outside of
-// InstantSearch; preserve them when InstantSearch writes the URL.
-const EXTERNAL_PARAMS = ['sort', 'status'];
+// `sort`, `status` and the contest year bounds are managed by the problems page
+// outside of InstantSearch; preserve them when InstantSearch writes the URL.
+const EXTERNAL_PARAMS = ['sort', 'status', 'yearFrom', 'yearTo'];
 
 // Section label -> module IDs, matching the Section filter options
 const sectionModules: Record<string, string[]> = Object.fromEntries(

--- a/src/pages/problems/index.tsx
+++ b/src/pages/problems/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Chapter } from '../../../content/ordering';
 
 import {
@@ -7,6 +7,7 @@ import {
   Pagination,
   PoweredBy,
   useInstantSearch,
+  useRefinementList,
 } from 'react-instantsearch';
 
 import { GetStaticProps } from 'next';
@@ -14,6 +15,10 @@ import SECTIONS from '../../../content/ordering';
 import BlindModeToggle from '../../components/BlindModeToggle';
 import { difficultyClasses } from '../../components/DifficultyBox';
 import Layout from '../../components/layout';
+import {
+  CONTEST_YEARS,
+  usacoProblemIdsInYearRange,
+} from '../../components/ProblemsPage/contestYears';
 import ProblemHits from '../../components/ProblemsPage/ProblemHits';
 import {
   createRouting,
@@ -24,6 +29,7 @@ import Selection, {
   SelectionProps,
 } from '../../components/ProblemsPage/Selection';
 import TagsRefinementList from '../../components/ProblemsPage/TagsRefinementList';
+import Select from '../../components/Select';
 import SEO from '../../components/seo';
 import { SortButton } from '../../components/SortButton';
 import TopNavigationBar from '../../components/TopNavigationBar/TopNavigationBar';
@@ -56,6 +62,14 @@ const STATUS_OPTIONS = [
   'Solved',
 ];
 
+const YEAR_OPTIONS = CONTEST_YEARS.map(year => ({
+  label: String(year),
+  value: year,
+}));
+
+const FILTER_CELL_CLASS =
+  'tw-forms-disable-all-descendants col-span-2 sm:col-span-3 md:col-span-1 lg:col-span-2';
+
 /** Replaces the given query params in the URL without adding history entries. */
 function updateUrlParams(updates: Record<string, string[]>) {
   const url = new URL(window.location.href);
@@ -67,36 +81,88 @@ function updateUrlParams(updates: Record<string, string[]>) {
 }
 
 /**
- * Applies the Status filter (a list of status labels) by expanding it into the
- * matching problem IDs. Runs again when user progress loads / changes, since
- * the expansion depends on it.
+ * Applies the Status and contest year filters, neither of which corresponds to
+ * an indexed attribute, by expanding them into the matching problem IDs. Both
+ * refine on objectID, so they have to be intersected and written together.
+ * Runs again when user progress loads / changes, since the Status expansion
+ * depends on it.
  */
-function StatusFilterSync({
+function ProblemIdFilterSync({
   statuses,
+  yearFrom,
+  yearTo,
   problemIds,
 }: {
   statuses: string[];
+  yearFrom: number | null;
+  yearTo: number | null;
   problemIds: string[];
 }) {
   const userProgress = useUserProgressOnProblems();
   const { setIndexUiState } = useInstantSearch();
+  // A widget for objectID has to be mounted for the refinement below to reach
+  // the search; this one renders nothing, and its limit is kept small since its
+  // facet values are unused (the largest widget limit wins for the query).
+  useRefinementList({ attribute: 'objectID', limit: 1 });
+  // Whether the refinement below is currently applied, so that clearing the
+  // filters doesn't write an empty refinement (and fire a search) on mount
+  const isApplied = useRef(false);
   useEffect(() => {
-    if (!statuses.length) return;
-    const ids = problemIds.filter(id =>
-      statuses.includes(userProgress[id] ?? 'Not Attempted')
-    );
-    // No matches usually means user progress hasn't loaded yet; leave the
-    // results unfiltered instead of showing zero results
-    if (!ids.length) return;
-    setIndexUiState(prevIndexUiState => ({
-      ...prevIndexUiState,
-      refinementList: {
-        ...prevIndexUiState.refinementList,
-        objectID: [...ids, 'null'],
-      },
-    }));
-  }, [statuses, problemIds, userProgress]);
+    const setObjectIDs = (objectID: string[]) =>
+      setIndexUiState(prevIndexUiState => ({
+        ...prevIndexUiState,
+        refinementList: { ...prevIndexUiState.refinementList, objectID },
+      }));
+    const hasYearFilter = yearFrom !== null || yearTo !== null;
+    if (!statuses.length && !hasYearFilter) {
+      if (!isApplied.current) return;
+      isApplied.current = false;
+      setObjectIDs([]);
+      return;
+    }
+    let ids = problemIds;
+    if (statuses.length) {
+      const withStatus = ids.filter(id =>
+        statuses.includes(userProgress[id] ?? 'Not Attempted')
+      );
+      // No matches usually means user progress hasn't loaded yet; leave the
+      // results unfiltered instead of showing zero results
+      if (!withStatus.length) return;
+      ids = withStatus;
+    }
+    if (hasYearFilter) {
+      const inRange = usacoProblemIdsInYearRange(yearFrom, yearTo);
+      ids = ids.filter(id => inRange.has(id));
+    }
+    isApplied.current = true;
+    setObjectIDs([...ids, 'null']);
+  }, [statuses, yearFrom, yearTo, problemIds, userProgress]);
   return null;
+}
+
+function YearSelect({
+  placeholder,
+  value,
+  onChange,
+}: {
+  placeholder: string;
+  value: number | null;
+  onChange: (year: number | null) => void;
+}) {
+  return (
+    <Select
+      options={YEAR_OPTIONS}
+      value={YEAR_OPTIONS.find(option => option.value === value) ?? null}
+      onChange={(option: { value: number } | null) =>
+        onChange(option?.value ?? null)
+      }
+      isClearable
+      isSearchable={false}
+      placeholder={placeholder}
+      className="text-black dark:text-white"
+      classNamePrefix="select"
+    />
+  );
 }
 
 interface ProblemsPageProps {
@@ -104,16 +170,17 @@ interface ProblemsPageProps {
 }
 
 export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
-  const userProgress = useUserProgressOnProblems();
   const [shuffle, sendShuffle] = useState(0);
   const [random, sendRandom] = useState(0);
   const [sort, setSort] = useState('Relevance');
-  // Status labels selected via the URL or the Status dropdown; expanded into
-  // problem IDs by StatusFilterSync
+  // Status labels and USACO contest year bounds selected via the URL or their
+  // dropdowns; expanded into problem IDs by ProblemIdFilterSync
   const [statuses, setStatuses] = useState<string[]>([]);
+  const [yearFrom, setYearFrom] = useState<number | null>(null);
+  const [yearTo, setYearTo] = useState<number | null>(null);
   const routing = useMemo(createRouting, []);
   useEffect(() => {
-    // Restore the page-managed params (sort, status) from the URL;
+    // Restore the page-managed params (sort, status, years) from the URL;
     // InstantSearch's routing handles the rest
     const params = new URLSearchParams(window.location.search);
     const sortParam = params.get('sort');
@@ -122,7 +189,22 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
       .getAll('status')
       .filter(status => STATUS_OPTIONS.includes(status));
     if (statusParams.length) setStatuses(statusParams);
+    const yearParam = (param: string) => {
+      const year = Number(params.get(param));
+      return CONTEST_YEARS.includes(year) ? year : null;
+    };
+    setYearFrom(yearParam('yearFrom'));
+    setYearTo(yearParam('yearTo'));
   }, []);
+  /** Keeps the bounds ordered, so picking a From after the To moves both. */
+  const setYears = (from: number | null, to: number | null) => {
+    setYearFrom(from);
+    setYearTo(to);
+    updateUrlParams({
+      yearFrom: from === null ? [] : [String(from)],
+      yearTo: to === null ? [] : [String(to)],
+    });
+  };
   const selectionMetadata: SelectionProps[] = [
     {
       attribute: 'difficulty',
@@ -176,23 +258,6 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
         value: chapters.map(chapter => chapter.items).flat(),
       })),
     },
-    {
-      attribute: 'objectID',
-      limit: 500,
-      placeholder: 'Status',
-      searchable: false,
-      isMulti: true,
-      onRefine: labels => {
-        setStatuses(labels);
-        updateUrlParams({ status: labels });
-      },
-      items: STATUS_OPTIONS.map(label => ({
-        label,
-        value: problemIds.filter(
-          id => (userProgress[id] ?? 'Not Attempted') == label
-        ),
-      })),
-    },
   ];
   return (
     <Layout>
@@ -206,7 +271,12 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
           indexName={indexName}
           routing={routing}
         >
-          <StatusFilterSync statuses={statuses} problemIds={problemIds} />
+          <ProblemIdFilterSync
+            statuses={statuses}
+            yearFrom={yearFrom}
+            yearTo={yearTo}
+            problemIds={problemIds}
+          />
           <div className="bg-blue-600 px-5 py-16 dark:bg-blue-900">
             <div className="mx-auto mb-6 max-w-3xl">
               <h1 className="dark:text-dark-high-emphasis mb-6 text-center text-3xl font-bold text-white sm:text-5xl">
@@ -229,13 +299,60 @@ export default function ProblemsPage({ problemIds }: ProblemsPageProps) {
             <div className="col-span-5 px-1 py-0.5 sm:col-span-6 md:col-span-7 lg:col-span-8 xl:col-span-8">
               <div className="mb-5 grid grid-cols-1 items-center gap-x-5 gap-y-3 sm:grid-cols-2 lg:grid-cols-6">
                 {selectionMetadata.map(props => (
-                  <div
-                    className="tw-forms-disable-all-descendants col-span-2 sm:col-span-3 md:col-span-1 lg:col-span-2"
-                    key={props.attribute}
-                  >
+                  <div className={FILTER_CELL_CLASS} key={props.attribute}>
                     <Selection {...props} />
                   </div>
                 ))}
+                <div className={FILTER_CELL_CLASS}>
+                  <Select
+                    options={STATUS_OPTIONS.map(label => ({
+                      label,
+                      value: label,
+                    }))}
+                    value={statuses.map(label => ({ label, value: label }))}
+                    onChange={(selection: { value: string }[] | null) => {
+                      const labels = (selection ?? []).map(
+                        option => option.value
+                      );
+                      setStatuses(labels);
+                      updateUrlParams({ status: labels });
+                    }}
+                    isMulti
+                    isClearable
+                    isSearchable={false}
+                    placeholder="Status"
+                    className="text-black dark:text-white"
+                    classNamePrefix="select"
+                  />
+                </div>
+                <div className={FILTER_CELL_CLASS}>
+                  <YearSelect
+                    placeholder="From Year"
+                    value={yearFrom}
+                    onChange={year =>
+                      setYears(
+                        year,
+                        year !== null && yearTo !== null && year > yearTo
+                          ? year
+                          : yearTo
+                      )
+                    }
+                  />
+                </div>
+                <div className={FILTER_CELL_CLASS}>
+                  <YearSelect
+                    placeholder="To Year"
+                    value={yearTo}
+                    onChange={year =>
+                      setYears(
+                        year !== null && yearFrom !== null && year < yearFrom
+                          ? year
+                          : yearFrom,
+                        year
+                      )
+                    }
+                  />
+                </div>
               </div>
               <div className="mb-5 flex flex-wrap justify-center gap-3">
                 <button


### PR DESCRIPTION
Closes #6505.

Adds **From Year** / **To Year** dropdowns to `/problems`. Setting either bound restricts results to USACO problems whose contest falls in that range — non-USACO problems have no contest year, so they drop out, which gives the "USACO problems only" behavior the issue asked for. Either bound works alone as open-ended (`From Year 2020` = 2020 onward), and picking a From later than the current To bumps the To along so you can't land on an empty range by accident.

The year comes from `div_to_probs.json` — the same data behind the `Contest: 2020 January` label already shown on each hit. It covers 2015–2026; pre-2016 USACO (`Old Bronze`/`Old Silver`/`Old Gold`) isn't in that file, so those never match a year range.

### Implementation notes

Neither Status nor the year range maps to an indexed attribute, so both expand into `objectID` refinements. Two independent writers on one attribute clobber each other, so:

- **Status moved out of `Selection`** into a page-managed `Select`, and a single effect (`ProblemIdFilterSync`) writes the *intersection* of Status and the year range.
- **A refinement-list widget for `objectID` has to stay mounted** for that refinement to reach the search. The Status `Selection` used to provide it implicitly; removing it silently broke the filter (UI state set, query unchanged), so `ProblemIdFilterSync` now mounts a virtual one.
- `yearFrom` / `yearTo` are page-managed URL params, added to `EXTERNAL_PARAMS` so InstantSearch preserves them.

### Algolia usage

Held flat for the common case. A bare `/problems` visit writes no refinement and fires exactly the queries it did before. Using the filter costs one search per dropdown change, like any other filter; a shared link with `?yearFrom=…` costs two searches (initial + effect-applied), and a refined `objectID` adds one disjunctive-facet query per search — both identical to how `?status=` already behaves. `robots.txt` already disallows `/problems?` wholesale, so the new params inherit that protection.

### Testing

Verified manually against the dev server:

- `2020–2020` → 48 problems across all four 2020 contests; `2024–2025` and `2015–2016 + Difficulty=Easy` also correct
- URL round-trip on reload for `yearFrom` / `yearTo` / `status` / `difficulty` together
- From > To clamp bumps the other bound
- Status + year intersect (`Solved` + `2020` → 2 problems, both 2020)
- Clearing years leaves Status applied; clearing everything restores the full result set

`tsc`, `prettier`, and `eslint` are clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)