### PR TITLE
Add padding to textareas

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -55,6 +55,8 @@
 
 input,
 .input,
+textarea,
+.textarea,
 .flatpickr-input {
   @apply px-3 py-2;
 }


### PR DESCRIPTION
The contact form's Message field had its text jammed against the border, while the text inputs above it looked fine.

Cause: the padding rule in `src/styles/components.css` only listed `input`, `.input`, and `.flatpickr-input`. The `.textarea` class supplied border, rounding, and focus styles but no padding, so textareas fell back to the Tailwind preflight `padding: 0`.

Fix: add `textarea, .textarea` to that rule.

This also fixes other unpadded textareas that had the same problem (e.g. `ProblemSuggestionModal.tsx`, `QuizGeneratorModal.tsx`). Textareas already using `.input` are unchanged, and Monaco's internal editor textarea sets its own `padding: 0` at higher specificity, so the code editors are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NbUihbUJXtxEDDRQKBbjm