### PR TITLE
Force patched glob and yaml via parent/child resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,9 @@
     "typescript": "^5.9.2"
   },
   "resolutions": {
-    "postcss": "^8.5.24"
+    "postcss": "^8.5.24",
+    "cacache/glob": "^10.5.0",
+    "remark-mdx-frontmatter/yaml": "^2.8.3"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10197,9 +10197,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2":
-  version: 10.4.5
-  resolution: "glob@npm:10.4.5"
+"glob@npm:^10.5.0":
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
   dependencies:
     foreground-child: "npm:^3.1.0"
     jackspeak: "npm:^3.1.2"
@@ -10209,7 +10209,7 @@ __metadata:
     path-scurry: "npm:^1.11.1"
   bin:
     glob: dist/esm/bin.mjs
-  checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
+  checksum: 10c0/100705eddbde6323e7b35e1d1ac28bcb58322095bd8e63a7d0bef1a2cdafe0d0f7922a981b2b48369a4f8c1b077be5c171804534c3509dfe950dde15fbe6d828
   languageName: node
   linkType: hard
 
@@ -18278,12 +18278,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0":
-  version: 2.8.0
-  resolution: "yaml@npm:2.8.0"
+"yaml@npm:^2.8.3":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
   bin:
     yaml: bin.mjs
-  checksum: 10c0/f6f7310cf7264a8107e72c1376f4de37389945d2fb4656f8060eca83f01d2d703f9d1b925dd8f39852a57034fafefde6225409ddd9f22aebfda16c6141b71858
+  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps). _(N/A — not a solution PR)_
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
- [x] I have linked this PR to any issues that it closes. _(N/A)_

---

Closes `glob` #470 and `yaml` #495 — the two that #6520 had to drop.

| Package | Vulnerable copy | → |
|---|---|---|
| `glob` | `10.4.5` via `cacache` | `10.5.0` |
| `yaml` | `2.8.0` via `remark-mdx-frontmatter` | `2.9.0` |

## Why scoped, and why *this* scoping

Both packages also resolve to copies that are **already patched** — `glob` at 7.2.3 and 13.0.6, `yaml` at 1.10.3 (which *is* the fix for the 1.x line). A bare `"glob"` or `"yaml"` resolution would drag those to a different major and break their consumers.

The obvious scoping mechanism is Yarn's descriptor key (`"glob@npm:^10.2.2"`), and that's what #6520 originally used — but **it breaks the Vercel build**. Proven by bisect: a *no-op* descriptor resolution resolving to the version already in the lockfile still failed the deployment, while a bare-key resolution passed.

Yarn's **parent/child** key form (`"cacache/glob"`) produces byte-identical resolutions without the `@npm:` syntax, and deploys cleanly — verified on a scratch branch before opening this.

## Verification

- Resolutions confirmed: `glob` keeps 7.2.3 and 13.0.6 alongside 10.5.0; `yaml` keeps 1.10.3 alongside 2.9.0; `postcss` from #6520 unchanged at 8.5.24
- Vercel deployment verified green on the scratch branch carrying these exact resolutions
- `yarn check-ts-errors` clean with `src/functions/node_modules` moved aside
- `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zgE8HbygMgVFFQ2hM8SK7
