### PR TITLE
Regenerate usaco-divisions.json on dev startup; stop AGENTS.md churn

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,7 @@ CODE_OF_CONDUCT.md
 coverage
 PULL_REQUEST_TEMPLATE.md
 *.mdx
+
+# rewritten verbatim by `next dev`; prettier rewraps it and the two fight
+AGENTS.md
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,8 @@
 
 # This is NOT the Next.js you know
 
-This version has breaking changes — APIs, conventions, and file structure may
-all differ from your training data. Read the relevant guide in
-`node_modules/next/dist/docs/` (resolved from this file's directory; in
-monorepos the `next` package may not be visible from the repo root) before
-writing any code. Heed deprecation notices.
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 
-This block is written and re-added by `next dev` — verify at
-`node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a
-diff only re-creates the uncommitted change; committing it with your work keeps
-the tree clean.
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
 
 <!-- END:nextjs-agent-rules -->

--- a/docs/Front End Documentation.md
+++ b/docs/Front End Documentation.md
@@ -39,6 +39,10 @@ If you ever need to rebuild the database from scratch (for example after
 changing how content is parsed), delete `data/content.db` and restart, or run
 `yarn tsx scripts/index-content.ts`.
 
+`public/usaco-divisions.json` is generated the same way and is gitignored, since
+every build regenerates it. Both dev servers rewrite it on startup if it is
+missing, so a fresh clone or a `rm` of `public/` needs no extra step.
+
 ## Link Checker
 
 `build-tests` CI checks every _internal_ link on every push and PR, and fails

--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -7,6 +7,12 @@ import { getWritableDatabase } from '../src/lib/database';
 import type { ProblemMetadata } from '../src/models/problem';
 import { MdxContent, ProblemInfo } from '../src/types/content';
 
+const USACO_DIVISIONS_JSON = join(
+  process.cwd(),
+  'public',
+  'usaco-divisions.json'
+);
+
 // Only auto-run when executed directly (not when imported by watch-content.ts)
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch(console.error);
@@ -762,14 +768,35 @@ async function generateUsacoDivisionsJson(
   );
 
   // Write to public directory
-  const publicDir = join(process.cwd(), 'public');
-  const outputPath = join(publicDir, 'usaco-divisions.json');
-
   await writeFile(
-    outputPath,
+    USACO_DIVISIONS_JSON,
     JSON.stringify({ problems: usacoDivisionProblems }, null, 2)
   );
-  console.log(`USACO divisions JSON written to: ${outputPath}`);
+  console.log(`USACO divisions JSON written to: ${USACO_DIVISIONS_JSON}`);
+}
+
+/**
+ * Regenerates public/usaco-divisions.json if it is missing.
+ *
+ * It is gitignored and only rewritten when a .problems.json changes, so a
+ * clone (or a pull across the commit that untracked it) can have an up-to-date
+ * content.db and no JSON, leaving DivisionList to 404 on it. Both dev entry
+ * points call this on startup. Returns whether it had to write the file.
+ */
+export async function ensureUsacoDivisionsJson(): Promise<boolean> {
+  const { access } = await import('fs/promises');
+  try {
+    await access(USACO_DIVISIONS_JSON);
+    return false;
+  } catch {
+    const db = await getWritableDatabase();
+    try {
+      await generateUsacoDivisionsJson(db);
+    } finally {
+      db.close();
+    }
+    return true;
+  }
 }
 
 // async: do all parsing/IO up front

--- a/scripts/load-content.ts
+++ b/scripts/load-content.ts
@@ -24,6 +24,13 @@ async function load() {
   if (rebuild) {
     const { main } = await import('./index-content');
     await main();
+  } else {
+    // public/usaco-divisions.json is gitignored and only rewritten when a
+    // .problems.json changes, so it can be missing next to a valid cache.
+    const { ensureUsacoDivisionsJson } = await import('./index-content');
+    if (await ensureUsacoDivisionsJson()) {
+      console.log('Regenerated public/usaco-divisions.json.');
+    }
   }
 }
 

--- a/scripts/watch-content.ts
+++ b/scripts/watch-content.ts
@@ -47,6 +47,10 @@ async function watchContent() {
     await main();
   } else {
     console.log('[watch] Using cached content.db. Watching for changes...');
+    const { ensureUsacoDivisionsJson } = await import('./index-content');
+    if (await ensureUsacoDivisionsJson()) {
+      console.log('[watch] Regenerated public/usaco-divisions.json.');
+    }
   }
 
   // Start Next.js dev server as a child process. `--webpack` must match the


### PR DESCRIPTION
Two follow-ups to #6531, both about generated files behaving badly in local dev.

### `public/usaco-divisions.json` regenerates itself

Now that it's gitignored, it can be missing next to a perfectly good `content.db` — after a fresh clone whose first index predates it, or a pull across #6531 (git deletes the tracked file, and the surviving `content.db` means `load-content.ts` skips the rebuild). `DivisionList` then 404s on `fetch('/usaco-divisions.json')` until someone happens to touch a `.problems.json`, since that's the only thing that rewrites it.

`ensureUsacoDivisionsJson()` writes it only when missing, and both dev entry points call it on startup. The output path is now a constant so the generator and the existence check can't drift.

Verified all four cases against a local server:

| case | result |
| --- | --- |
| `dev:watch`, file missing | regenerated, logged, served 200 |
| `dev:watch`, file present | no write, silent |
| `yarn dev`, file missing | regenerated, served 200 |
| output | byte-identical to the deployed copy |

### `AGENTS.md` stops fighting prettier

`AGENTS.md` landed in #6530, and it's rewritten verbatim by `next dev` on every run. But `.github/workflows/prettier.yml` (autofix.ci) runs `yarn prettier . --write` and commits the result, and `proseWrap` is `always` for `*.md` — so CI rewrapped the file, and every subsequent `next dev` unwraps it again. The result is a permanently dirty `AGENTS.md` for anyone running the dev server; it was already dirty in my tree when I started this branch.

Ignore `AGENTS.md` / `CLAUDE.md` in prettier and commit them as `next dev` writes them. Confirmed `git status` stays clean across a dev-server run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FHFeWAqLyVmvd2RJBoX4r