### PR TITLE
Decouple Gold Combinatorics from DP

### DIFF
--- a/content/4_Gold/Combinatorics.problems.json
+++ b/content/4_Gold/Combinatorics.problems.json
@@ -253,18 +253,6 @@
       }
     },
     {
-      "uniqueId": "cf-1666F",
-      "name": "Fancy Stack",
-      "url": "https://codeforces.com/problemset/problem/1666/F",
-      "source": "CF",
-      "difficulty": "Hard",
-      "isStarred": false,
-      "tags": ["Combinatorics", "DP"],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
       "uniqueId": "usaco-1210",
       "name": "Cow Camp",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1210",

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -587,6 +587,18 @@
       }
     },
     {
+      "uniqueId": "cf-1666F",
+      "name": "Fancy Stack",
+      "url": "https://codeforces.com/problemset/problem/1666/F",
+      "source": "CF",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Combinatorics", "DP"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
       "uniqueId": "cf-906D",
       "name": "Power Tower",
       "url": "https://codeforces.com/problemset/problem/906/D",

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -616,7 +616,7 @@
       "name": "Sums",
       "url": "https://szkopul.edu.pl/problemset/problem/ROXsaseQWYR11jbNvCgM19Er/site/?key=statement",
       "source": "POI",
-      "difficulty": "Insane",
+      "difficulty": "Very Hard",
       "isStarred": false,
       "tags": ["SP"],
       "solutionMetadata": {

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -589,7 +589,7 @@
     {
       "uniqueId": "cf-1666F",
       "name": "Fancy Stack",
-      "url": "https://codeforces.com/problemset/problem/1666/F",
+      "url": "https://codeforces.com/contest/1666/problem/F",
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,

--- a/content/4_Gold/Intro_DP.mdx
+++ b/content/4_Gold/Intro_DP.mdx
@@ -5,7 +5,6 @@ author: Michael Cao, Benjamin Qi, Neo Wang, Daniel Zhu
 prerequisites:
   - complete-rec
   - modular
-  - combo
 description: 'Speeding up naive recursive solutions with memoization.'
 frequency: 4
 ---


### PR DESCRIPTION
Closes #6536.

The contact form report noted that some Combinatorics problems require DP even though the DP module comes later in the Gold ordering.

**Fancy Stack (`cf-1666F`) → Gold Conclusion**, placed at the end of the Hard group. Arena (`cf-1606E`), the other problem named in the issue, was already moved to the Gold Conclusion in #6541. Fancy Stack was the only remaining `DP`-tagged problem in the Combinatorics list, so the module's problem set no longer depends on DP.

**Dropped `combo` as a prerequisite of `intro-dp`.** None of the internal solutions for Intro to DP's problems use binomial coefficients or factorials — I grepped all 14 of them. The closest is Stamp Painting (`usaco-791`), whose prose mentions complementary counting but has no binomials/factorials/modular inverses. Three solutions (`usaco-791`, `usaco-673`, `usaco-1185`) do arithmetic mod 1e9+7, which the existing `modular` prerequisite already covers, and the module text itself never mentions combinatorics.

Two unrelated tidy-ups ride along: Fancy Stack's URL now uses the `/contest/1666/problem/F` form, and Sums (`poi-sums`) in the Gold Conclusion drops from Insane to Very Hard.

We considered reversing the dependence instead (making `intro-dp` a prerequisite of `combo`), but the DP in the Combinatorics module is light and self-contained: Pascal's Triangle states its recurrence with base cases, and Derangements Method 2 is a linear recurrence. Neither assumes memoization or state-design fluency, so no prerequisite edge is added in either direction. This also keeps `combo` in the Math group ahead of the DP group in `ordering.ts` without a backwards-pointing prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQdr6VvQsUPM6yNdJPVjoq
