### PR TITLE
Fix incorrect module "Last Updated" timestamps in production

### DIFF
--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -218,11 +218,101 @@ async function indexMdxFiles(
   }
 }
 
+/**
+ * Vercel checks the repository out with a shallow clone (`--depth=10`), which
+ * makes every file look like it was added by the shallow boundary commit. That
+ * gives every module the same, very recent "Last Updated" timestamp instead of
+ * the time it was actually last edited. Deepen the clone before reading any
+ * timestamps; `--filter=blob:none` keeps it cheap since we only need commits
+ * and trees, not the contents of every historical revision.
+ *
+ * Memoized: the fetch only needs to happen once per process.
+ */
+let fullGitHistory: Promise<boolean> | null = null;
+
+function ensureFullGitHistory(): Promise<boolean> {
+  fullGitHistory ??= fetchFullGitHistory();
+  return fullGitHistory;
+}
+
+async function fetchFullGitHistory(): Promise<boolean> {
+  const { execFileSync } = await import('child_process');
+  const git = (args: string[]) =>
+    execFileSync('git', args, {
+      encoding: 'utf-8',
+      // Fail instead of hanging on a credential prompt for a private repo.
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5 * 60 * 1000,
+    }).trim();
+
+  let isShallow: string;
+  try {
+    isShallow = git(['rev-parse', '--is-shallow-repository']);
+  } catch (error) {
+    console.warn('Not a git repository; skipping module timestamps:', error);
+    return false;
+  }
+  if (isShallow !== 'true') return true;
+
+  const remote = getGitRemoteUrl(git);
+  if (!remote) {
+    console.warn(
+      'Shallow git repository with no known remote; skipping module timestamps.'
+    );
+    return false;
+  }
+
+  console.log(
+    `Shallow git repository detected, fetching history from ${remote}...`
+  );
+  try {
+    git(['fetch', '--filter=blob:none', '--unshallow', remote]);
+  } catch (error) {
+    console.warn('Failed to fetch full git history:', error);
+    return false;
+  }
+
+  if (git(['rev-parse', '--is-shallow-repository']) === 'true') {
+    console.warn('Repository is still shallow; skipping module timestamps.');
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Vercel clones without configuring a remote, so fall back to reconstructing
+ * the repository URL from the environment it exposes to builds.
+ */
+function getGitRemoteUrl(git: (args: string[]) => string): string | null {
+  try {
+    const origin = git(['remote', 'get-url', 'origin']);
+    if (origin) return origin;
+  } catch {
+    // No origin remote; fall through to the Vercel environment variables.
+  }
+
+  const host = {
+    github: 'github.com',
+    gitlab: 'gitlab.com',
+    bitbucket: 'bitbucket.org',
+  }[process.env.VERCEL_GIT_PROVIDER ?? ''];
+  const owner = process.env.VERCEL_GIT_REPO_OWNER;
+  const slug = process.env.VERCEL_GIT_REPO_SLUG;
+  if (!host || !owner || !slug) return null;
+
+  return `https://${host}/${owner}/${slug}.git`;
+}
+
 async function getBatchGitTimestamps(
   filePaths: string[]
 ): Promise<Map<string, string>> {
   const { execSync } = await import('child_process');
   const timestamps = new Map<string, string>();
+
+  // Without the full history git reports the shallow boundary commit for every
+  // file, so leave the timestamps empty rather than showing a wrong date.
+  if (!(await ensureFullGitHistory())) return timestamps;
 
   // Batch files to avoid Windows command line length limit (~8191 chars)
   const BATCH_SIZE = 50;


### PR DESCRIPTION
Fixes #6473.

## Root cause

Vercel checks out the repository with a shallow clone (`git clone --depth=10`). In a shallow clone the boundary commit looks like a root commit that *adds every file in the repo*, so `git log --format="%ct|%H" --name-only -- <files>` in `getBatchGitTimestamps` reports that commit for every module. Every module ends up with the same, very recent `git_author_time` — which is why https://usaco.guide/bronze shows everything as "12 hours ago" while a local (full) clone shows the real dates.

Reproduced directly:

```console
$ git clone --depth=10 https://github.com/cpinitiative/usaco-guide.git && cd usaco-guide
$ git log --format="%ct|%H" --name-only -- content/2_Bronze/Time_Comp.mdx
1786213179|1558e813...      # the shallow boundary commit — hours old

content/2_Bronze/Time_Comp.mdx

# full clone, same file:
1780602513|b25293af...      # 2026-06-04, the real last edit
```

## Fix

Deepen the clone once, before any timestamps are read:

- `git fetch --filter=blob:none --unshallow <remote>` — the blobless filter keeps it cheap, since `git log --name-only` only needs commits and trees, not the contents of every historical revision. It adds ~4s to the build (vs. ~35s for a full unshallow of this repo's 30k commits).
- Vercel clones **without configuring a remote**, so if `git remote get-url origin` fails, the URL is reconstructed from the `VERCEL_GIT_PROVIDER` / `VERCEL_GIT_REPO_OWNER` / `VERCEL_GIT_REPO_SLUG` build env vars.
- `GIT_TERMINAL_PROMPT=0` and a timeout so a private/unauthenticated remote fails fast instead of hanging the build.
- If the history still can't be fetched, `getBatchGitTimestamps` returns no timestamps at all rather than the shallow boundary commit's date — the UI already hides "Last Updated" when `gitAuthorTime` is null, so it degrades to showing nothing instead of showing something wrong.

No behavior change for full clones (local dev, `yarn dev`, watch mode): the shallow check short-circuits and the fetch never runs.

## Testing

End-to-end, running the real `scripts/index-content.ts` inside a `--depth=10` clone with `origin` removed and the `VERCEL_GIT_*` vars set (i.e. simulating the Vercel build environment):

```
Shallow git repository detected, fetching history from https://github.com/cpinitiative/usaco-guide.git...
=== Content Indexed Successfully ===
Took 19.75 seconds
```

Resulting Bronze timestamps — byte-for-byte identical to indexing from a full clone, and 0 null timestamps:

| module | git_author_time |
| --- | --- |
| intro-ds | 2026-06-04T19:48:33.000Z |
| time-comp | 2026-06-04T19:48:33.000Z |
| complete-rec | 2026-04-28T09:26:44.000Z |
| ad-hoc | 2026-03-14T14:26:22.000Z |
| casework | 2025-09-07T19:14:05.000Z |

Also verified the fallback path (shallow clone, no remote, no `VERCEL_GIT_*`): logs `Shallow git repository with no known remote; skipping module timestamps.`, indexing completes normally, timestamps are null. And re-ran indexing in the full local clone to confirm identical output to before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzMi2a6awW44tVarJK365V