### PR TITLE
chore: standardize problem tags

### DIFF
--- a/content/2_Bronze/Ad_Hoc.problems.json
+++ b/content/2_Bronze/Ad_Hoc.problems.json
@@ -8,7 +8,7 @@
       "source": "Bronze",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Ad-Hoc"],
+      "tags": ["Ad Hoc"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "ad-hoc"

--- a/content/2_Bronze/Intro_Graphs.problems.json
+++ b/content/2_Bronze/Intro_Graphs.problems.json
@@ -8,7 +8,7 @@
       "source": "Bronze",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Permutation", "Graph"],
+      "tags": ["Permutation", "Graphs"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/2_Bronze/Intro_Sets.problems.json
+++ b/content/2_Bronze/Intro_Sets.problems.json
@@ -133,7 +133,7 @@
       "source": "Bronze",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Set", "Maps"],
+      "tags": ["Set", "Map"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1445"

--- a/content/3_Silver/Binary_Search.problems.json
+++ b/content/3_Silver/Binary_Search.problems.json
@@ -72,7 +72,7 @@
       "source": "Gold",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Binary Search", "Sorting", "2P", "Greedy"],
+      "tags": ["Binary Search", "Sorting", "Two Pointers", "Greedy"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/3_Silver/Binary_Search_Sorted_Array.problems.json
+++ b/content/3_Silver/Binary_Search_Sorted_Array.problems.json
@@ -22,7 +22,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2P", "Binary Search"],
+      "tags": ["Two Pointers", "Binary Search"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -44,7 +44,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Binary Search", "Greedy", "2P"],
+      "tags": ["Binary Search", "Greedy", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -202,7 +202,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Game Theory", "NT"],
+      "tags": ["Game", "Number Theory"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -262,7 +262,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Binary Search, 2P"],
+      "tags": ["Binary Search", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -385,7 +385,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Functional Graphs"],
+      "tags": ["Functional Graph"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -397,7 +397,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Functional Graphs"],
+      "tags": ["Functional Graph"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -409,7 +409,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Greedy", "Prefix", "Bitwise"],
+      "tags": ["Greedy", "Prefix Sums", "Bitwise"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -493,7 +493,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Trees", "Greedy"],
+      "tags": ["Tree", "Greedy"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -617,7 +617,7 @@
       "source": "AC",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Trees", "Game Theory"],
+      "tags": ["Tree", "Game"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Graph_Traversal.problems.json
+++ b/content/3_Silver/Graph_Traversal.problems.json
@@ -145,7 +145,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Connected Components", "2P", "Binary Search"],
+      "tags": ["Connected Components", "Two Pointers", "Binary Search"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -193,7 +193,7 @@
       "source": "Silver",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Spanning Tree", "Constructive", "Cycles"],
+      "tags": ["Spanning Tree", "Constructive", "Cycle"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1184"
@@ -295,7 +295,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Trees", "Bipartite"],
+      "tags": ["Tree", "Bipartite"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/3_Silver/Greedy_Sorting.problems.json
+++ b/content/3_Silver/Greedy_Sorting.problems.json
@@ -61,7 +61,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Greedy", "Sorting", "2P"],
+      "tags": ["Greedy", "Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -87,7 +87,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Greedy", "Sorting", "2P"],
+      "tags": ["Greedy", "Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -207,7 +207,7 @@
       "source": "Silver",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Sorting", "Greedy", "2P"],
+      "tags": ["Sorting", "Greedy", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/More_Prefix_Sums.problems.json
+++ b/content/3_Silver/More_Prefix_Sums.problems.json
@@ -78,7 +78,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Difference Array", "Sortings"],
+      "tags": ["Difference Array", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -191,7 +191,7 @@
       "source": "AC",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Trees", "2D Prefix Sums"],
+      "tags": ["Tree", "2D Prefix Sums"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Two_Pointers.problems.json
+++ b/content/3_Silver/Two_Pointers.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["2P", "Sorting"],
+      "tags": ["Two Pointers", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -22,7 +22,7 @@
       "source": "CF",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["2P"],
+      "tags": ["Two Pointers"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "two-pointers"
@@ -49,7 +49,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["2P", "Sorting"],
+      "tags": ["Two Pointers", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -61,7 +61,7 @@
       "source": "Silver",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2P", "Sorting"],
+      "tags": ["Two Pointers", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -73,7 +73,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2P", "Binary Search"],
+      "tags": ["Two Pointers", "Binary Search"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -85,7 +85,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2P"],
+      "tags": ["Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -97,7 +97,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2P", "Sorting", "Sliding Window"],
+      "tags": ["Two Pointers", "Sorting", "Sliding Window"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -109,7 +109,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["2P", "Sorting"],
+      "tags": ["Two Pointers", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -121,7 +121,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["2P", "Sorting"],
+      "tags": ["Two Pointers", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -133,7 +133,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["2P"],
+      "tags": ["Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -145,7 +145,7 @@
       "source": "Silver",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Two Pointers", "Prefix Sum", "Binary Search"],
+      "tags": ["Two Pointers", "Prefix Sums", "Binary Search"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -157,7 +157,7 @@
       "source": "CEOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["2P", "Sorting"],
+      "tags": ["Two Pointers", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -169,7 +169,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["2P", "Greedy"],
+      "tags": ["Two Pointers", "Greedy"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -59,7 +59,7 @@
       "source": "AC",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DSU", "SP"],
+      "tags": ["DSU", "Shortest Path"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"
@@ -136,7 +136,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Segtree", "DP"],
+      "tags": ["SegTree", "DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -174,7 +174,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Bitmasks", "DP", "SP"],
+      "tags": ["Bitmasks", "DP", "Shortest Path"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -389,7 +389,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Bitmask"],
+      "tags": ["DP", "Bitmasks"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -415,7 +415,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Graph theory", "Math"],
+      "tags": ["Graphs", "Math"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"
@@ -466,7 +466,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Trees", "Probabilities"],
+      "tags": ["DP", "Tree", "Probability"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -567,7 +567,7 @@
       "source": "QOJ",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "Maths"],
+      "tags": ["DP", "Math"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -630,7 +630,7 @@
       "source": "POI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/DP_Bitmasks.problems.json
+++ b/content/4_Gold/DP_Bitmasks.problems.json
@@ -62,7 +62,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Bitmasks", "MinCostFlow"],
+      "tags": ["Bitmasks", "Min Cost Flow"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -147,7 +147,7 @@
       "source": "YS",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Bitmasks", "Meet in Middle", "DP"],
+      "tags": ["Bitmasks", "Meet in the Middle", "DP"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -198,7 +198,7 @@
       "source": "COCI",
       "difficulty": "Very Hard",
       "isStarred": true,
-      "tags": ["Bitmasks", "DP", "Tree", "Game Theory"],
+      "tags": ["Bitmasks", "DP", "Tree", "Game"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -251,7 +251,7 @@
       "source": "CF",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["DP", "Bitmasks", "NT"],
+      "tags": ["DP", "Bitmasks", "Number Theory"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -264,7 +264,7 @@
       "source": "CF",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["Bitmasks", "NT", "Binary Search"],
+      "tags": ["Bitmasks", "Number Theory", "Binary Search"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/4_Gold/Divisibility.problems.json
+++ b/content/4_Gold/Divisibility.problems.json
@@ -77,7 +77,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["NT"],
+      "tags": ["Number Theory"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Hashing.problems.json
+++ b/content/4_Gold/Hashing.problems.json
@@ -213,7 +213,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Two Pointers, XOR Hashing"],
+      "tags": ["Two Pointers", "XOR Hashing"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -226,7 +226,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Combinatorics, XOR Hashing"],
+      "tags": ["Combinatorics", "XOR Hashing"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -239,7 +239,7 @@
       "source": "JOI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Trees, XOR Hashing"],
+      "tags": ["Tree", "XOR Hashing"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Intro_Sorted_Sets.problems.json
+++ b/content/4_Gold/Intro_Sorted_Sets.problems.json
@@ -84,7 +84,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Multiset", "Sorting", "Greedy"],
+      "tags": ["Sorted Set", "Sorting", "Greedy"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/LIS.problems.json
+++ b/content/4_Gold/LIS.problems.json
@@ -62,7 +62,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP, LIS"],
+      "tags": ["DP", "LIS"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/MST.problems.json
+++ b/content/4_Gold/MST.problems.json
@@ -159,7 +159,7 @@
       "source": "COCI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["MST", "NT"],
+      "tags": ["MST", "Number Theory"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/4_Gold/Meet_In_The_Middle.problems.json
+++ b/content/4_Gold/Meet_In_The_Middle.problems.json
@@ -35,7 +35,7 @@
       "source": "Silver",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Meet in the Middle", "2P"],
+      "tags": ["Meet in the Middle", "Two Pointers"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1207"
@@ -73,7 +73,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Meet in the Middle", "DFS", "NT"],
+      "tags": ["Meet in the Middle", "DFS", "Number Theory"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/4_Gold/PURS.problems.json
+++ b/content/4_Gold/PURS.problems.json
@@ -89,7 +89,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "Coordinate Compress"],
+      "tags": ["PURS", "Coordinate Compression"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -113,7 +113,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "Coordinate Compress"],
+      "tags": ["PURS", "Coordinate Compression"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Shortest_Paths.problems.json
+++ b/content/4_Gold/Shortest_Paths.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "shortest-paths"
@@ -23,7 +23,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -35,7 +35,7 @@
       "source": "Gold",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -47,7 +47,7 @@
       "source": "Gold",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -59,7 +59,7 @@
       "source": "Gold",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal",
         "usacoId": "861"
@@ -72,7 +72,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -84,7 +84,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1090"
@@ -97,7 +97,12 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SP", "Coordinate Compression", "Binary Search", "DP"],
+      "tags": [
+        "Shortest Path",
+        "Coordinate Compression",
+        "Binary Search",
+        "DP"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -109,7 +114,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -121,7 +126,7 @@
       "source": "Kattis",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -133,7 +138,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -145,7 +150,7 @@
       "source": "AC",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["SP", "Greedy"],
+      "tags": ["Shortest Path", "Greedy"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -157,7 +162,7 @@
       "source": "IOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -170,7 +175,7 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["SP", "DP"],
+      "tags": ["Shortest Path", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -182,7 +187,7 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -194,7 +199,7 @@
       "source": "APIO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["SP", "Geometry"],
+      "tags": ["Shortest Path", "Geometry"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -206,7 +211,7 @@
       "source": "Balkan OI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -218,7 +223,7 @@
       "source": "Balkan OI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["SP", "Stack"],
+      "tags": ["Shortest Path", "Stack"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Sliding_Window.problems.json
+++ b/content/4_Gold/Sliding_Window.problems.json
@@ -61,7 +61,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2P"],
+      "tags": ["Two Pointers"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "sliding-window"
@@ -76,7 +76,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2P", "Binary Search"],
+      "tags": ["Two Pointers", "Binary Search"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -112,7 +112,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Sliding Window", "2P"],
+      "tags": ["Sliding Window", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Unweighted_Shortest_Paths.problems.json
+++ b/content/4_Gold/Unweighted_Shortest_Paths.problems.json
@@ -171,7 +171,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/5_Plat/2DRQ.problems.json
+++ b/content/5_Plat/2DRQ.problems.json
@@ -51,7 +51,7 @@
       "source": "DMOPC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["D&C", "2DRQ", "BIT"],
+      "tags": ["Divide and Conquer", "2DRQ", "BIT"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "DMOJ"

--- a/content/5_Plat/Binary_Jump.problems.json
+++ b/content/5_Plat/Binary_Jump.problems.json
@@ -76,7 +76,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Binary Jumping", "Binary Search", "2P"],
+      "tags": ["Binary Jumping", "Binary Search", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Centroid.problems.json
+++ b/content/5_Plat/Centroid.problems.json
@@ -138,7 +138,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Centroid", "NT"],
+      "tags": ["Centroid", "Number Theory"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/5_Plat/Conclusion.problems.json
+++ b/content/5_Plat/Conclusion.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Small-To-Large Merging", "Virtual Tree", "DP", "Tree"],
+      "tags": ["Small to Large", "Virtual Tree", "DP", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -21,7 +21,7 @@
       "source": "CC",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Lazy Segtree"],
+      "tags": ["Lazy SegTree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CC"
@@ -47,7 +47,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Sqrt", "Segment Tree"],
+      "tags": ["DP", "Sqrt", "SegTree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -60,7 +60,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Convex Hull"],
+      "tags": ["Convex"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -73,7 +73,7 @@
       "source": "QOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Virtual Tree", "Segment Tree"],
+      "tags": ["Virtual Tree", "SegTree"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -85,7 +85,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Segtree"],
+      "tags": ["SegTree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -110,7 +110,7 @@
       "source": "TLX",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Centroid Decomposition"],
+      "tags": ["Centroid"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "TLX"

--- a/content/5_Plat/Convex_Hull_Trick.problems.json
+++ b/content/5_Plat/Convex_Hull_Trick.problems.json
@@ -71,7 +71,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -156,7 +156,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Bitmask DP", "Convex"],
+      "tags": ["Bitmasks", "DP", "Convex"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/DC-DP.problems.json
+++ b/content/5_Plat/DC-DP.problems.json
@@ -8,7 +8,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -22,7 +22,7 @@
       "source": "CEOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -34,7 +34,7 @@
       "source": "COI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/mostafa-saad/MyCompetitiveProgramming/blob/master/Olympiad/COI/official/2015/final-exam2/solutions.pdf"
@@ -47,7 +47,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -59,7 +59,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -71,7 +71,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -84,7 +84,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -97,7 +97,7 @@
       "source": "POI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://www.youtube.com/watch?v=IKN7DPQSnKI"
@@ -110,7 +110,7 @@
       "source": "IOI",
       "difficulty": "Very Hard",
       "isStarred": true,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "IOI",
         "year": 2014
@@ -123,7 +123,7 @@
       "source": "Platinum",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "926"
@@ -136,7 +136,7 @@
       "source": "JOI",
       "difficulty": "Very Hard",
       "isStarred": true,
-      "tags": ["D&C", "DP"],
+      "tags": ["Divide and Conquer", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/DC-SRQ.problems.json
+++ b/content/5_Plat/DC-SRQ.problems.json
@@ -73,7 +73,7 @@
       "source": "NOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Knapsack", "D&C", "SRQ"],
+      "tags": ["DP", "Knapsack", "Divide and Conquer", "SRQ"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -85,7 +85,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Matrix", "D&C"],
+      "tags": ["Matrix", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "997"

--- a/content/5_Plat/DP_SOS.problems.json
+++ b/content/5_Plat/DP_SOS.problems.json
@@ -35,7 +35,7 @@
       "source": "Platinum",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Combo", "DP"],
+      "tags": ["Combinatorics", "DP"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1309"
@@ -60,7 +60,7 @@
       "source": "Platinum",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["NT", "Prefix Sums"],
+      "tags": ["Number Theory", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1213"
@@ -99,7 +99,7 @@
       "source": "kilonova",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Bitmasks", "SOS DP", "NT"],
+      "tags": ["Bitmasks", "SOS DP", "Number Theory"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Geo_Pri.problems.json
+++ b/content/5_Plat/Geo_Pri.problems.json
@@ -83,7 +83,7 @@
       "source": "LC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Geometry", "Radians", "Sliding Windows"],
+      "tags": ["Geometry", "Sliding Window"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "geo-pri"
@@ -197,7 +197,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Geometry", "Sorting", "Angles"],
+      "tags": ["Geometry", "Sorting"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"

--- a/content/5_Plat/PIE.problems.json
+++ b/content/5_Plat/PIE.problems.json
@@ -37,7 +37,7 @@
       "source": "TopCoder",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["PIE", "Strings", "Patterns"],
+      "tags": ["PIE", "Strings"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "PIE"

--- a/content/5_Plat/Sparse_Segtree.problems.json
+++ b/content/5_Plat/Sparse_Segtree.problems.json
@@ -23,7 +23,7 @@
       "source": "IOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sparse Segtree", "Lazy SegTree"],
+      "tags": ["Sparse SegTree", "Lazy SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Sqrt.problems.json
+++ b/content/5_Plat/Sqrt.problems.json
@@ -53,7 +53,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sqrt", "Mo's Algorithm", "Trees"],
+      "tags": ["Sqrt", "Mo's Algorithm", "Tree"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "sqrt"

--- a/content/6_Advanced/Catalan.problems.json
+++ b/content/6_Advanced/Catalan.problems.json
@@ -59,7 +59,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Catalan, Combinatorics"],
+      "tags": ["Catalan", "Combinatorics"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/Comb_Sub.problems.json
+++ b/content/6_Advanced/Comb_Sub.problems.json
@@ -111,7 +111,7 @@
       "source": "COCI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["NT"],
+      "tags": ["Number Theory"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/Eulerian_Tours.problems.json
+++ b/content/6_Advanced/Eulerian_Tours.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Hamiltonian path"],
+      "tags": ["Hamiltonian Path"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "eulerian-tours"

--- a/content/6_Advanced/Eulers_Formula.problems.json
+++ b/content/6_Advanced/Eulers_Formula.problems.json
@@ -8,7 +8,7 @@
       "source": "APIO",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Persistent Segtree", "Euler's Formula", "2DRQ"],
+      "tags": ["Persistent SegTree", "Euler's Formula", "2DRQ"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/Game_Theory.problems.json
+++ b/content/6_Advanced/Game_Theory.problems.json
@@ -118,7 +118,7 @@
       "source": "Baltic OI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Game", "Graph"],
+      "tags": ["Game", "Graphs"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/boi-2014/tasks/blob/master/solutions/analysis/coprobber.pdf"

--- a/content/6_Advanced/Matroid.problems.json
+++ b/content/6_Advanced/Matroid.problems.json
@@ -23,7 +23,7 @@
       "source": "DMOJ",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Matroids", "Trees", "MST"],
+      "tags": ["Matroids", "Tree", "MST"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/MinCostFlow.problems.json
+++ b/content/6_Advanced/MinCostFlow.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["MCF"],
+      "tags": ["Min Cost Flow"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -21,7 +21,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["MCF"],
+      "tags": ["Min Cost Flow"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -47,7 +47,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Bitmasks", "MCF"],
+      "tags": ["Bitmasks", "Min Cost Flow"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/Offline_Del.problems.json
+++ b/content/6_Advanced/Offline_Del.problems.json
@@ -124,7 +124,7 @@
       "source": "Baltic OI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["D&C", "DSUrb"],
+      "tags": ["Divide and Conquer", "DSUrb"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/Persistent.problems.json
+++ b/content/6_Advanced/Persistent.problems.json
@@ -23,7 +23,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Persistent Segtree"],
+      "tags": ["Persistent SegTree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -36,7 +36,7 @@
       "source": "SPOJ",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Persistent Segtree"],
+      "tags": ["Persistent SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -48,7 +48,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Persistent Segtree"],
+      "tags": ["Persistent SegTree"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -60,7 +60,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Persistent Segtree"],
+      "tags": ["Persistent SegTree"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -72,7 +72,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Persistent Segtree"],
+      "tags": ["Persistent SegTree"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -84,7 +84,7 @@
       "source": "COCI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Persistent Segtree"],
+      "tags": ["Persistent SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -96,7 +96,7 @@
       "source": "NOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Persistent Segtree"],
+      "tags": ["Persistent SegTree"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -108,7 +108,7 @@
       "source": "CEOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Persistent Segtree", "Sqrt"],
+      "tags": ["Persistent SegTree", "Sqrt"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -121,7 +121,7 @@
       "source": "APIO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Persistent Segtree", "Euler's Formula", "2DRQ"],
+      "tags": ["Persistent SegTree", "Euler's Formula", "2DRQ"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -133,7 +133,7 @@
       "source": "COCI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Persistent Segtree"],
+      "tags": ["Persistent SegTree"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://hsin.hr/coci/archive/2020_2021/contest3_solutions.zip"
@@ -146,7 +146,7 @@
       "source": "IOI",
       "difficulty": "Very Hard",
       "isStarred": true,
-      "tags": ["Persistent Segtree", "2DRQ"],
+      "tags": ["Persistent SegTree", "2DRQ"],
       "solutionMetadata": {
         "kind": "IOI",
         "year": 2015

--- a/content/6_Advanced/SCC.problems.json
+++ b/content/6_Advanced/SCC.problems.json
@@ -215,7 +215,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["2SAT", "Binary Search", "Trees"],
+      "tags": ["2SAT", "Binary Search", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/SPneg.problems.json
+++ b/content/6_Advanced/SPneg.problems.json
@@ -82,7 +82,7 @@
       "source": "APIO",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["SP", "Output Only"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/Segtree_Beats.problems.json
+++ b/content/6_Advanced/Segtree_Beats.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "segtree-beats"
@@ -23,7 +23,7 @@
       "source": "YS",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "segtree-beats"
@@ -38,7 +38,7 @@
       "source": "HDU",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -50,7 +50,7 @@
       "source": "CSA",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CSA"
@@ -63,7 +63,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -76,7 +76,7 @@
       "source": "HR",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "HR"
@@ -89,7 +89,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -102,7 +102,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -115,7 +115,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -128,7 +128,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["SegTreeBeats"],
+      "tags": ["SegTree Beats"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/String_Search.problems.json
+++ b/content/6_Advanced/String_Search.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["Z", "KMP"],
+      "tags": ["Z Algorithm", "KMP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -109,7 +109,7 @@
       "source": "YS",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["Z"],
+      "tags": ["Z Algorithm"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -121,7 +121,7 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["Z", "KMP"],
+      "tags": ["Z Algorithm", "KMP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -146,7 +146,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Z"],
+      "tags": ["Z Algorithm"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/Wavelet.problems.json
+++ b/content/6_Advanced/Wavelet.problems.json
@@ -35,7 +35,7 @@
       "source": "COCI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Wavelet", "Persistent Segtree"],
+      "tags": ["Wavelet", "Persistent SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -47,7 +47,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Wavelet", "Persistent Segtree"],
+      "tags": ["Wavelet", "Persistent SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -59,7 +59,7 @@
       "source": "YS",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Wavelet", "Persistent Segtree"],
+      "tags": ["Wavelet", "Persistent SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }


### PR DESCRIPTION
Closes #6558.

Normalizes the `tags` field across all `content/**/*.problems.json`. **186 distinct tags → 144.** Data-only change; no code touched.

### 1. Split tags that mistakenly combined two topics

| before | after |
| --- | --- |
| `Trees, XOR Hashing` | `Tree`, `XOR Hashing` |
| `Two Pointers, XOR Hashing` | `Two Pointers`, `XOR Hashing` |
| `Combinatorics, XOR Hashing` | `Combinatorics`, `XOR Hashing` |
| `Binary Search, 2P` | `Binary Search`, `Two Pointers` |
| `Catalan, Combinatorics` | `Catalan`, `Combinatorics` |
| `DP, LIS` | `DP`, `LIS` |
| `Bitmask DP` | `Bitmasks`, `DP` |

`Bitmask DP` was the odd one out — every other problem in the Bitmask DP module is already tagged `["Bitmasks", "DP"]`.

### 2. Merge duplicate spellings

Where an abbreviation and a spelled-out name both existed, the spelled-out name wins:

`2P`→`Two Pointers` · `NT`→`Number Theory` · `SP`→`Shortest Path` · `D&C`→`Divide and Conquer` · `MCF`/`MinCostFlow`→`Min Cost Flow` · `Combo`→`Combinatorics`

Otherwise the more common of the two spellings wins:

`Ad-Hoc`→`Ad Hoc` · `Bitmask`→`Bitmasks` · `Centroid Decomposition`→`Centroid` · `Convex Hull`→`Convex` · `Coordinate Compress`→`Coordinate Compression` · `Cycles`→`Cycle` · `Functional Graphs`→`Functional Graph` · `Game Theory`→`Game` · `Graph`/`Graph theory`→`Graphs` · `Maps`→`Map` · `Maths`→`Math` · `Meet in Middle`→`Meet in the Middle` · `Multiset`→`Sorted Set` · `Prefix`/`Prefix Sum`→`Prefix Sums` · `Probabilities`→`Probability` · `Sliding Windows`→`Sliding Window` · `Small-To-Large Merging`→`Small to Large` · `Sortings`→`Sorting` · `Trees`→`Tree`

Segment tree family casing was inconsistent in both directions, so the whole family now uses `SegTree`: `Segment Tree`/`Segtree`→`SegTree`, `Lazy Segtree`→`Lazy SegTree`, `Persistent Segtree`→`Persistent SegTree`, `Sparse Segtree`→`Sparse SegTree`, `SegTreeBeats`→`SegTree Beats`.

### 3. Drop tags too niche to filter on

`Radians`, `Angles`, `Patterns`, `Output Only` — one use each, and none of them a technique you'd browse by. Every affected problem keeps its remaining tags (e.g. Maximum Number of Visible Points is still `Geometry`, `Sliding Window`).

### 4. Spell out cryptic tags

`Z`→`Z Algorithm`, `Hamiltonian path`→`Hamiltonian Path`.

### Left alone

Rare ≠ niche: `Cactus`, `Rerooting`, `Euler Totient`, `Generating Functions`, `Sieve`, `LCM`, `Interactive`, etc. are legitimate named topics that just happen to have one problem each.

Abbreviations that never had a spelled-out counterpart are untouched — guide jargon like `PURS`, `PURQ`, `1DRQ`/`2DRQ`/`3DRQ`, `DSUrb`, `Dynacon`, `KRT`, and standard ones like `LCA`, `DSU`, `SCC`, `MST`, `HLD`, `BCC`, `APSP`. (`APSP` sitting next to `Shortest Path` is a little uneven — happy to expand that one too if you'd prefer.)

Genuinely distinct neighbors are also left as-is: `Bitwise`/`Bitmasks`/`Bitset`, `Divisors`/`Divisibility`, `Spanning Tree`/`MST`, `Suffix Array`/`Suffix Tree`/`Suffix Structures`.

### Verification

- `git diff` touches only tag content — 48 files. The one non-`"tags":`-line hunk is Prettier rewrapping a now-longer tags array onto multiple lines.
- All 145 `*.problems.json` files still parse, and `prettier --check` passes on every changed file.
- No problem ended up with an empty tag list that didn't already have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAtwgtWDg8mxDCGH7ZW59X