### PR TITLE
Force patched postcss and preact via resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,5 +124,9 @@
     "tsx": "^4.20.3",
     "typescript": "^5.9.2"
   },
+  "resolutions": {
+    "postcss": "^8.5.23",
+    "preact": "^10.29.0"
+  },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13311,7 +13311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.16, nanoid@npm:^3.3.6":
+"nanoid@npm:^3.3.16":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:
@@ -14052,7 +14052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
+"picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -14496,28 +14496,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.31":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
-  dependencies:
-    nanoid: "npm:^3.3.6"
-    picocolors: "npm:^1.0.0"
-    source-map-js: "npm:^1.0.2"
-  checksum: 10c0/748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.2.14, postcss@npm:^8.4.33, postcss@npm:^8.4.38, postcss@npm:^8.4.40, postcss@npm:^8.4.41":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^8.5.23":
   version: 8.5.23
   resolution: "postcss@npm:8.5.23"
@@ -14529,10 +14507,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"preact@npm:^10.10.0":
-  version: 10.27.0
-  resolution: "preact@npm:10.27.0"
-  checksum: 10c0/f00d84fdceca2d6236c093afb005ab34bfc9bac7fdeac2bb83c09791034692e0c1eb431659ba1fba1b9914ca0f9918da13b0a212ffb51c3ca2c2f5e5f5f01219
+"preact@npm:^10.29.0":
+  version: 10.29.8
+  resolution: "preact@npm:10.29.8"
+  peerDependencies:
+    preact-render-to-string: ">=5"
+  peerDependenciesMeta:
+    preact-render-to-string:
+      optional: true
+  checksum: 10c0/505460352139e0ce5b9c971b69d8d9f3b73ea0f316e3ff1c0b3db9a1abe206c9dff6ba385eb796253c38fcc08b5ade70cd8da3d9d6c9e9aec1a2fd59348253ae
   languageName: node
   linkType: hard
 
@@ -16405,7 +16388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf


### PR DESCRIPTION
- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps). _(N/A — not a solution PR)_
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
- [x] I have linked this PR to any issues that it closes. _(N/A)_

---

Collapses every nested copy of `postcss` to a single `8.5.23` and `preact` to `10.29.8`, closing five Dependabot alerts:

| Package | Alerts | Vulnerable range |
|---|---|---|
| `postcss` | #533, #693, #694, #705 | `<8.5.10`, `<8.5.12`, `<8.5.18`, `<=8.5.22` |
| `preact` | #389 | `10.26.5` – `10.28.1` |

## Why `resolutions` rather than a version bump

Bumping a direct dependency would not have been enough. `postcss@8.5.6` is pulled in by `@storybook/nextjs`, `@tailwindcss/postcss`, `css-loader` and `resolve-url-loader`, and `8.4.31` is pinned **exactly** by `next@15.5.21` — so the vulnerable copies survive any change to the root range. `next@16` ships `postcss: 8.5.23` itself, so this matches where `next` is heading anyway.

`preact` is pinned to `^10.29.0` rather than `^10.27.3` deliberately: the advisory's vulnerable range includes `>=10.28.0 <10.28.2`, so a caret on `10.27.3` could still resolve *into* a vulnerable version. Latest is `10.29.8`.

## Risk

Both are same-major bumps of build-time/rendering libraries. `preact` is the one that ships to users (via `instantsearch.js`), so **bundlewatch is the check to watch**. `postcss` only runs during `next build`.

## Verification

- `yarn check-ts-errors` clean with `src/functions/node_modules` moved aside, so local module resolution matches CI
- `prettier --check` clean
- No files under `src/functions` touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zgE8HbygMgVFFQ2hM8SK7
