### PR TITLE
Force patched postcss via resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,5 +124,8 @@
     "tsx": "^4.20.3",
     "typescript": "^5.9.2"
   },
+  "resolutions": {
+    "postcss": "^8.5.24"
+  },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13340,7 +13340,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.16, nanoid@npm:^3.3.6":
+"nanoid@npm:^3.3.16":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:
@@ -14081,7 +14081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
+"picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -14522,28 +14522,6 @@ __metadata:
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 10c0/f4142a4f56565f77c1831168e04e3effd9ffcc5aebaf0f538eee4b2d465adfd4b85a44257bb48418202a63806a7da7fe9f56c330aebb3cac898e46b4cbf49161
-  languageName: node
-  linkType: hard
-
-"postcss@npm:8.4.31":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
-  dependencies:
-    nanoid: "npm:^3.3.6"
-    picocolors: "npm:^1.0.0"
-    source-map-js: "npm:^1.0.2"
-  checksum: 10c0/748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.2.14, postcss@npm:^8.4.33, postcss@npm:^8.4.38, postcss@npm:^8.4.40, postcss@npm:^8.4.41":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
   languageName: node
   linkType: hard
 
@@ -16442,7 +16420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf


### PR DESCRIPTION
- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps). _(N/A — not a solution PR)_
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
- [x] I have linked this PR to any issues that it closes. _(N/A)_

---

Closes four Dependabot alerts — `postcss` #533, #693, #694, #705.

`postcss` keeps vulnerable copies alive in **nested** positions that a root-range bump cannot reach:

- `8.4.31`, pinned **exactly** by `next@15.5.21`
- `8.5.6`, via `@storybook/nextjs`, `@tailwindcss/postcss`, `css-loader`, `resolve-url-loader`

#6519 bumped the *root* range to `^8.5.24`, which does nothing for either. A bare resolution collapses all copies to a single `8.5.24`. `next@16` ships `postcss 8.5.23` itself, so this matches where `next` is heading.

## Why `glob` and `yaml` were dropped

They were in an earlier version of this PR and are the reason it failed CI. Their resolutions needed Yarn's **descriptor-scoped key syntax** (`"glob@npm:^10.2.2"`), because both packages also resolve to copies that are already patched — `glob` at 7.2.3/13.0.6 and `yaml` at 1.10.3 — which a bare key would clobber.

**Vercel's build fails on that syntax outright.** Established by bisect:

| Branch | Resolution | Vercel |
|---|---|---|
| `bisect/postcss-only` | `"postcss": "^8.5.24"` | ✅ pass |
| `bisect/glob-only` | `"glob@npm:^10.2.2": "^10.5.0"` | ❌ fail |
| `bisect/yaml-only` | `"yaml@npm:^2.0.0": "^2.8.3"` | ❌ fail |
| `bisect/descriptor-noop` | `"glob@npm:^7.1.3": "^7.2.3"` — **changes no installed version** | ❌ fail |

That last row is the proof: a descriptor-scoped key that resolves to the version already in the lockfile still fails the deployment. The syntax is the trigger, not the upgrade.

`glob` #470 and `yaml` #495 therefore stay open for now. Neither is reachable in this app — `glob`'s CVE is command injection via its `-c/--cmd` **CLI** flag (used here only as a library), and `yaml`'s is a stack overflow on deeply nested input (it parses your own config files). A follow-up is testing Yarn's parent/child key form (`"cacache/glob"`), which produces identical resolutions without the `@npm:` syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zgE8HbygMgVFFQ2hM8SK7
