### PR TITLE
Count .problems.json edits towards a module's "Last Updated"

### DIFF
--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -174,15 +174,21 @@ async function indexMdxFiles(
     `);
 
   // Batch git commands for performance
-  const gitTimestamps = await getBatchGitTimestamps(
-    files.map(f => path.join(baseDir, f))
-  );
+  const mdxPaths = files.map(f => path.join(baseDir, f));
+  const gitTimestamps = await getGitTimestamps([
+    ...mdxPaths,
+    // Solutions don't have problem lists.
+    ...(type === 'module' ? mdxPaths.map(problemsJsonPath) : []),
+  ]);
 
   const transaction = db.transaction(
     (items: Array<{ content: MdxContent }>) => {
       for (const { content } of items) {
-        const gitTime =
-          gitTimestamps.get(path.resolve(content.fileAbsolutePath)) || null;
+        const gitTime = getLastUpdated(
+          gitTimestamps,
+          content.fileAbsolutePath,
+          type
+        );
 
         insertStmt.run(
           content.frontmatter.id,
@@ -216,6 +222,35 @@ async function indexMdxFiles(
     );
     transaction(items);
   }
+}
+
+/**
+ * A module's problem list lives in a sibling `<name>.problems.json`, so editing
+ * that file changes what the module renders just like editing the .mdx does.
+ * Both count towards the module's "Last Updated" timestamp.
+ *
+ * Not every module has one (a few General modules have no problems), and
+ * `git log` simply reports nothing for a path that was never committed, so a
+ * missing file needs no special handling.
+ */
+function problemsJsonPath(mdxPath: string): string {
+  return mdxPath.replace(/\.mdx$/, '.problems.json');
+}
+
+function getLastUpdated(
+  timestamps: Map<string, string>,
+  mdxPath: string,
+  type: 'module' | 'solution'
+): string | null {
+  const resolved = path.resolve(mdxPath);
+  const mdxTime = timestamps.get(resolved);
+  if (type === 'solution') return mdxTime ?? null;
+
+  const problemsTime = timestamps.get(problemsJsonPath(resolved));
+  if (!mdxTime) return problemsTime ?? null;
+  if (!problemsTime) return mdxTime;
+  // ISO-8601 UTC strings sort chronologically.
+  return problemsTime > mdxTime ? problemsTime : mdxTime;
 }
 
 /**
@@ -304,49 +339,58 @@ function getGitRemoteUrl(git: (args: string[]) => string): string | null {
   return `https://${host}/${owner}/${slug}.git`;
 }
 
-async function getBatchGitTimestamps(
+/**
+ * Maps each path to the ISO time of the last commit that touched it.
+ *
+ * Deliberately one `git log` per file: handing several pathspecs to a single
+ * `git log` evaluates history simplification against the union of them, which
+ * silently changes the answer for individual files (it moved ~15% of the
+ * content files here, mostly onto the date of a repo-wide reformat that left
+ * their content untouched). Running one process per file is also *faster*,
+ * since `-1` lets git stop at the first matching commit instead of walking the
+ * whole history once per batch.
+ */
+async function getGitTimestamps(
   filePaths: string[]
 ): Promise<Map<string, string>> {
-  const { execSync } = await import('child_process');
   const timestamps = new Map<string, string>();
 
   // Without the full history git reports the shallow boundary commit for every
   // file, so leave the timestamps empty rather than showing a wrong date.
   if (!(await ensureFullGitHistory())) return timestamps;
 
-  // Batch files to avoid Windows command line length limit (~8191 chars)
-  const BATCH_SIZE = 50;
+  const { execFile } = await import('child_process');
+  const { promisify } = await import('util');
+  const run = promisify(execFile);
 
-  for (let i = 0; i < filePaths.length; i += BATCH_SIZE) {
-    const batch = filePaths.slice(i, i + BATCH_SIZE);
-
-    try {
-      const result = execSync(
-        `git log --format="%ct|%H" --name-only -- ${batch.map(f => `"${f}"`).join(' ')}`,
-        { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
-      );
-
-      const lines = result.split('\n');
-      let currentTimestamp: string | null = null;
-
-      for (const line of lines) {
-        if (line.includes('|')) {
-          const [timestamp] = line.split('|');
-          currentTimestamp = new Date(parseInt(timestamp) * 1000).toISOString();
-        } else if (line.trim() && currentTimestamp) {
-          const resolvedPath = path.resolve(line.trim());
-          if (!timestamps.has(resolvedPath)) {
-            timestamps.set(resolvedPath, currentTimestamp);
+  const CONCURRENCY = 16;
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: CONCURRENCY }, async () => {
+      while (next < filePaths.length) {
+        const filePath = filePaths[next++];
+        try {
+          const { stdout } = await run('git', [
+            'log',
+            '-1',
+            '--format=%ct',
+            '--',
+            filePath,
+          ]);
+          // Empty for a path that was never committed.
+          const seconds = parseInt(stdout.trim(), 10);
+          if (!isNaN(seconds)) {
+            timestamps.set(
+              path.resolve(filePath),
+              new Date(seconds * 1000).toISOString()
+            );
           }
+        } catch (error) {
+          console.warn(`Failed to get git timestamp for ${filePath}:`, error);
         }
       }
-    } catch (error) {
-      console.warn(
-        `Failed to get git timestamps for batch ${Math.floor(i / BATCH_SIZE) + 1}:`,
-        error
-      );
-    }
-  }
+    })
+  );
 
   return timestamps;
 }
@@ -739,8 +783,10 @@ async function prepareMdxInsert(relPath: string, absPath: string) {
     ? 'module'
     : 'solution';
 
-  const gitTimestamps = await getBatchGitTimestamps([absPath]);
-  const gitTime = gitTimestamps.get(path.resolve(absPath)) || null;
+  const gitTimestamps = await getGitTimestamps(
+    type === 'module' ? [absPath, problemsJsonPath(absPath)] : [absPath]
+  );
+  const gitTime = getLastUpdated(gitTimestamps, absPath, type);
 
   const division =
     type === 'module' ? moduleIDToSectionMap[content.frontmatter.id] : null;


### PR DESCRIPTION
Follow-up to #6510.

## `.problems.json` counts towards "Last Updated"

A module's problem list lives in a sibling `<name>.problems.json`, so editing it changes what the module renders just as much as editing the `.mdx`. The indexer now takes the later of the two commit times.

All 145 `.problems.json` files pair 1:1 with an `.mdx` of the same name (verified: 0 orphan JSONs, and every `MODULE_ID` matches its sibling's frontmatter `id`). Three General modules have no problem list — `Debugging_Cpp`, `Olympiads`, `Resources_USA-specific` — and keep using their `.mdx` time alone; `git log` reports nothing for a path that was never committed, so they need no special-casing. `content/extraProblems.json` has no module page, so it's not involved.

Effect on Bronze:

| module | before | after | why |
| --- | --- | --- | --- |
| bronze-conclusion | 2023-02-19 | 2026-08-03 | `Conclusion.problems.json` updated |
| casework | 2025-09-07 | 2026-06-19 | `Casework.problems.json` updated |
| intro-greedy | 2026-03-14 | 2026-06-14 | problems.json newer |
| time-comp | 2026-06-04 | 2026-06-04 | problems.json older, correctly ignored |

## One `git log` per file instead of 50 pathspecs per call

While testing the above I found the existing batching was itself producing wrong dates, so this commit also replaces it. `git log --name-only -- <50 paths>` evaluates history simplification against the **union** of the pathspecs, so whether a given commit survives pruning depends on the other 49 files in the batch. **151 of 980 content files got a different timestamp that way** than `git log -1 -- <file>` gives.

Concrete case — `content/2_Bronze/Ad_Hoc.mdx`:

```console
$ git log -1 --format=%cI -- content/2_Bronze/Ad_Hoc.mdx
2025-09-21T15:23:40+05:30        # correct

# batched with 49 other paths:
2026-03-14                       # commit 0bcc89ca, "add formatting changes"
```

That reformat commit added a trailing newline that was *already* on master via a pre-commit hook, so the merge left the file's content unchanged — single-path history simplification correctly prunes it, the union-pathspec walk does not. Roughly 100 modules were showing the date of that repo-wide reformat rather than their real last edit.

Switched to one `git log -1 --format=%ct -- <file>` per path, 16 at a time. This is also what the old Gatsby setup did (`gatsby-transformer-gitinfo`), and it's **faster**, not slower: `-1` lets git stop at the first matching commit instead of walking all 30k commits once per batch.

| approach | 1125 paths |
| --- | --- |
| batched, 50 pathspecs/call | 7.5s |
| per-file, 16 concurrent | 5.5s |

Full `prebuild` went from 16.2s to 13.9s. Using `execFile` with an args array also removes the Windows command-line-length limit that motivated the batching, along with the manual path quoting.

## Verification

Re-indexed the full local repo on top of merged `master`: 0 null timestamps across all 980 modules and solutions, and spot-checked values match `git log -1` exactly, including the max-of-two cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzMi2a6awW44tVarJK365V