### PR TITLE
Make the CI link check actually check links

### DIFF
--- a/.github/linkcheck-skip.txt
+++ b/.github/linkcheck-skip.txt
@@ -17,3 +17,19 @@
 //dmoj\.ca/
 //www\.spoj\.com/
 //stackoverflow\.com/
+
+# The entries below only matter if -e (external links) is turned on, which it
+# is NOT on push/PR -- external checking is a manual exercise. They record what
+# a one-off external run on 2026-08-23 found unusable from a CI runner, so it
+# doesn't have to be rediscovered:
+#   403 to a CI IP: topcoder (16), en.cppreference (12), hackerearth (7),
+#                   artofproblemsolving (4), w3schools (3), leetcode (3)
+#   429 rate limit: qoj.ac (24), atcoder.jp (4)
+# Left commented -- enable alongside -e if you ever wire up a scheduled run.
+#//www\.topcoder\.com/
+#//en\.cppreference\.com/
+#//www\.hackerearth\.com/
+#//artofproblemsolving\.com/
+#//www\.w3schools\.com/
+#//leetcode\.com/
+#//qoj\.ac/

--- a/.github/linkcheck-skip.txt
+++ b/.github/linkcheck-skip.txt
@@ -1,0 +1,10 @@
+# URLs for linkcheck to ignore. One regular expression per line; lines
+# starting with a hash are comments.
+# https://github.com/filiph/linkcheck#the---skip-file-option
+
+# Next.js image optimizer. Every /_next/image URL comes back without a
+# content-type linkcheck recognises, so it reports all of them as
+# "server reported no mime type" -- 216 lines in the first real run,
+# enough to drown out genuine findings. The images themselves still ship
+# from public/, they just aren't reachable as plain URLs to crawl.
+/_next/image\?

--- a/.github/linkcheck-skip.txt
+++ b/.github/linkcheck-skip.txt
@@ -8,3 +8,12 @@
 # enough to drown out genuine findings. The images themselves still ship
 # from public/, they just aren't reachable as plain URLs to crawl.
 /_next/image\?
+
+# Hosts that answer HEAD with 403 (bot protection). linkcheck only retries as
+# GET on a 405, so every link to these would be reported broken. Measured with
+# `curl -I`: codeforces 403, dmoj 403, spoj 403, stackoverflow 403.
+# usaco.org is fine (200/301) and is deliberately NOT skipped.
+//codeforces\.com/
+//dmoj\.ca/
+//www\.spoj\.com/
+//stackoverflow\.com/

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -40,12 +40,13 @@ jobs:
           yarn start &
           timeout 120 bash -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 2; done'
       - run: dart pub global activate linkcheck
-      # TEMPORARY: continue-on-error is here only to measure how many broken
-      # links exist. It must be removed before this branch is merged.
+      # Anchors are off: headings inside <CPPSection>/<JavaSection>/<PySection>
+      # only render once the reader picks a language, so a crawler reading the
+      # server HTML sees ~85 anchors it cannot resolve. Pages themselves are
+      # still checked, which is what actually 404s a reader.
       - name: Check Links
-        continue-on-error: true
         run: |
-          $HOME/.pub-cache/bin/linkcheck --no-nice \
+          $HOME/.pub-cache/bin/linkcheck --no-nice --no-check-anchors \
             --skip-file .github/linkcheck-skip.txt :3000
 
       - name: Bundle Watch

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -21,7 +21,6 @@ jobs:
         run: corepack enable
       - uses: dart-lang/setup-dart@v1
 
-      - run: yarn add serve@14.2.4
       - run: yarn add bundlewatch@0.4.0
 
       - name: Cache node modules
@@ -36,10 +35,16 @@ jobs:
       - run: yarn build
         env:
           NODE_OPTIONS: --max-old-space-size=4096
-      - run: ./node_modules/.bin/serve public &
+      - name: Start server
+        run: |
+          yarn start &
+          timeout 120 bash -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 2; done'
       - run: dart pub global activate linkcheck
 
+      # TEMPORARY: continue-on-error is here only to measure how many broken
+      # links exist. It must be removed before this branch is merged.
       - name: Check Links
+        continue-on-error: true
         run: $HOME/.pub-cache/bin/linkcheck --no-nice :3000
 
       - name: Bundle Watch

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Check Links
         continue-on-error: true
         run: |
-          $HOME/.pub-cache/bin/linkcheck --no-nice \
+          $HOME/.pub-cache/bin/linkcheck --no-nice -e \
             --skip-file .github/linkcheck-skip.txt :3000
 
       - name: Bundle Watch

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Check Links
         continue-on-error: true
         run: |
-          $HOME/.pub-cache/bin/linkcheck --no-nice -e \
+          $HOME/.pub-cache/bin/linkcheck --no-nice \
             --skip-file .github/linkcheck-skip.txt :3000
 
       - name: Bundle Watch

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -40,12 +40,13 @@ jobs:
           yarn start &
           timeout 120 bash -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 2; done'
       - run: dart pub global activate linkcheck
-
       # TEMPORARY: continue-on-error is here only to measure how many broken
       # links exist. It must be removed before this branch is merged.
       - name: Check Links
         continue-on-error: true
-        run: $HOME/.pub-cache/bin/linkcheck --no-nice :3000
+        run: |
+          $HOME/.pub-cache/bin/linkcheck --no-nice \
+            --skip-file .github/linkcheck-skip.txt :3000
 
       - name: Bundle Watch
         run: yarn bundlewatch .next/static/chunks/*.js

--- a/content/1_General/Contests.mdx
+++ b/content/1_General/Contests.mdx
@@ -103,7 +103,7 @@ at past problems.
 	>
 		An alternative for CF-Predictor
 	</Resource>
-	<Resource title="CF Visualizer" url="http://cfviz.netlify.com/compare.html">
+	<Resource title="CF Visualizer" url="https://cfviz.netlify.app/compare.html">
 		compare users
 	</Resource>
 	<Resource

--- a/content/1_General/Contributing.mdx
+++ b/content/1_General/Contributing.mdx
@@ -22,9 +22,8 @@ The USACO Guide has a public
 - If you're looking to add/modify problem solutions, refer to the `solutions/`
   folder.
 - All static files (e.g., images, videos, etc.) have been moved to the
-  [/public/](../public/) directory because Next.js can only serve static files
-  from there.
-    - Use absolute imports in the [/content/](../content/) and [/solutions/](../solutions/) directories.
+  `public/` directory because Next.js can only serve static files from there.
+    - Use absolute imports in the `content/` and `solutions/` directories.
 - (Almost) all the other files and folders are related to the front-end code.
 
 If you have any questions about how to contribute, feel free to just open an

--- a/content/1_General/Olympiads.mdx
+++ b/content/1_General/Olympiads.mdx
@@ -86,7 +86,7 @@ links.
 - [oj.uz](https://oj.uz/problems/source/40)
   - Most problems from 2011-2020.
 
-### [CEOI](http://ceoi.inf.elte.hu/) (Central European)
+### [CEOI](https://ceoi.elte.hu/) (Central European)
 
 - [CSES](https://cses.fi/)
   - All problems from 2005-2019.

--- a/content/1_General/Resources_USA-specific.mdx
+++ b/content/1_General/Resources_USA-specific.mdx
@@ -41,13 +41,6 @@ These links are provided for convenience only; USACO does not officially endorse
 		teams of 4, 4 hours, Java or Python
 	</Resource>
 	<Resource
-		source="UT Dallas"
-		title="Battle of the Brains"
-		url="https://cs.utdallas.edu/tag/high-school-programming-contest/"
-	>
-		teams of 3, 3 hours, Java or C++
-	</Resource>
-	<Resource
 		source="Lockheed Martin"
 		title="Code Quest"
 		url="https://www.lockheedmartin.com/en-us/who-we-are/communities/codequest/code-quest-registration.html"

--- a/content/1_General/Resources_USA-specific.mdx
+++ b/content/1_General/Resources_USA-specific.mdx
@@ -43,7 +43,7 @@ These links are provided for convenience only; USACO does not officially endorse
 	<Resource
 		source="UT Dallas"
 		title="Battle of the Brains"
-		url="https://www.utdallas.edu/k12/hs-contest/"
+		url="https://cs.utdallas.edu/tag/high-school-programming-contest/"
 	>
 		teams of 3, 3 hours, Java or C++
 	</Resource>
@@ -121,7 +121,7 @@ There are of course many different computing camps and programs available for hi
 The USACO is one of several national organizations in the USA that select teams
 of students to participate in their respective International Science Olympiads.
 The most prominent are the
-[USA Mathematics Olympiad (USAMO)](http://amc.maa.org/usamo/usamo.shtml), the
+[USA Mathematics Olympiad (USAMO)](https://maa.org/maa-invitational-competitions/), the
 [US Physics Team (USAPhO)](http://www.aapt.org/physicsteam/program.cfm), the
 [US National Chemistry Olympiad (USNCO)](https://www.acs.org/content/acs/en/education/students/highschool/olympiad.html),
 and the [USA Biolympiad (USABO)](http://www.usabo-trc.org).

--- a/content/4_Gold/Hashmaps.mdx
+++ b/content/4_Gold/Hashmaps.mdx
@@ -316,7 +316,7 @@ functions here. If you need a replacement for `unordered_set<K>`, use
 	</Resource>
 	<Resource
 		source="GCC"
-		url="https://gcc.gnu.org/onlinedocs/libstdc++/ext/pb_ds/gp_hash_table.html#Resize_Policy566860465"
+		url="https://gcc.gnu.org/onlinedocs/libstdc++/manual/policy_data_structures_design.html#container.hash.interface"
 		title="gp_hash_table Interface"
 	>
 		documentation
@@ -381,7 +381,7 @@ which case an error is thrown).
 <Resources>
 	<Resource
 		source="GCC"
-		url="https://gcc.gnu.org/onlinedocs/libstdc++/ext/pb_ds/hash_standard_resize_policy.html"
+		url="https://gcc.gnu.org/onlinedocs/libstdc++/manual/policy_data_structures_design.html#container.hash.details.resize_policies"
 		title="Resize Policy"
 	>
 		documentation

--- a/content/5_Plat/Bitsets.mdx
+++ b/content/5_Plat/Bitsets.mdx
@@ -530,8 +530,7 @@ runs in $\mathcal{O}(nX)$ time, which is fast enough with $X=5\cdot 10^5$ using
 bitset.
 
 It turns out that $X\approx \max a_i\cdot \sqrt n$ (up to a constant) suffices
-for correctness with high probability (briefly mentioned
-[here](https://faculty.cc.gatech.edu/~rpeng/CS4540_F20/ps1.pdf)). I'm not totally
+for correctness with high probability. I'm not totally
 sure about the details, but intuitively, the random shuffle reduces the optimal
 subset to some distribution with variance at most $(\max a_i)^2\cdot n$. In the
 special case where each $a_i$ is either $0$ or $\max a_i$, we can bound the

--- a/content/5_Plat/Bitsets.mdx
+++ b/content/5_Plat/Bitsets.mdx
@@ -531,7 +531,7 @@ bitset.
 
 It turns out that $X\approx \max a_i\cdot \sqrt n$ (up to a constant) suffices
 for correctness with high probability (briefly mentioned
-[here](https://www.cc.gatech.edu/~rpeng/CS4540_F20/ps1.pdf)). I'm not totally
+[here](https://faculty.cc.gatech.edu/~rpeng/CS4540_F20/ps1.pdf)). I'm not totally
 sure about the details, but intuitively, the random shuffle reduces the optimal
 subset to some distribution with variance at most $(\max a_i)^2\cdot n$. In the
 special case where each $a_i$ is either $0$ or $\max a_i$, we can bound the

--- a/content/6_Advanced/Interactive.mdx
+++ b/content/6_Advanced/Interactive.mdx
@@ -215,4 +215,4 @@ int find_coin(std::vector<int> b) {
 
 <Problems problems="communicationGeneral" />
 
-CEOI tasks can be found [here](http://ceoi.inf.elte.hu/tasks-archive/).
+CEOI tasks can be found [here](https://ceoi.elte.hu/tasks-archive.html).

--- a/content/team/authors.ts
+++ b/content/team/authors.ts
@@ -123,7 +123,7 @@ export const Authors: Author[] = [
     blurb:
       'Bing-Dong Liu is a USACO Platinum competitor who creates video editorials for USACO Training problems.',
     codeforces: 'lunchbox',
-    github: 'dongliu0426',
+    github: 'dongliu07',
     email: 'dongliu0426@gmail.com',
     youtube: 'https://www.youtube.com/channel/UC6je-w-ygZqxRsG76HtMceQ',
   },

--- a/content/team/contributors.ts
+++ b/content/team/contributors.ts
@@ -306,7 +306,6 @@ export const FormerMembers: Member[] = [
   {
     photo: 'daniel',
     name: 'Daniel Guan',
-    github: 'DGuan64',
     titles: [roles.founder, 'Director of Classes', 'Finalist'],
   },
   {

--- a/content/team/contributors.ts
+++ b/content/team/contributors.ts
@@ -66,7 +66,7 @@ export const OrderedFirstMembers: Member[] = [
     photo: 'Dong',
     name: 'Bing-Dong Liu',
     titles: ['Content Manager', roles.liveInstructor],
-    github: 'dongliu0426',
+    github: 'dongliu07',
     codeforces: 'lunchbox',
     email: 'dongliu0426@gmail.com',
     youtube: 'https://www.youtube.com/channel/UC6je-w-ygZqxRsG76HtMceQ',
@@ -95,7 +95,7 @@ export const OrderedFirstMembers: Member[] = [
       roles.contentAuthor,
       roles.liveInstructor,
     ],
-    github: 'TheGamingMousse',
+    github: 'eysbutno',
   },
   {
     photo: 'david_guo',
@@ -221,7 +221,6 @@ export const RestOfMembers: Member[] = [
     name: 'Kalyan Cherukuri',
     titles: [roles.clubCurriculum],
     linkedin: 'http://www.linkedin.com/in/kal-che',
-    website: 'https://kal-che.vercel.app/',
   },
   {
     photo: 'ruben',
@@ -409,7 +408,7 @@ export const FormerMembers: Member[] = [
     photo: 'dustin',
     name: 'Dustin Miao',
     titles: [roles.liveInstructor, roles.contentAuthor],
-    github: 'dutinmeow',
+    github: 'dmiao623',
     email: 'dutin20.meow@gmail.com',
     codeforces: 'dutinmeow',
   },
@@ -519,7 +518,7 @@ export const FormerMembers: Member[] = [
     photo: 'pranav',
     name: 'Pranav Jadhav',
     titles: ['Director of Clubs', roles.clubCurriculum],
-    github: 'pranavgithub1',
+    github: 'pranavjad',
     email: 'pra168109@gmail.com',
   },
   {
@@ -560,7 +559,7 @@ export const FormerMembers: Member[] = [
     name: 'Amogha Pokkulandra',
     titles: [roles.liveInstructor, roles.videoInstructor],
     email: 'amogha.pokkulandra@gmail.com',
-    github: 'x3n0coder',
+    github: 'apc0der',
   },
   {
     photo: 'albertz',
@@ -644,7 +643,7 @@ export const FormerMembers: Member[] = [
     name: 'Adham Ibrahim',
     titles: [roles.liveInstructor],
     email: 'adhamibrahim719@gmail.com',
-    github: 'adham-ibrahim7',
+    github: 'adhamsi',
   },
   {
     photo: 'alex_chen',

--- a/src/mdx-plugins/remark-toc.js
+++ b/src/mdx-plugins/remark-toc.js
@@ -1,6 +1,7 @@
 /*eslint-disable */
 
 import GithubSlugger from 'github-slugger';
+import { toString as mdastToPlainString } from 'mdast-util-to-string';
 import mdastToStringWithKatex from './mdast-to-string.js';
 
 export default ({ tableOfContents }) => {
@@ -13,8 +14,13 @@ export default ({ tableOfContents }) => {
     if (node.type === 'heading') {
       const val = {
         depth: node.depth,
+        // The displayed label keeps rendered KaTeX and HTML-escaped text, but
+        // the slug must match the heading id, which rehype-slug derives from
+        // the plain text. Slugging the escaped/rendered form instead produced
+        // dead anchors for every heading containing ' & < > or math
+        // ("Knuth's Optimization" -> knuth39s-optimization, id knuths-optimization).
         value: mdastToStringWithKatex(node),
-        slug: slugger.slug(mdastToStringWithKatex(node), false),
+        slug: slugger.slug(mdastToPlainString(node), false),
       };
       if (curLang !== null) {
         tableOfContents[curLang].push(val);


### PR DESCRIPTION
The `Check Links` step in `build-tests.yml` has been checking nothing since the Gatsby→Next migration. This makes it work, and fixes the bugs that surfaced once it did.

## What was wrong

Under Gatsby, `public/` **was** the build output, so `serve public` + `linkcheck` crawled the rendered site. Under Next, `public/` is the static-asset *source* directory and the build output lives in `.next`. The migration commit ([`ab9a8efd9`](https://github.com/cpinitiative/usaco-guide/commit/ab9a8efd9), Mar 2026) touched this workflow with exactly one line — adding `corepack: true` — and left the two link-check lines alone. `public/` silently changed meaning and the step kept passing.

Last green run on master ([`32587430929`](https://github.com/cpinitiative/usaco-guide/actions/runs/32587430929)):

```
645 links, 364 destination URLs, 0 errors     <- 1.03 seconds
```

`public/` holds 303 files, so that's "every asset file, plus the directory listings `serve` generates." It confirmed that files which exist, exist — while ~1000 content pages went unchecked for five months.

## What this does

| | before | after |
|---|---|---|
| what's crawled | `public/` asset listing | the real site via `next start` |
| links seen | 645 | **17,771** |
| can the step fail? | **no** | **yes** |

Serve the app instead of the asset folder, wait for the port, skip `/_next/image` (216 false "no mime type" reports — Next's optimizer returns no content-type linkcheck accepts), and drop `continue-on-error`.

`--no-check-anchors` is set. After the TOC fix below, the 85 remaining anchor warnings are all headings inside `<CPPSection>`/`<JavaSection>`/`<PySection>`, which only render once a reader picks a language — the server HTML a crawler sees contains one language's headings, so the rest are unresolvable no matter how correct their slugs are. linkcheck exits 1 on warnings, so leaving anchors on would keep the step permanently red. Broken *pages* are still caught, which is the failure a reader actually hits.

## Bugs found once it worked

**Table-of-contents slugs (159 across 34 modules).** `remark-toc` slugged its own string rather than the id `rehype-slug` assigns:

```js
slug: slugger.slug(mdastToStringWithKatex(node), false)
```

`mdastToStringWithKatex` HTML-escapes text and runs KaTeX — correct for the label the TOC displays, wrong for a slug:

| Heading | id | TOC link |
|---|---|---|
| Knuth's Optimization | `knuths-optimization` | `knuth39s-optimization` |
| GCD & LCM | `gcd--lcm` | `gcd-amp-lcm` |
| `` `<Asterisk>` `` | `asterisk` | `ltasteriskgt` |
| $\mathcal{O}(M\log N)$ Implementation | `mathcalomlog-n-...` | `span-classkatex…` (~500 chars) |

So the TOC entry for **any heading containing `'`, `&`, `<`, `>`, or math jumped nowhere.** Slug the plain text instead. Checked across every module: 3978 TOC entries, **159 unmatched before, 0 after**.

**`Contributing.mdx`** — `/public/`, `/content/`, `/solutions/` were markdown links resolving to site routes (308→404). They refer to repo directories and the two bullets above them already use code spans; matched that.

**14 dead external links**, found by a one-off `-e` run (since reverted — external checking is not enabled on push/PR):

```
amc.maa.org/usamo/usamo.shtml   -> maa.org/maa-invitational-competitions/
ceoi.inf.elte.hu/               -> ceoi.elte.hu/            (host gone entirely)
ceoi.inf.elte.hu/tasks-archive/ -> ceoi.elte.hu/tasks-archive.html
cfviz.netlify.com/              -> cfviz.netlify.app/       (netlify domain rename)
www.cc.gatech.edu/~rpeng/       -> faculty.cc.gatech.edu/~rpeng/
ext/pb_ds/gp_hash_table.html    -> manual/policy_data_structures_design.html#container.hash.interface
ext/pb_ds/hash_standard_...     -> ...#container.hash.details.resize_policies
```

Plus six contributor GitHub handles, each resolved through the commits API (which reports an account's current login): `adham-ibrahim7→adhamsi`, `dongliu0426→dongliu07`, `dutinmeow→dmiao623`, `pranavgithub1→pranavjad`, `TheGamingMousse→eysbutno`, `x3n0coder→apc0der`. Kalyan Cherukuri's dead personal site removed; LinkedIn stays.

## Removed rather than repointed

Three links had no working replacement, so they were dropped:

- **Georgia Tech problem set** (`Bitsets.mdx`) — `faculty.cc.gatech.edu` 403s automation and the page does not load. The parenthetical existed only to hold the link, so it went too.
- **UT Dallas "Battle of the Brains"** resource — the candidate replacement returns 200 but is a news archive whose newest post is 2019; the contest appears defunct.
- **Daniel Guan's `github` field** (`DGuan64`, 404) — no commits in this repo under that name and no confident match, so the field is removed rather than guessed at. The rest of the entry is unchanged.

One handle is worth a glance: **`github.com/apc0der`** (was `x3n0coder`, Amogha Pokkulandra). It resolves and the profile's display name matches exactly, but it came from GitHub user search rather than commit history like the other five.

## Follow-ups, not in scope here

- **Language-section anchors (85).** Not fixable server-side; needs all language variants rendered, or a browser-based checker.
- **Ongoing external checking.** The one-off run found 15 dead links; nothing watches them now. `.github/linkcheck-skip.txt` records, commented out, which hosts block CI runners (403: topcoder, cppreference, hackerearth, aops, w3schools, leetcode; 429: qoj.ac, atcoder) so a scheduled `-e` job can start from that data. Not viable as a PR gate — the failure set depends on which runner IP you draw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCZVZtmUK6fTSpNMok8jqG
