### PR TITLE
Move problems from overloaded modules into conclusions

### DIFF
--- a/content/2_Bronze/Conclusion.problems.json
+++ b/content/2_Bronze/Conclusion.problems.json
@@ -196,6 +196,18 @@
       }
     },
     {
+      "uniqueId": "usaco-1085",
+      "name": "Just Stalling",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1085",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Combinatorics"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
       "uniqueId": "cf-358C",
       "name": "Dima and Containers",
       "url": "https://codeforces.com/problemset/problem/358/C",

--- a/content/3_Silver/Binary_Search.problems.json
+++ b/content/3_Silver/Binary_Search.problems.json
@@ -143,18 +143,6 @@
       }
     },
     {
-      "uniqueId": "cf-862E",
-      "name": "Mahmoud & Ehab & Function",
-      "url": "https://codeforces.com/contest/862/problem/E",
-      "source": "CF",
-      "difficulty": "Normal",
-      "isStarred": false,
-      "tags": ["Binary Search"],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
       "uniqueId": "cc-TRPTSTIC",
       "name": "TripTastic",
       "url": "https://www.codechef.com/problems/TRPTSTIC",
@@ -200,43 +188,6 @@
       "tags": ["Binary Search"],
       "solutionMetadata": {
         "kind": "internal"
-      }
-    },
-    {
-      "uniqueId": "cf-847B",
-      "name": "Preparing for Merge Sort",
-      "url": "https://codeforces.com/contest/847/problem/B",
-      "source": "CF",
-      "difficulty": "Normal",
-      "isStarred": false,
-      "tags": ["Binary Search"],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
-      "uniqueId": "cf-1244E",
-      "name": "Minimizing Difference",
-      "url": "https://codeforces.com/contest/1244/problem/E",
-      "source": "CF",
-      "difficulty": "Normal",
-      "isStarred": false,
-      "tags": ["Binary Search", "Prefix Sums", "Greedy"],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
-      "uniqueId": "cf-104468H",
-      "name": "Ammar-utiful Array",
-      "url": "https://codeforces.com/gym/104468/problem/H",
-      "source": "CF",
-      "difficulty": "Normal",
-      "isStarred": false,
-      "tags": ["Binary Search", "Prefix Sums"],
-      "solutionMetadata": {
-        "kind": "internal",
-        "hasHints": true
       }
     },
     {

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -538,6 +538,55 @@
       }
     },
     {
+      "uniqueId": "cf-862E",
+      "name": "Mahmoud & Ehab & Function",
+      "url": "https://codeforces.com/contest/862/problem/E",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Binary Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-104468H",
+      "name": "Ammar-utiful Array",
+      "url": "https://codeforces.com/gym/104468/problem/H",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Binary Search", "Prefix Sums"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "cf-847B",
+      "name": "Preparing for Merge Sort",
+      "url": "https://codeforces.com/contest/847/problem/B",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Binary Search"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "cf-1244E",
+      "name": "Minimizing Difference",
+      "url": "https://codeforces.com/contest/1244/problem/E",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Binary Search", "Prefix Sums", "Greedy"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
       "uniqueId": "cf-700B",
       "name": "Connecting Universities",
       "url": "https://codeforces.com/contest/700/problem/B",

--- a/content/4_Gold/Combinatorics.problems.json
+++ b/content/4_Gold/Combinatorics.problems.json
@@ -126,18 +126,6 @@
       }
     },
     {
-      "uniqueId": "usaco-1085",
-      "name": "Just Stalling",
-      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1085",
-      "source": "Bronze",
-      "difficulty": "Easy",
-      "isStarred": false,
-      "tags": ["Combinatorics"],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
       "uniqueId": "cf-2211D",
       "name": "AND-array",
       "url": "https://codeforces.com/problemset/problem/2211/D",
@@ -223,18 +211,6 @@
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
-      }
-    },
-    {
-      "uniqueId": "cf-1606E",
-      "name": "Arena",
-      "url": "https://codeforces.com/problemset/problem/1606/E",
-      "source": "CF",
-      "difficulty": "Normal",
-      "isStarred": false,
-      "tags": ["Combinatorics", "DP"],
-      "solutionMetadata": {
-        "kind": "internal"
       }
     },
     {

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -461,6 +461,18 @@
       }
     },
     {
+      "uniqueId": "cf-1606E",
+      "name": "Arena",
+      "url": "https://codeforces.com/problemset/problem/1606/E",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Combinatorics", "DP"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
       "uniqueId": "cf-2021E2",
       "name": "Digital Village (Hard Version)",
       "url": "https://codeforces.com/contest/2021/problem/E2",
@@ -559,6 +571,19 @@
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"
+      }
+    },
+    {
+      "uniqueId": "usaco-1499",
+      "name": "Friendship Editing",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1499",
+      "source": "Gold",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Bitmasks", "DP", "Graphs"],
+      "solutionMetadata": {
+        "kind": "USACO",
+        "usacoId": "1499"
       }
     },
     {

--- a/content/4_Gold/DP_Bitmasks.problems.json
+++ b/content/4_Gold/DP_Bitmasks.problems.json
@@ -141,19 +141,6 @@
       }
     },
     {
-      "uniqueId": "usaco-1499",
-      "name": "Friendship Editing",
-      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1499",
-      "source": "Gold",
-      "difficulty": "Hard",
-      "isStarred": false,
-      "tags": ["Bitmasks", "DP", "Graphs"],
-      "solutionMetadata": {
-        "kind": "USACO",
-        "usacoId": "1499"
-      }
-    },
-    {
       "uniqueId": "ys-MaxIndepSet",
       "name": "Max Indep Set",
       "url": "https://judge.yosupo.jp/problem/maximum_independent_set",

--- a/content/4_Gold/DP_Trees.problems.json
+++ b/content/4_Gold/DP_Trees.problems.json
@@ -152,18 +152,6 @@
       }
     },
     {
-      "uniqueId": "usaco-1020",
-      "name": "Delegation",
-      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1020",
-      "source": "Platinum",
-      "difficulty": "Normal",
-      "isStarred": false,
-      "tags": ["DP", "Tree", "Binary Search"],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
       "uniqueId": "usaco-1497",
       "name": "Bessie's Function",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1497",
@@ -209,6 +197,18 @@
       "difficulty": "Hard",
       "isStarred": false,
       "tags": ["Functional Graph"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1020",
+      "name": "Delegation",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1020",
+      "source": "Platinum",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["DP", "Tree", "Binary Search"],
       "solutionMetadata": {
         "kind": "internal"
       }


### PR DESCRIPTION
Resolves #6527.

Trims modules that had accumulated too many problems by relocating some of them to the corresponding division conclusion module, following the list suggested in the issue thread.

**Silver Binary Search → Silver Conclusion**
- Mahmoud & Ehab & Function (`cf-862E`)
- Ammar-utiful Array (`cf-104468H`)
- Preparing for Merge Sort (`cf-847B`)
- Minimizing Difference (`cf-1244E`)

**Gold Combinatorics → Conclusion**
- Just Stalling (`usaco-1085`) → Bronze Conclusion, remarked as Hard (relative to Bronze)
- Arena (`cf-1606E`) → Gold Conclusion

**Gold Bitmask DP → Gold Conclusion**
- Friendship Editing (`usaco-1499`)

**Gold DP on Trees**
- Delegation (Platinum) (`usaco-1020`): difficulty bumped Normal → Hard

Each moved problem is inserted into its destination's matching difficulty group so the lists stay sorted. Solution files are unchanged since they're matched by `uniqueId`.

Not included from the issue's suggestion list: Graph Traversal (Moocast, Wormhole Sort, Redistributing Gifts), Combinatorics' Strivore, Bitmask DP's Guard Mark, and DP on Trees' Parsa's Humongous Tree / Distance in Tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQdr6VvQsUPM6yNdJPVjoq