### PR TITLE
Ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ yarn-error.log*
 # ide
 .vscode
 .cursor
+.claude
 
 # vercel
 .vercel


### PR DESCRIPTION
- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps). _(N/A — not a solution PR)_
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
- [x] I have linked this PR to any issues that it closes. _(N/A)_

---

One line, grouped with `.vscode` and `.cursor` in the existing `# ide` section.

Claude Code stores per-developer local state in `.claude/`, and that now includes **git worktrees** — a nested git repository inside an untracked directory. That combination is easy to sweep into a commit with `git add -A` or `git add .`, which is exactly what happened to me on a scratch branch while debugging the Vercel failure on #6520. Git's own `warning: adding embedded git repository` was the only thing that caught it.

Ignoring it removes the footgun for anyone working in this repo with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zgE8HbygMgVFFQ2hM8SK7
