### PR TITLE
Patch form-data advisories (GHSA-fjxv-7rqg-78g4, GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "axios": "^1.18.0",
     "bad-words": "^4.0.0",
     "better-sqlite3": "^12.6.2",
-    "broken-link-checker": "^0.7.8",
     "child_process": "^1.0.2",
     "chokidar": "^5.0.0",
     "chromatic": "^15.0.0",
@@ -121,6 +120,7 @@
     "@types/react-lifecycles-compat": "^3",
     "@types/seedrandom": "^3",
     "@types/throttle-debounce": "^5",
+    "broken-link-checker": "^0.7.8",
     "cssnano": "^7.1.0",
     "eslint": "^9",
     "eslint-config-next": "15.4.5",
@@ -128,6 +128,9 @@
     "rimraf": "^6.1.3",
     "tailwindcss": "^4",
     "typescript": "^5.9.2"
+  },
+  "resolutions": {
+    "form-data@~2.3.2": "^2.5.6"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "typescript": "^5.9.2"
   },
   "resolutions": {
-    "form-data@~2.3.2": "^2.5.6"
+    "request/form-data": "^2.5.6"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7627,7 +7627,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.6":
+"combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
@@ -10140,41 +10140,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^2.5.5":
-  version: 2.5.5
-  resolution: "form-data@npm:2.5.5"
+"form-data@npm:^2.5.5, form-data@npm:^2.5.6":
+  version: 2.5.6
+  resolution: "form-data@npm:2.5.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
+    hasown: "npm:^2.0.4"
     mime-types: "npm:^2.1.35"
     safe-buffer: "npm:^5.2.1"
-  checksum: 10c0/7fb70447849fc9bce4d01fe9a626f6587441f85779a2803b67f803e1ab52b0bd78db0a7acd80d944c665f68ca90936c327f1244b730719b638a0219e98b20488
+  checksum: 10c0/de6b085a2b0d013299ccc888b677dbdb3d2a54ef8d74982bda9ad7d928f57440abae1bc736a5b85ea01077cfb6c72e9a7752dc786304271c03bd0013ef8f08cb
   languageName: node
   linkType: hard
 
 "form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
-  languageName: node
-  linkType: hard
-
-"form-data@npm:~2.3.2":
-  version: 2.3.3
-  resolution: "form-data@npm:2.3.3"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.6"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/706ef1e5649286b6a61e5bb87993a9842807fd8f149cd2548ee807ea4fb882247bdf7f6e64ac4720029c0cd5c80343de0e22eee1dc9e9882e12db9cc7bc016a4
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -10724,6 +10713,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -13484,7 +13482,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:^2.1.35, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:^2.1.35, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:


### PR DESCRIPTION
Closes three open Dependabot alerts, all on `form-data`:

| Alert | Advisory | Severity | Vulnerable | Fixed in |
|---|---|---|---|---|
| [#355](https://github.com/cpinitiative/usaco-guide/security/dependabot/355) | GHSA-fjxv-7rqg-78g4 — unsafe `Math.random()` multipart boundary | critical | `< 2.5.4` | 2.5.4 |
| [#633](https://github.com/cpinitiative/usaco-guide/security/dependabot/633) | GHSA-hmw2-7cc7-3qxx — CRLF injection | high | `< 2.5.6` | 2.5.6 |
| [#634](https://github.com/cpinitiative/usaco-guide/security/dependabot/634) | GHSA-hmw2-7cc7-3qxx — CRLF injection | high | `>= 4.0.0, < 4.0.6` | 4.0.6 |

## Why Dependabot couldn't do this itself

The 2.x copy behind #355/#633 arrives through a fully unmaintained chain:

```
broken-link-checker@0.7.8   (latest published, Jun 2022)
└─ robot-directives@~0.3.0  (Jun 2022)
   └─ useragent@^2.1.8      (latest published, Jun 2022)
      └─ request@^2.88.0    (deprecated 2020, final release)
         └─ form-data@~2.3.2  →  2.3.3   ← vulnerable
```

`~2.3.2` means `>=2.3.2 <2.4.0`, so 2.5.6 is out of range. Dependabot only opens a PR when some version combination satisfies every declared range — it won't rewrite a third party's manifest. Fixing this would require bumping an ancestor, but every ancestor is already at its newest published version and `request` is deprecated, so no such release exists or ever will.

## Changes

- Added a `resolutions` entry (the file had none) unpinning only the copy `request` pulls in:
  ```json
  "resolutions": { "request/form-data": "^2.5.6" }
  ```
  `@types/request`'s `^2.5.5` and `axios`'s `^4.0.5` are untouched by it. The nested-path key form is used deliberately: Vercel installs with Yarn 1.22 (it doesn't honor `packageManager` without `ENABLE_EXPERIMENTAL_COREPACK`), and Yarn 1 mis-parses the Yarn 4 descriptor form `form-data@~2.3.2` into the range `~2.3.2@^2.5.6` and fails the install. `request/form-data` is understood by both.
- Ran `yarn up -R form-data` to refresh the other copies within their existing ranges.
- Moved `broken-link-checker` from `dependencies` to `devDependencies` — it's only invoked by the manual `check-links` script and isn't imported anywhere in `src/`, `scripts/`, or CI. This also drops the `runtime` scope label from the alerts.

Resulting tree:

```
├─ @types/request@2.48.13 └─ form-data@2.5.6  (was 2.5.5)
├─ axios@1.18.0           └─ form-data@4.0.6  (was 4.0.5)
└─ request@2.88.2         └─ form-data@2.5.6  (was 2.3.3)
```

## Risk

form-data 2.5.x is API-compatible with 2.3.x, and `request` only touches the basic append/pipe surface. Nothing in the repo constructs a multipart body at all (`grep -rn FormData src scripts` is empty; every `axios` call is a GET or a JSON POST), so the vulnerable code path is never exercised — this is hygiene, not live exposure.

## Follow-up, not addressed here

`broken-link-checker` looks droppable, but the link check that runs in `build-tests.yml` (`serve public` + Dart `linkcheck`) points at `public/`, which after the Gatsby→Next migration holds only static assets and two stray HTML files — no rendered pages. That CI step appears to be checking nothing, and is worth fixing before removing the npm checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCZVZtmUK6fTSpNMok8jqG