### PR TITLE
Bump chromaui/action v1 → v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: yarn eslint --quiet
 
       - name: Run chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@v18
         with:
           projectToken: 6f3c58ad349c
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps). _(N/A — not a solution PR)_
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
- [x] I have linked this PR to any issues that it closes. _(N/A)_

---

The fifth bump from #6517, held back while the Chromatic check was in an unknown state.

**No config change is needed.** All three inputs this workflow passes still exist in `chromaui/action@v18`:

| Input | v18 |
|---|---|
| `projectToken` | present |
| `token` | present |
| `exitZeroOnChanges` | present |

v1 also runs on a long-deprecated Node runtime; v18 runs on `node24`.

## What to watch

This PR is its own test — the `tests` job runs this action, so a breaking change shows up as a job failure rather than something subtle.

Note the separate, **pre-existing** `UI Tests` condition ("13 changes must be accepted as baselines") is unrelated to the action version and has been present on every PR today. This bump is not expected to clear it; that still needs someone with Chromatic access to accept the baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zgE8HbygMgVFFQ2hM8SK7
