### PR TITLE
feat: paginate conclusion problem tables (12 per page)

### DIFF
--- a/content/2_Bronze/Conclusion.mdx
+++ b/content/2_Bronze/Conclusion.mdx
@@ -23,7 +23,7 @@ concept</Asterisk> The difficulties listed here are relative to the Bronze
 division (difficulty is subjective and isn't always accurate though). We'll be
 expanding this list as we get more problem suggestions.
 
-<Problems problems="problems" />
+<Problems problems="problems" pageSize={12} />
 
 ## Final Thoughts
 

--- a/content/3_Silver/Conclusion.mdx
+++ b/content/3_Silver/Conclusion.mdx
@@ -25,7 +25,7 @@ these problems appeared in a higher division, but can still be solved using only
 Silver-level topics. We'll be expanding this list as we get more problem
 suggestions.
 
-<Problems problems="problems" />
+<Problems problems="problems" pageSize={12} />
 
 ## Final Thoughts
 

--- a/content/4_Gold/Conclusion.mdx
+++ b/content/4_Gold/Conclusion.mdx
@@ -24,7 +24,7 @@ concept</Asterisk> The difficulties listed here are relative to the Gold
 division (difficulty is subjective and isn't always accurate though). We'll be
 expanding this list as we get more problem suggestions.
 
-<Problems problems="problems" />
+<Problems problems="problems" pageSize={12} />
 
 ## Final Thoughts
 

--- a/content/5_Plat/Conclusion.mdx
+++ b/content/5_Plat/Conclusion.mdx
@@ -15,7 +15,7 @@ concept</Asterisk> The difficulties listed here are relative to the Platinum
 division (difficulty is subjective and isn't always accurate though). We'll be
 expanding this list as we get more problem suggestions.
 
-<Problems problems="problems" />
+<Problems problems="problems" pageSize={12} />
 
 ## Final Thoughts
 

--- a/src/components/markdown/ProblemsList/ProblemsList.tsx
+++ b/src/components/markdown/ProblemsList/ProblemsList.tsx
@@ -12,6 +12,7 @@ import { ListTable } from '../ListTable/ListTable';
 import { DivisionProblemInfo } from './DivisionList/DivisionProblemInfo';
 import ProblemsListHeader from './ProblemsListHeader';
 import ProblemsListItem from './ProblemsListItem';
+import ProblemsListPagination from './ProblemsListPagination';
 import SuggestProblemRow from './SuggestProblemRow';
 
 type ProblemsListProps =
@@ -20,6 +21,11 @@ type ProblemsListProps =
       children?: React.ReactNode;
       problems?: string;
       hideSuggestProblemButton?: boolean;
+      /**
+       * If set, the table is split into pages of this many problems. Problem
+       * order is unchanged. Only supported for non-division tables.
+       */
+      pageSize?: number;
     }
   | {
       title?: string;
@@ -36,6 +42,7 @@ type AnnotatedProblemsListProps =
       children?: React.ReactNode;
       problems: ProblemInfo[];
       hideSuggestProblemButton?: boolean;
+      pageSize?: number;
     }
   | {
       isDivisionTable: true;
@@ -80,14 +87,81 @@ export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
 
   const path = usePathname();
 
+  const tableId = `problemlist-${
+    props.isDivisionTable === false
+      ? props.tableName
+      : 'division-' + props.division
+  }`;
+
+  // Pagination is opt-in via the `pageSize` prop, and only for non-division
+  // tables (division tables are already filtered by division & season).
+  const pageSize = props.isDivisionTable === false ? props.pageSize : undefined;
+  const isPaginated = !!pageSize && props.problems!.length > pageSize;
+  const numPages = isPaginated
+    ? Math.ceil(props.problems!.length / pageSize!)
+    : 1;
+  const [page, setPage] = React.useState(0);
+  // Set once we've jumped to the page containing the problem linked to by the
+  // URL hash, so that we can scroll to it after that page has rendered.
+  const [pendingHashScroll, setPendingHashScroll] = React.useState<
+    string | null
+  >(null);
+
+  const problemsRef = React.useRef(props.problems);
+  problemsRef.current = props.problems;
+
+  // Links to a specific problem (`#problem-<uniqueId>`) may point at a problem
+  // that isn't on the first page, so switch to the page containing it. The
+  // browser can't scroll to it on its own since it isn't rendered yet.
+  React.useEffect(() => {
+    if (!isPaginated) return;
+    const goToHashedProblem = () => {
+      const prefix = '#problem-';
+      const hash = decodeURIComponent(window.location.hash);
+      if (!hash.startsWith(prefix)) return;
+      const uniqueId = hash.substring(prefix.length);
+      const index = (problemsRef.current as ProblemInfo[]).findIndex(
+        problem => problem.uniqueId === uniqueId
+      );
+      if (index === -1) return;
+      setPage(Math.floor(index / pageSize!));
+      setPendingHashScroll(`problem-${uniqueId}`);
+    };
+    goToHashedProblem();
+    window.addEventListener('hashchange', goToHashedProblem);
+    return () => window.removeEventListener('hashchange', goToHashedProblem);
+  }, [isPaginated, pageSize]);
+
+  React.useEffect(() => {
+    if (!pendingHashScroll) return;
+    document.getElementById(pendingHashScroll)?.scrollIntoView();
+    setPendingHashScroll(null);
+  }, [pendingHashScroll]);
+
+  // Scrolling has to happen after the new page has been committed to the DOM,
+  // otherwise a shorter page shifts the layout out from under us.
+  const [pendingScrollToTable, setPendingScrollToTable] = React.useState(false);
+  React.useEffect(() => {
+    if (!pendingScrollToTable) return;
+    document
+      .getElementById(tableId)
+      ?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    setPendingScrollToTable(false);
+  }, [pendingScrollToTable, tableId]);
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+    setPendingScrollToTable(true);
+  };
+
+  const shownProblems = isPaginated
+    ? props.problems!.slice(page * pageSize!, (page + 1) * pageSize!)
+    : props.problems!;
+
   return (
     <>
       <ListTable
-        id={`problemlist-${
-          props.isDivisionTable === false
-            ? props.tableName
-            : 'division-' + props.division
-        }`}
+        id={tableId}
         header={
           <ProblemsListHeader
             showTags={showTags}
@@ -122,7 +196,7 @@ export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
           })}
         {props.isDivisionTable === false && (
           <>
-            {props.problems.map((problem: ProblemInfo) => (
+            {(shownProblems as ProblemInfo[]).map((problem: ProblemInfo) => (
               <ProblemsListItem
                 key={problem.uniqueId}
                 problem={problem}
@@ -136,12 +210,24 @@ export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
                 showPercent={shouldShowSolvePercentage}
               />
             ))}
-            {!props.hideSuggestProblemButton && path.includes('conclusion') && (
-              <SuggestProblemRow listName={props.tableName!} />
-            )}
+            {!props.hideSuggestProblemButton &&
+              path.includes('conclusion') &&
+              page === numPages - 1 && (
+                <SuggestProblemRow listName={props.tableName!} />
+              )}
           </>
         )}
       </ListTable>
+
+      {isPaginated && (
+        <ProblemsListPagination
+          page={page}
+          numPages={numPages}
+          numProblems={props.problems!.length}
+          pageSize={pageSize!}
+          onChange={handlePageChange}
+        />
+      )}
 
       <Transition show={showModal} as={Fragment}>
         <div className="fixed inset-x-0 bottom-0 z-10 px-4 pb-6 sm:inset-0 sm:flex sm:items-center sm:justify-center sm:p-0">

--- a/src/components/markdown/ProblemsList/ProblemsList.tsx
+++ b/src/components/markdown/ProblemsList/ProblemsList.tsx
@@ -3,8 +3,11 @@ import { usePathname } from 'next/navigation';
 import * as React from 'react';
 import { Fragment } from 'react';
 import { useMarkdownProblemLists } from '../../../context/MarkdownProblemListsContext';
+import { useIsUserDataLoaded } from '../../../context/UserDataContext/UserDataContext';
 import {
   useHideDifficultySetting,
+  useProblemListPages,
+  useSetProblemListPage,
   useShowTagsSetting,
 } from '../../../context/UserDataContext/properties/simpleProperties';
 import { ProblemInfo } from '../../../models/problem';
@@ -110,6 +113,29 @@ export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
   const problemsRef = React.useRef(props.problems);
   problemsRef.current = props.problems;
 
+  // The list id alone isn't unique across the site -- every conclusion module
+  // names its list "problems" -- so scope the remembered page to the module.
+  const pageKey = `${path}|${
+    props.isDivisionTable === false ? props.tableName : ''
+  }`;
+  const storedPages = useProblemListPages();
+  const setStoredPage = useSetProblemListPage();
+  const isUserDataLoaded = useIsUserDataLoaded();
+  // Restoring only happens once, so that a slow write doesn't bounce the user
+  // back to the page they just navigated away from.
+  const hasSetPageRef = React.useRef(false);
+
+  // User data isn't available on the first render, so the remembered page gets
+  // restored once it loads.
+  React.useEffect(() => {
+    if (!isPaginated || hasSetPageRef.current) return;
+    const storedPage = storedPages?.[pageKey];
+    if (storedPage === undefined) return;
+    hasSetPageRef.current = true;
+    // The list may have shrunk since the page was remembered.
+    setPage(Math.min(Math.max(storedPage, 0), numPages - 1));
+  }, [isPaginated, storedPages, pageKey, numPages]);
+
   // Links to a specific problem (`#problem-<uniqueId>`) may point at a problem
   // that isn't on the first page, so switch to the page containing it. The
   // browser can't scroll to it on its own since it isn't rendered yet.
@@ -124,6 +150,8 @@ export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
         problem => problem.uniqueId === uniqueId
       );
       if (index === -1) return;
+      // A deep link is more specific than the remembered page, so it wins.
+      hasSetPageRef.current = true;
       setPage(Math.floor(index / pageSize!));
       setPendingHashScroll(`problem-${uniqueId}`);
     };
@@ -150,8 +178,11 @@ export function ProblemsList(unannotatedProps: ProblemsListProps): JSX.Element {
   }, [pendingScrollToTable, tableId]);
 
   const handlePageChange = (newPage: number) => {
+    hasSetPageRef.current = true;
     setPage(newPage);
     setPendingScrollToTable(true);
+    // updateUserData() throws if it's called before user data finishes loading.
+    if (isUserDataLoaded) setStoredPage(pageKey, newPage);
   };
 
   const shownProblems = isPaginated

--- a/src/components/markdown/ProblemsList/ProblemsListPagination.tsx
+++ b/src/components/markdown/ProblemsList/ProblemsListPagination.tsx
@@ -1,0 +1,111 @@
+export type ProblemsListPaginationProps = {
+  page: number; // zero-indexed
+  numPages: number;
+  numProblems: number;
+  pageSize: number;
+  onChange: (page: number) => void;
+};
+
+/**
+ * Returns the page numbers (zero-indexed) to show, with `null` marking an
+ * ellipsis. Always includes the first page, the last page, and the pages
+ * adjacent to the current one.
+ */
+const getPageItems = (page: number, numPages: number): (number | null)[] => {
+  const shown = new Set<number>();
+  for (const p of [0, page - 1, page, page + 1, numPages - 1]) {
+    if (p >= 0 && p < numPages) shown.add(p);
+  }
+  const sorted = [...shown].sort((a, b) => a - b);
+  const items: (number | null)[] = [];
+  let prev: number | null = null;
+  for (const p of sorted) {
+    if (prev !== null && p !== prev + 1) items.push(null);
+    items.push(p);
+    prev = p;
+  }
+  return items;
+};
+
+const arrowClasses =
+  'dark:text-dark-high-emphasis inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm leading-5 font-medium text-gray-700 transition duration-150 ease-in-out hover:text-gray-500 focus:border-blue-300 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-gray-700 dark:border-gray-800 dark:bg-gray-900 dark:disabled:hover:text-gray-400';
+
+export default function ProblemsListPagination({
+  page,
+  numPages,
+  numProblems,
+  pageSize,
+  onChange,
+}: ProblemsListPaginationProps): JSX.Element {
+  const first = page * pageSize + 1;
+  const last = Math.min((page + 1) * pageSize, numProblems);
+
+  return (
+    <nav
+      className="mb-4 flex flex-col items-center justify-between gap-3 px-4 sm:flex-row sm:px-6 md:px-0"
+      aria-label="Problem list pagination"
+    >
+      <p className="dark:text-dark-med-emphasis text-sm text-gray-500">
+        Showing{' '}
+        <span className="dark:text-dark-high-emphasis font-medium text-gray-700">
+          {first}
+        </span>
+        –
+        <span className="dark:text-dark-high-emphasis font-medium text-gray-700">
+          {last}
+        </span>{' '}
+        of{' '}
+        <span className="dark:text-dark-high-emphasis font-medium text-gray-700">
+          {numProblems}
+        </span>{' '}
+        problems
+      </p>
+
+      <div className="flex items-center space-x-1">
+        <button
+          type="button"
+          className={arrowClasses}
+          onClick={() => onChange(page - 1)}
+          disabled={page === 0}
+        >
+          Prev
+        </button>
+
+        {getPageItems(page, numPages).map((p, i) =>
+          p === null ? (
+            <span
+              key={`ellipsis-${i}`}
+              className="px-1 text-sm text-gray-500 dark:text-gray-400"
+            >
+              …
+            </span>
+          ) : (
+            <button
+              key={p}
+              type="button"
+              aria-current={p === page ? 'page' : undefined}
+              className={
+                'inline-flex items-center rounded-md border px-3 py-1.5 text-sm leading-5 font-medium transition duration-150 ease-in-out focus:outline-hidden ' +
+                (p === page
+                  ? 'border-blue-600 bg-blue-600 text-white dark:border-blue-700 dark:bg-blue-700'
+                  : 'dark:text-dark-high-emphasis border-gray-300 bg-white text-gray-700 hover:text-gray-500 focus:border-blue-300 dark:border-gray-800 dark:bg-gray-900')
+              }
+              onClick={() => onChange(p)}
+            >
+              {p + 1}
+            </button>
+          )
+        )}
+
+        <button
+          type="button"
+          className={arrowClasses}
+          onClick={() => onChange(page + 1)}
+          disabled={page === numPages - 1}
+        >
+          Next
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/src/context/UserDataContext/UserDataContext.tsx
+++ b/src/context/UserDataContext/UserDataContext.tsx
@@ -41,6 +41,11 @@ export type UserData = {
     division: string;
     season: string;
   };
+  /**
+   * Which page of a paginated problems table the user last had open,
+   * mapping `<module path>|<problem list id>` to a zero-indexed page number.
+   */
+  problemListPages: Record<string, number>;
   lang: Language;
   lastViewedModule: string;
   lastVisitDate: number; // timestamp
@@ -95,6 +100,7 @@ export const assignDefaultsToUserData = (data: object): UserData => {
       division: '',
       season: '',
     },
+    problemListPages: {},
     lang: 'cpp',
     lastViewedModule: '',
     lastVisitDate: new Date().getTime(),

--- a/src/context/UserDataContext/migration.ts
+++ b/src/context/UserDataContext/migration.ts
@@ -30,6 +30,8 @@ export default function runMigration() {
       hideModules: getLegacy('hideModules')!,
       showIgnored: getLegacy('showIgnored')!,
       divisionTableQuery: getLegacy('divisionTableQuery')!,
+      // didn't exist in the legacy schema
+      problemListPages: {},
       lang: getLegacy('lang')!,
       lastViewedModule: getLegacy('lastViewedModule')!,
       lastVisitDate: getLegacy('lastVisitDate')!,

--- a/src/context/UserDataContext/properties/simpleProperties.ts
+++ b/src/context/UserDataContext/properties/simpleProperties.ts
@@ -89,6 +89,20 @@ export const useSetDivisionTableQuery = createSimpleUserDataMutation(
   }
 );
 
+export const useProblemListPages = createUserDataGetter(
+  userData => userData.problemListPages
+);
+export const useSetProblemListPage = createSimpleUserDataMutation(
+  (userData, listKey: string, page: number) => {
+    return {
+      problemListPages: {
+        ...userData.problemListPages,
+        [listKey]: page,
+      },
+    };
+  }
+);
+
 // last viewed module is set in useUpdateStreakEffect
 // we have a limitation of one update per second (firebase rate limit),
 // so we combine the two updates


### PR DESCRIPTION
Addresses the first half of #6559 — the Silver and Gold additional practice lists (62 and 51 problems) are hard to navigate as one long table.

Adds opt-in pagination to `<Problems />` via a new `pageSize` prop, and turns it on for all four conclusion modules at **12 problems per page**. **Problem order is unchanged.**

Not doing starring or difficulty subdivision here — that's the other half of the issue.

### Changes

**Pagination**

- **`ProblemsListPagination.tsx`** (new) — numbered pager below the table: `Showing 1–12 of 62 problems` on the left, `Prev [1][2]…[6] Next` on the right. Ellipsis-windowed so it stays compact as lists grow; stacks vertically on mobile.
- **`ProblemsList.tsx`** — slices the list when `pageSize` is set and the list is longer than one page (so short lists render exactly as before once they fit). Division tables are unaffected; they already filter by division/season.
- `#problem-<uniqueId>` deep links (e.g. the Module column on [USACO Monthlies](https://usaco.guide/general/usaco-monthlies)) jump to the page containing that problem and scroll to it — the browser can't scroll to a row that isn't rendered. Also listens for `hashchange`.
- Changing pages scrolls back to the top of the table (after commit, so the layout doesn't shift out from under it).
- The "Suggest a Problem" row now renders only on the last page.

**Remembering the page**

Reloading the module, or navigating to another module and back, would otherwise reset you to page 1. The open page is now persisted in user data as `problemListPages`, alongside the existing `divisionTableQuery` used by the monthlies table.

- Stored per module (`<module path>|<list id>`) — every conclusion module names its list `problems`, so the list id alone isn't a unique key. Silver and Gold each remember their own page.
- Restored once, when user data finishes loading, and clamped in case the list has shrunk since.
- A `#problem-<id>` deep link takes precedence over the remembered page.

### Testing

Verified locally on `/silver/silver-conclusion`, `/gold/gold-conclusion`, and `/bronze/bronze-conclusion`:

- 12 rows per page; counts and Prev/Next disabled states correct at both ends.
- Set Silver to page 2 → reload → still page 2; navigate to Gold (page 1, its own key) and back → Silver still page 2.
- `/silver/silver-conclusion#problem-cf-1622C` opens on page 3 with "Set Or Decrease" highlighted and scrolled into view, overriding the remembered page 2.
- Light and dark mode, and 500px-wide viewport (no horizontal overflow).
- `yarn check-ts-errors` clean; no new eslint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8xzeth53L1Zy4kgdUcS6N