### PR TITLE
Add missing time complexities to Silver Graph Traversal solutions

### DIFF
--- a/content/3_Silver/Graph_Traversal.mdx
+++ b/content/3_Silver/Graph_Traversal.mdx
@@ -554,6 +554,8 @@ in a line.
 
 ### DFS Solution
 
+**Time Complexity:** $\mathcal{O}(N + M)$
+
 <LanguageSection>
 <CPPSection>
 
@@ -773,6 +775,8 @@ To resolve this, we can implement a BFS solution, as shown below.
 
 ### BFS Solution
 
+**Time Complexity:** $\mathcal{O}(N + M)$
+
 <LanguageSection>
 <CPPSection>
 
@@ -949,6 +953,8 @@ When we visit a previously visited node, check to see whether its color matches 
 See [here](https://codeforces.com/blog/entry/67883).
 
 </Optional>
+
+**Time Complexity:** $\mathcal{O}(N + M)$
 
 <LanguageSection>
 <CPPSection>
@@ -1139,6 +1145,8 @@ print(*team)
 
 The specifics of the algorithm are almost exactly the same; it's just that we
 do them in an iterative rather than recursive fashion.
+
+**Time Complexity:** $\mathcal{O}(N + M)$
 
 <LanguageSection>
 <CPPSection>

--- a/solutions/silver/dmoj-rank.mdx
+++ b/solutions/silver/dmoj-rank.mdx
@@ -9,7 +9,8 @@ author: Ryan Chou, Ryan Kim
 We can use the games to construct a directed graph. If $a$ wins against $b$ then we can construct an edge from $b$ to $a$. Since the bounds of $N$ and $K$ are small, we can start a DFS from every vertex. If we reach that vertex again, then we can mark that vertex as “cyclic” and count said vertex in the result.
 
 ## Implementation
-$\mathcal{O}(N(N + K))$ time
+
+**Time Complexity:** $\mathcal{O}(N(N + K))$
 
 <LanguageSection>
 <CPPSection>

--- a/solutions/silver/kattis-birthday.mdx
+++ b/solutions/silver/kattis-birthday.mdx
@@ -44,6 +44,8 @@ we can update `adj[a][b]` and `adj[b][a]` to true.
 
 ## Implementation
 
+**Time Complexity:** $\mathcal{O}(c \cdot p^2)$ per test case
+
 <LanguageSection>
 
 <CPPSection>

--- a/solutions/silver/usaco-920.mdx
+++ b/solutions/silver/usaco-920.mdx
@@ -26,6 +26,8 @@ Otherwise, the solution will always be $2^k$.
 
 ## Implementation
 
+**Time Complexity:** $\mathcal{O}(N + M)$
+
 <LanguageSection>
 <CPPSection>
 


### PR DESCRIPTION
Every solution linked from [`/silver/graph-traversal`](https://usaco.guide/silver/graph-traversal) now states a time complexity in the standard place, immediately above its code. Five were missing one; a sixth had it in a non-standard format.

| Problem | Location | Complexity |
|---|---|---|
| Birthday Party | `solutions/silver/kattis-birthday.mdx` | $\mathcal{O}(c \cdot p^2)$ per test case |
| The Great Revegetation | `solutions/silver/usaco-920.mdx` | $\mathcal{O}(N + M)$ |
| Rank | `solutions/silver/dmoj-rank.mdx` | $\mathcal{O}(N(N + K))$ — *reformatted, value unchanged* |
| Building Roads (in-module, DFS + BFS) | `content/3_Silver/Graph_Traversal.mdx` | $\mathcal{O}(N + M)$ each |
| Building Teams (in-module, DFS + BFS) | `content/3_Silver/Graph_Traversal.mdx` | $\mathcal{O}(N + M)$ each |

Notes:

- **Birthday Party** is the one worth a second look. The graph is stored as an adjacency matrix (`bool adj[105][105]`), so a single DFS is $\mathcal{O}(p^2)$ rather than $\mathcal{O}(p + c)$, and it is rerun once per removed edge — $\mathcal{O}(c \cdot p^2)$, or $5 \times 10^7$ at the limits. Both the C++ and Java implementations do this.
- **Rank** already stated `$\mathcal{O}(N(N + K))$ time` as bare prose under `## Implementation`; this only switches it to the `**Time Complexity:**` line every other solution in the module uses.
- For the two in-module solutions where prose or an `<Optional>` block sits between the `###` heading and the code (Building Teams DFS and BFS), the line goes after that content so it reads as a caption on the code instead of interrupting the explanation.

`prettier --check` passes on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmzqX6G2rydeZoi613yYf5