### PR TITLE
chore: finish the tag cleanup — merges, extraProblems, alphabetical order

### DIFF
--- a/content/2_Bronze/Complete_Rec.problems.json
+++ b/content/2_Bronze/Complete_Rec.problems.json
@@ -23,7 +23,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Complete Search", "Recursion", "Permutation"],
+      "tags": ["Complete Search", "Permutation", "Recursion"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "complete-rec"
@@ -38,7 +38,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Complete Search", "Recursion", "Permutation"],
+      "tags": ["Complete Search", "Permutation", "Recursion"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "complete-rec"
@@ -65,7 +65,7 @@
       "source": "Bronze",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Complete Search", "Recursion", "Permutation"],
+      "tags": ["Complete Search", "Permutation", "Recursion"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/2_Bronze/Intro_Graphs.problems.json
+++ b/content/2_Bronze/Intro_Graphs.problems.json
@@ -8,7 +8,7 @@
       "source": "Bronze",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Permutation", "Graphs"],
+      "tags": ["Graphs", "Permutation"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -35,7 +35,7 @@
       "source": "Bronze",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Tree", "DFS"],
+      "tags": ["DFS", "Tree"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -61,7 +61,7 @@
       "source": "Bronze",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Permutation", "Cycle"],
+      "tags": ["Cycle", "Permutation"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/2_Bronze/Intro_Sets.problems.json
+++ b/content/2_Bronze/Intro_Sets.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Sorting", "Set"],
+      "tags": ["Set", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -61,7 +61,7 @@
       "source": "Bronze",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Simulation", "Set"],
+      "tags": ["Set", "Simulation"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -121,7 +121,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Set", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Set"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -133,7 +133,7 @@
       "source": "Bronze",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Set", "Map"],
+      "tags": ["Map", "Set"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1445"
@@ -158,7 +158,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Set", "Map"],
+      "tags": ["Map", "Set"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/2_Bronze/Intro_Sorting.problems.json
+++ b/content/2_Bronze/Intro_Sorting.problems.json
@@ -47,7 +47,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Sorting", "Greedy"],
+      "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -59,7 +59,7 @@
       "source": "Bronze",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorting", "Simulation"],
+      "tags": ["Simulation", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Binary_Search.problems.json
+++ b/content/3_Silver/Binary_Search.problems.json
@@ -72,7 +72,7 @@
       "source": "Gold",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Binary Search", "Sorting", "Two Pointers", "Greedy"],
+      "tags": ["Binary Search", "Greedy", "Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/3_Silver/Binary_Search_Sorted_Array.problems.json
+++ b/content/3_Silver/Binary_Search_Sorted_Array.problems.json
@@ -22,7 +22,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Two Pointers", "Binary Search"],
+      "tags": ["Binary Search", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": ["Trees", "Greedy"],
+      "tags": ["Tree", "Greedy"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -606,7 +606,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Trees"],
+      "tags": ["Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": ["Tree", "Greedy"],
+      "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -300,7 +300,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Ad Hoc", "Greedy", "DFS"],
+      "tags": ["Ad Hoc", "DFS", "Greedy"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -324,7 +324,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Number Theory", "Graphs", "BFS", "Shortest Path", "Bipartite"],
+      "tags": ["BFS", "Bipartite", "Graphs", "Number Theory", "Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -422,7 +422,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Greedy", "Prefix Sums", "Bitwise"],
+      "tags": ["Bitwise", "Greedy", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -482,7 +482,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DFS", "Bipartite"],
+      "tags": ["Bipartite", "DFS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -506,7 +506,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "Greedy"],
+      "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -519,7 +519,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Prefix Sums", "Binary Search"],
+      "tags": ["Binary Search", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -545,7 +545,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DFS", "Connected Components"],
+      "tags": ["Connected Components", "DFS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -594,7 +594,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Binary Search", "Prefix Sums", "Greedy"],
+      "tags": ["Binary Search", "Greedy", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -643,7 +643,7 @@
       "source": "AC",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Tree", "Game"],
+      "tags": ["Game", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -694,7 +694,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Functional Graph", "Binary Search", "Math"],
+      "tags": ["Binary Search", "Functional Graph", "Math"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -720,7 +720,7 @@
       "source": "CF",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Priority Queue", "Math"],
+      "tags": ["Math", "Priority Queue"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -733,7 +733,7 @@
       "source": "Kattis",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Connected Components", "Binary Search"],
+      "tags": ["Binary Search", "Connected Components"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -757,7 +757,7 @@
       "source": "Gold",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Binary Search", "Prefix Sums", "Two Pointers", "Sqrt"],
+      "tags": ["Binary Search", "Prefix Sums", "Sqrt", "Two Pointers"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1449"

--- a/content/3_Silver/Flood_Fill.problems.json
+++ b/content/3_Silver/Flood_Fill.problems.json
@@ -47,7 +47,7 @@
       "source": "Kattis",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Flood Fill", "Connected Components"],
+      "tags": ["Connected Components", "Flood Fill"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -59,7 +59,7 @@
       "source": "Old Silver",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Flood Fill", "Binary Search"],
+      "tags": ["Binary Search", "Flood Fill"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/3_Silver/Graph_Traversal.problems.json
+++ b/content/3_Silver/Graph_Traversal.problems.json
@@ -35,7 +35,7 @@
       "source": "Silver",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Connected Components", "DFS", "BFS"],
+      "tags": ["BFS", "Connected Components", "DFS"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -108,7 +108,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Connected Components", "Binary Search"],
+      "tags": ["Binary Search", "Connected Components"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -120,7 +120,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Connected Components", "Binary Search"],
+      "tags": ["Binary Search", "Connected Components"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -145,7 +145,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Connected Components", "Two Pointers", "Binary Search"],
+      "tags": ["Binary Search", "Connected Components", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -169,7 +169,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DFS", "Connected Components", "Prefix Sums"],
+      "tags": ["Connected Components", "DFS", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -193,7 +193,7 @@
       "source": "Silver",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Spanning Tree", "Constructive", "Cycle"],
+      "tags": ["Constructive", "Cycle", "Spanning Tree"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1184"
@@ -271,7 +271,7 @@
       "source": "CC",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DFS", "Bipartite"],
+      "tags": ["Bipartite", "DFS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -283,7 +283,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DFS", "Bipartite"],
+      "tags": ["Bipartite", "DFS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -295,7 +295,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Tree", "Bipartite"],
+      "tags": ["Bipartite", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/3_Silver/Greedy_Sorting.problems.json
+++ b/content/3_Silver/Greedy_Sorting.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": ["Sorting", "Greedy"],
+      "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -22,7 +22,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Sorting", "Greedy"],
+      "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "greedy-sorting"
@@ -135,7 +135,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Sorting", "Greedy"],
+      "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -159,7 +159,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorting", "Greedy", "Deque"],
+      "tags": ["Deque", "Greedy", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -171,7 +171,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorting", "Greedy"],
+      "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -207,7 +207,7 @@
       "source": "Silver",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Sorting", "Greedy", "Two Pointers"],
+      "tags": ["Greedy", "Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Intro_Bitwise.problems.json
+++ b/content/3_Silver/Intro_Bitwise.problems.json
@@ -65,7 +65,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Bitwise", "Complete Search", "Binary Search"],
+      "tags": ["Binary Search", "Bitwise", "Complete Search"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -136,7 +136,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Bitwise", "Prefix Sums", "Binary Search"],
+      "tags": ["Binary Search", "Bitwise", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -173,7 +173,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Math", "Greedy"],
+      "tags": ["Greedy", "Math"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -211,7 +211,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Math", "Interactive"],
+      "tags": ["Interactive", "Math"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Intro_Tree.problems.json
+++ b/content/3_Silver/Intro_Tree.problems.json
@@ -23,7 +23,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Tree", "Connected Components", "Diameter"],
+      "tags": ["Connected Components", "Diameter", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -35,7 +35,7 @@
       "source": "Silver",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Tree", "Connected Components"],
+      "tags": ["Connected Components", "Tree"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -60,7 +60,7 @@
       "source": "Silver",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Tree", "Connected Components"],
+      "tags": ["Connected Components", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -84,7 +84,7 @@
       "source": "Silver",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Tree", "Coloring"],
+      "tags": ["Coloring", "Tree"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -157,7 +157,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "Sorting", "Binary Search"],
+      "tags": ["Binary Search", "Sorting", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -169,7 +169,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "Bipartite"],
+      "tags": ["Bipartite", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -181,7 +181,7 @@
       "source": "POI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Tree", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/More_Prefix_Sums.problems.json
+++ b/content/3_Silver/More_Prefix_Sums.problems.json
@@ -191,7 +191,7 @@
       "source": "AC",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Tree", "2D Prefix Sums"],
+      "tags": ["2D Prefix Sums", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Prefix_Sums.problems.json
+++ b/content/3_Silver/Prefix_Sums.problems.json
@@ -59,7 +59,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Prefix Sums", "Math"],
+      "tags": ["Math", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Priority_Queues.problems.json
+++ b/content/3_Silver/Priority_Queues.problems.json
@@ -23,7 +23,7 @@
       "source": "LC",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Greedy", "Sorting", "Priority Queue"],
+      "tags": ["Greedy", "Priority Queue", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -47,7 +47,7 @@
       "source": "Silver",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Sorted Set", "Priority Queue"],
+      "tags": ["Priority Queue", "Sorted Set"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -71,7 +71,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Sorting", "Priority Queue"],
+      "tags": ["Priority Queue", "Sorting"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -83,7 +83,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorting", "Priority Queue"],
+      "tags": ["Priority Queue", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Sorting_Custom.problems.json
+++ b/content/3_Silver/Sorting_Custom.problems.json
@@ -37,7 +37,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Sorting", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -49,7 +49,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorting", "Prefix Sums", "Coordinate Compression"],
+      "tags": ["Coordinate Compression", "Prefix Sums", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -61,7 +61,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorting", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -73,7 +73,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Sorting", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -109,7 +109,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Sorting", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -133,7 +133,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorting", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/3_Silver/Two_Pointers.problems.json
+++ b/content/3_Silver/Two_Pointers.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["Two Pointers", "Sorting"],
+      "tags": ["Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -49,7 +49,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Two Pointers", "Sorting"],
+      "tags": ["Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -61,7 +61,7 @@
       "source": "Silver",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Two Pointers", "Sorting"],
+      "tags": ["Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -73,7 +73,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Two Pointers", "Binary Search"],
+      "tags": ["Binary Search", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -97,7 +97,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Two Pointers", "Sorting", "Sliding Window"],
+      "tags": ["Sliding Window", "Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -109,7 +109,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Two Pointers", "Sorting"],
+      "tags": ["Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -121,7 +121,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Two Pointers", "Sorting"],
+      "tags": ["Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -145,7 +145,7 @@
       "source": "Silver",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Two Pointers", "Prefix Sums", "Binary Search"],
+      "tags": ["Binary Search", "Prefix Sums", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -157,7 +157,7 @@
       "source": "CEOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Two Pointers", "Sorting"],
+      "tags": ["Sorting", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -169,7 +169,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Two Pointers", "Greedy"],
+      "tags": ["Greedy", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/4_Gold/All_Roots.problems.json
+++ b/content/4_Gold/All_Roots.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Tree", "DFS"],
+      "tags": ["DFS", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -71,7 +71,7 @@
       "source": "APIO",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["DP", "Casework"],
+      "tags": ["Casework", "DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "DMOJ"
@@ -96,7 +96,7 @@
       "source": "APIO",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["DP", "Casework"],
+      "tags": ["Casework", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Combinatorics.problems.json
+++ b/content/4_Gold/Combinatorics.problems.json
@@ -107,7 +107,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Combinatorics", "Binary Search"],
+      "tags": ["Binary Search", "Combinatorics"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -144,7 +144,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Combinatorics", "Bitwise"],
+      "tags": ["Bitwise", "Combinatorics"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -194,7 +194,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Bitset"],
+      "tags": ["Bitset", "PIE"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -246,7 +246,7 @@
       "source": "Gold",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Combinatorics", "Probability", "Math", "Binary Search"],
+      "tags": ["Binary Search", "Combinatorics", "Math", "Probability"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -592,7 +592,7 @@
       "source": "AC",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Expected Value", "Combinatorics"],
+      "tags": ["Probability", "Combinatorics"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -647,6 +647,18 @@
       "solutionMetadata": {
         "kind": "internal"
       }
+    },
+    {
+      "uniqueId": "cf-1582F1",
+      "name": "Korney Korneevich and XOR (easy version)",
+      "url": "https://codeforces.com/problemset/problem/1582/F1",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Bitmasks", "DP"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
     }
   ]
 }

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -655,7 +655,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Bitmasks", "DP"],
+      "tags": ["Bitwise", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -20,7 +20,7 @@
       "source": "Old Gold",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Bitmasks", "DP", "BFS"],
+      "tags": ["BFS", "Bitmasks", "DP"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -149,7 +149,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SegTree", "DP"],
+      "tags": ["DP", "SegTree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -174,7 +174,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Math", "Knapsack"],
+      "tags": ["DP", "Knapsack", "Math"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -301,7 +301,7 @@
       "source": "Kattis",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["LIS", "DP"],
+      "tags": ["DP", "LIS"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -314,7 +314,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DSU", "Set", "Greedy"],
+      "tags": ["DSU", "Greedy", "Set"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -339,7 +339,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Binary Search", "Two Pointers", "PURS"],
+      "tags": ["Binary Search", "DP", "PURS", "Two Pointers"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -364,7 +364,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Binary Search", "PURS", "DP"],
+      "tags": ["Binary Search", "DP", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -376,7 +376,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorted Set", "Priority Queue"],
+      "tags": ["Priority Queue", "Sorted Set"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -402,7 +402,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Bitmasks"],
+      "tags": ["Bitmasks", "DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -415,7 +415,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Number Theory", "Greedy"],
+      "tags": ["Greedy", "Number Theory"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"
@@ -466,7 +466,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "0/1 BFS", "Binary Search", "DSU"],
+      "tags": ["0/1 BFS", "Binary Search", "DP", "DSU"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -479,7 +479,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Tree", "Probability"],
+      "tags": ["DP", "Probability", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -504,7 +504,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DSU", "DP"],
+      "tags": ["DP", "DSU"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -529,7 +529,7 @@
       "source": "OII",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Stack", "Divide and Conquer"],
+      "tags": ["Divide and Conquer", "Stack"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -592,7 +592,7 @@
       "source": "AC",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Probability", "Combinatorics"],
+      "tags": ["Combinatorics", "Probability"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"

--- a/content/4_Gold/DP_Bitmasks.problems.json
+++ b/content/4_Gold/DP_Bitmasks.problems.json
@@ -135,7 +135,7 @@
       "source": "Kattis",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Bitmasks", "DP", "Geometry", "Binary Search"],
+      "tags": ["Binary Search", "Bitmasks", "DP", "Geometry"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -147,7 +147,7 @@
       "source": "YS",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Bitmasks", "Meet in the Middle", "DP"],
+      "tags": ["Bitmasks", "DP", "Meet in the Middle"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -198,7 +198,7 @@
       "source": "COCI",
       "difficulty": "Very Hard",
       "isStarred": true,
-      "tags": ["Bitmasks", "DP", "Tree", "Game"],
+      "tags": ["Bitmasks", "DP", "Game", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -223,7 +223,7 @@
       "source": "IOI",
       "difficulty": "Very Hard",
       "isStarred": true,
-      "tags": ["Bitmasks", "DP", "Tree", "DFS"],
+      "tags": ["Bitmasks", "DFS", "DP", "Tree"],
       "solutionMetadata": {
         "kind": "IOI",
         "year": 2007
@@ -238,7 +238,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "Combinatorics"],
+      "tags": ["Combinatorics", "DP"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -251,7 +251,7 @@
       "source": "CF",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["DP", "Bitmasks", "Number Theory"],
+      "tags": ["Bitmasks", "DP", "Number Theory"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -264,7 +264,7 @@
       "source": "CF",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["Bitmasks", "Number Theory", "Binary Search"],
+      "tags": ["Binary Search", "Bitmasks", "Number Theory"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -277,7 +277,7 @@
       "source": "CF",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["DP", "Bitmasks", "Combinatorics"],
+      "tags": ["Bitmasks", "Combinatorics", "DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/4_Gold/DP_Trees.problems.json
+++ b/content/4_Gold/DP_Trees.problems.json
@@ -23,7 +23,7 @@
       "source": "AC",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -35,7 +35,7 @@
       "source": "Gold",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -60,7 +60,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -73,7 +73,7 @@
       "source": "Baltic OI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "Greedy"],
+      "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -85,7 +85,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "Greedy"],
+      "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -110,7 +110,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -122,7 +122,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -134,7 +134,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -146,7 +146,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "Greedy"],
+      "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -183,7 +183,7 @@
       "source": "Kattis",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "Tree", "Number Theory"],
+      "tags": ["DP", "Number Theory", "Tree"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -208,7 +208,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "Tree", "Binary Search"],
+      "tags": ["Binary Search", "DP", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -260,7 +260,7 @@
       "source": "CSES",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["Tree", "Greedy"],
+      "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
         "kind": "sketch",
         "sketch": "equivalent to Baltic OI - Cat in a Tree."
@@ -273,7 +273,7 @@
       "source": "Baltic OI",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Divisibility.problems.json
+++ b/content/4_Gold/Divisibility.problems.json
@@ -175,7 +175,7 @@
       "source": "SPOJ",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Divisibility", "LCM", "Euler Totient"],
+      "tags": ["Divisibility", "Euler Totient", "LCM"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Hashing.problems.json
+++ b/content/4_Gold/Hashing.problems.json
@@ -84,7 +84,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Hashing", "Binary Search"],
+      "tags": ["Binary Search", "Hashing"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -134,7 +134,7 @@
       "source": "COCI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Hashing", "Binary Search"],
+      "tags": ["Binary Search", "Hashing"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -172,7 +172,7 @@
       "source": "COCI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Hashing", "DSU"],
+      "tags": ["DSU", "Hashing"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -184,7 +184,7 @@
       "source": "COI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Hashing", "Binary Search"],
+      "tags": ["Binary Search", "Hashing"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Intro_DP.problems.json
+++ b/content/4_Gold/Intro_DP.problems.json
@@ -112,7 +112,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "BFS"],
+      "tags": ["BFS", "DP"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -163,7 +163,7 @@
       "source": "Gold",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "Prefix Sums", "APSP"],
+      "tags": ["APSP", "DP", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Intro_Sorted_Sets.problems.json
+++ b/content/4_Gold/Intro_Sorted_Sets.problems.json
@@ -44,7 +44,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Sorted Set", "Greedy", "Binary Search"],
+      "tags": ["Binary Search", "Greedy", "Sorted Set"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -72,7 +72,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorted Set", "Priority Queue"],
+      "tags": ["Priority Queue", "Sorted Set"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -84,7 +84,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorted Set", "Sorting", "Greedy"],
+      "tags": ["Greedy", "Sorted Set", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -96,7 +96,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Sorting", "Sorted Set", "Greedy"],
+      "tags": ["Greedy", "Sorted Set", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -120,7 +120,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Greedy", "Sorting", "Sorted Set"],
+      "tags": ["Greedy", "Sorted Set", "Sorting"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -159,7 +159,7 @@
       "source": "Gold",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Sorting", "Greedy", "Sorted Set"],
+      "tags": ["Greedy", "Sorted Set", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Intro_Sorted_Sets.problems.json
+++ b/content/4_Gold/Intro_Sorted_Sets.problems.json
@@ -44,7 +44,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Sorted Set", "Greedy", "LIS", "Binary Search"],
+      "tags": ["Sorted Set", "Greedy", "Binary Search"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Knapsack_DP.problems.json
+++ b/content/4_Gold/Knapsack_DP.problems.json
@@ -157,7 +157,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Knapsack", "Binary Search"],
+      "tags": ["Binary Search", "DP", "Knapsack"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -209,7 +209,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Knapsack", "Exponentiation"],
+      "tags": ["Exponentiation", "Knapsack"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/LIS.problems.json
+++ b/content/4_Gold/LIS.problems.json
@@ -135,7 +135,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Bitmasks"],
+      "tags": ["Bitmasks", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -171,7 +171,7 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "LIS", "Binary Search"],
+      "tags": ["Binary Search", "DP", "LIS"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/LIS.problems.json
+++ b/content/4_Gold/LIS.problems.json
@@ -38,7 +38,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DP"],
+      "tags": ["LIS"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/LIS.problems.json
+++ b/content/4_Gold/LIS.problems.json
@@ -129,18 +129,6 @@
       }
     },
     {
-      "uniqueId": "cf-1582F1",
-      "name": "Korney Korneevich and XOR (easy version)",
-      "url": "https://codeforces.com/problemset/problem/1582/F1",
-      "source": "CF",
-      "difficulty": "Normal",
-      "isStarred": false,
-      "tags": ["Bitmasks", "DP"],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
       "uniqueId": "baltic-09-candy",
       "name": "2009 - Candy",
       "url": "https://qoj.ac/problem/16240",

--- a/content/4_Gold/MST.problems.json
+++ b/content/4_Gold/MST.problems.json
@@ -96,7 +96,7 @@
       "source": "HR",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["MST", "Binary Search"],
+      "tags": ["Binary Search", "MST"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "HR"
@@ -122,7 +122,7 @@
       "source": "JOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["MST", "Binary Search"],
+      "tags": ["Binary Search", "MST"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -184,7 +184,7 @@
       "source": "APIO",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["MST", "Bitmasks"],
+      "tags": ["Bitmasks", "MST"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "DMOJ"

--- a/content/4_Gold/Meet_In_The_Middle.problems.json
+++ b/content/4_Gold/Meet_In_The_Middle.problems.json
@@ -23,7 +23,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Meet in the Middle", "Binary Search"],
+      "tags": ["Binary Search", "Meet in the Middle"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -48,7 +48,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Meet in the Middle", "Binary Search", "DFS"],
+      "tags": ["Binary Search", "DFS", "Meet in the Middle"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -60,7 +60,7 @@
       "source": "YS",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Meet in the Middle", "Bitmasks", "DP"],
+      "tags": ["Bitmasks", "DP", "Meet in the Middle"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -73,7 +73,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Meet in the Middle", "DFS", "Number Theory"],
+      "tags": ["DFS", "Meet in the Middle", "Number Theory"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -86,7 +86,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Meet in the Middle", "Binary Search", "DFS"],
+      "tags": ["Binary Search", "DFS", "Meet in the Middle"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -99,7 +99,7 @@
       "source": "Kattis",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Meet in the Middle", "DFS", "PIE"],
+      "tags": ["DFS", "Meet in the Middle", "PIE"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Modular.problems.json
+++ b/content/4_Gold/Modular.problems.json
@@ -47,7 +47,7 @@
       "source": "Kilonova",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Prime Factorization", "Math"],
+      "tags": ["Math", "Prime Factorization"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -83,7 +83,7 @@
       "source": "Gold",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Modular Arithmetic", "Binary Search"],
+      "tags": ["Binary Search", "Modular Arithmetic"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/PURS.problems.json
+++ b/content/4_Gold/PURS.problems.json
@@ -65,7 +65,7 @@
       "source": "Kattis",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "Inversions"],
+      "tags": ["Inversions", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -89,7 +89,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "Coordinate Compression"],
+      "tags": ["Coordinate Compression", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -101,7 +101,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "Binary Search", "Offline"],
+      "tags": ["Binary Search", "Offline", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -113,7 +113,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "Coordinate Compression"],
+      "tags": ["Coordinate Compression", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -125,7 +125,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["PURS", "Offline"],
+      "tags": ["Offline", "PURS"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -138,7 +138,7 @@
       "source": "CSES",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["PURS", "Inversions"],
+      "tags": ["Inversions", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -152,7 +152,7 @@
       "source": "Gold",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["PURS", "Inversions"],
+      "tags": ["Inversions", "PURS"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -165,7 +165,7 @@
       "source": "Gold",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "Inversions"],
+      "tags": ["Inversions", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -177,7 +177,7 @@
       "source": "Gold",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "Inversions"],
+      "tags": ["Inversions", "PURS"],
       "solutionMetadata": {
         "kind": "internal",
         "usacoId": "719"
@@ -202,7 +202,7 @@
       "source": "Platinum",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "Inversions"],
+      "tags": ["Inversions", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Shortest_Paths.problems.json
+++ b/content/4_Gold/Shortest_Paths.problems.json
@@ -98,10 +98,10 @@
       "difficulty": "Normal",
       "isStarred": false,
       "tags": [
-        "Shortest Path",
-        "Coordinate Compression",
         "Binary Search",
-        "DP"
+        "Coordinate Compression",
+        "DP",
+        "Shortest Path"
       ],
       "solutionMetadata": {
         "kind": "internal"
@@ -150,7 +150,7 @@
       "source": "AC",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Shortest Path", "Greedy"],
+      "tags": ["Greedy", "Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -175,7 +175,7 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Shortest Path", "DP"],
+      "tags": ["DP", "Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -199,7 +199,7 @@
       "source": "APIO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Shortest Path", "Geometry"],
+      "tags": ["Geometry", "Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Sliding_Window.problems.json
+++ b/content/4_Gold/Sliding_Window.problems.json
@@ -23,7 +23,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sliding Window", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Sliding Window"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -35,7 +35,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sliding Window", "Set"],
+      "tags": ["Set", "Sliding Window"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -47,7 +47,7 @@
       "source": "CSES",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Sliding Window", "Set"],
+      "tags": ["Set", "Sliding Window"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -76,7 +76,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Two Pointers", "Binary Search"],
+      "tags": ["Binary Search", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -124,7 +124,7 @@
       "source": "APIO",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sliding Window", "Median"],
+      "tags": ["Median", "Sliding Window"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -161,7 +161,7 @@
       "source": "POI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sliding Window", "DP"],
+      "tags": ["DP", "Sliding Window"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -173,7 +173,7 @@
       "source": "APIO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Sliding Window", "DP"],
+      "tags": ["DP", "Sliding Window"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -185,7 +185,7 @@
       "source": "IOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Sliding Window", "Binary Search", "DP"],
+      "tags": ["Binary Search", "DP", "Sliding Window"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -197,7 +197,7 @@
       "source": "IOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Sliding Window", "DP"],
+      "tags": ["DP", "Sliding Window"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -260,7 +260,7 @@
       "source": "CC",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Sliding Window", "DP"],
+      "tags": ["DP", "Sliding Window"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://discuss.codechef.com/t/binland-editorial/65232"

--- a/content/4_Gold/Stacks.problems.json
+++ b/content/4_Gold/Stacks.problems.json
@@ -47,7 +47,7 @@
       "source": "CEOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Stack", "Geometry"],
+      "tags": ["Geometry", "Stack"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -83,7 +83,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Stack", "Binary Search"],
+      "tags": ["Binary Search", "Stack"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -133,7 +133,7 @@
       "source": "Gold",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Stack", "Sorted Set", "Linked List"],
+      "tags": ["Linked List", "Sorted Set", "Stack"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -145,7 +145,7 @@
       "source": "CSES",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Stack", "PURS"],
+      "tags": ["PURS", "Stack"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -158,7 +158,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Stack", "PURS", "DP"],
+      "tags": ["DP", "PURS", "Stack"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/4_Gold/TopoSort.problems.json
+++ b/content/4_Gold/TopoSort.problems.json
@@ -127,7 +127,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["TopoSort", "Binary Search"],
+      "tags": ["Binary Search", "TopoSort"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -140,7 +140,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["TopoSort", "Bitmasks"],
+      "tags": ["Bitmasks", "TopoSort"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Tree_Euler.problems.json
+++ b/content/4_Gold/Tree_Euler.problems.json
@@ -91,7 +91,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Euler Tour", "PURS", "HLD"],
+      "tags": ["Euler Tour", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -152,7 +152,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Euler Tour", "Binary Search"],
+      "tags": ["Binary Search", "Euler Tour"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"
@@ -178,7 +178,7 @@
       "source": "IOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Euler Tour", "Binary Search"],
+      "tags": ["Binary Search", "Euler Tour"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -191,7 +191,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Euler Tour", "PURS", "Lazy SegTree"],
+      "tags": ["Euler Tour", "Lazy SegTree", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/2DRQ.problems.json
+++ b/content/5_Plat/2DRQ.problems.json
@@ -51,7 +51,7 @@
       "source": "DMOPC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "2DRQ", "BIT"],
+      "tags": ["2DRQ", "BIT", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "DMOJ"

--- a/content/5_Plat/Binary_Jump.problems.json
+++ b/content/5_Plat/Binary_Jump.problems.json
@@ -189,7 +189,7 @@
       "source": "Old Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Small to Large", "Binary Jumping", "Euler Tour"],
+      "tags": ["Binary Jumping", "Euler Tour", "Small to Large"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "213"
@@ -354,7 +354,7 @@
       "source": "Google Kickstart",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["LCA", "Binary Jumping", "DFS"],
+      "tags": ["Binary Jumping", "DFS", "LCA"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -366,7 +366,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["LCA", "Binary Jumping"],
+      "tags": ["Binary Jumping", "LCA"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/5_Plat/Bitsets.problems.json
+++ b/content/5_Plat/Bitsets.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Knapsack", "Bitset"],
+      "tags": ["Bitset", "Knapsack"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "bitsets"
@@ -23,7 +23,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Bitset"],
+      "tags": ["Bitset", "PIE"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -37,7 +37,7 @@
       "source": "Platinum",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Geometry", "Bitset"],
+      "tags": ["Bitset", "Geometry"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "672"
@@ -131,7 +131,7 @@
       "source": "Baltic OI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Knapsack", "Bitset"],
+      "tags": ["Bitset", "Knapsack"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -168,7 +168,7 @@
       "source": "IZhO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Knapsack", "Bitset"],
+      "tags": ["Bitset", "Knapsack"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/bekzhan29/algos/blob/master/Editorials/IZhO/2017/Bootfall/english.md"
@@ -181,7 +181,7 @@
       "source": "Baltic OI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Knapsack", "Bitset"],
+      "tags": ["Bitset", "Knapsack"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Centroid.problems.json
+++ b/content/5_Plat/Centroid.problems.json
@@ -75,7 +75,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Centroid", "BIT"],
+      "tags": ["BIT", "Centroid"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Conclusion.problems.json
+++ b/content/5_Plat/Conclusion.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Small to Large", "Virtual Tree", "DP", "Tree"],
+      "tags": ["DP", "Small to Large", "Tree", "Virtual Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -47,7 +47,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Sqrt", "SegTree"],
+      "tags": ["DP", "SegTree", "Sqrt"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -73,7 +73,7 @@
       "source": "QOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Virtual Tree", "SegTree"],
+      "tags": ["SegTree", "Virtual Tree"],
       "solutionMetadata": {
         "kind": "none"
       }

--- a/content/5_Plat/Convex_Hull.problems.json
+++ b/content/5_Plat/Convex_Hull.problems.json
@@ -103,7 +103,7 @@
       "source": "Balkan OI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["MST", "Convex"],
+      "tags": ["Convex", "MST"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Convex_Hull_Trick.problems.json
+++ b/content/5_Plat/Convex_Hull_Trick.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "convex-hull-trick"
@@ -23,7 +23,7 @@
       "source": "APIO",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -35,7 +35,7 @@
       "source": "CEOI",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -47,7 +47,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -59,7 +59,7 @@
       "source": "CEOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -71,7 +71,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -83,7 +83,7 @@
       "source": "IOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -95,7 +95,7 @@
       "source": "APIO",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -107,7 +107,7 @@
       "source": "POI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -119,7 +119,7 @@
       "source": "POI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -131,7 +131,7 @@
       "source": "Platinum",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -156,7 +156,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Bitmasks", "DP", "Convex"],
+      "tags": ["Bitmasks", "Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -168,7 +168,7 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "none"
       }

--- a/content/5_Plat/DC-DP.problems.json
+++ b/content/5_Plat/DC-DP.problems.json
@@ -8,7 +8,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -22,7 +22,7 @@
       "source": "CEOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -34,7 +34,7 @@
       "source": "COI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/mostafa-saad/MyCompetitiveProgramming/blob/master/Olympiad/COI/official/2015/final-exam2/solutions.pdf"
@@ -47,7 +47,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -59,7 +59,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -71,7 +71,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -84,7 +84,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -97,7 +97,7 @@
       "source": "POI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://www.youtube.com/watch?v=IKN7DPQSnKI"
@@ -110,7 +110,7 @@
       "source": "IOI",
       "difficulty": "Very Hard",
       "isStarred": true,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "IOI",
         "year": 2014
@@ -123,7 +123,7 @@
       "source": "Platinum",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "926"
@@ -136,7 +136,7 @@
       "source": "JOI",
       "difficulty": "Very Hard",
       "isStarred": true,
-      "tags": ["Divide and Conquer", "DP"],
+      "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/DC-SRQ.problems.json
+++ b/content/5_Plat/DC-SRQ.problems.json
@@ -73,7 +73,7 @@
       "source": "NOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Knapsack", "Divide and Conquer", "SRQ"],
+      "tags": ["DP", "Divide and Conquer", "Knapsack", "SRQ"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -85,7 +85,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Matrix", "Divide and Conquer"],
+      "tags": ["Divide and Conquer", "Matrix"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "997"

--- a/content/5_Plat/DP_SOS.problems.json
+++ b/content/5_Plat/DP_SOS.problems.json
@@ -99,7 +99,7 @@
       "source": "kilonova",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Bitmasks", "SOS DP", "Number Theory"],
+      "tags": ["Bitmasks", "Number Theory", "SOS DP"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/HLD.problems.json
+++ b/content/5_Plat/HLD.problems.json
@@ -23,7 +23,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["LCA", "HLD"],
+      "tags": ["HLD", "LCA"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -35,7 +35,7 @@
       "source": "Gold",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURS", "HLD"],
+      "tags": ["HLD", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Matrix_Expo.problems.json
+++ b/content/5_Plat/Matrix_Expo.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Matrix", "Exponentiation"],
+      "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
         "kind": "CPH",
         "section": "23.2"
@@ -23,7 +23,7 @@
       "source": "SPOJ",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Matrix", "Exponentiation"],
+      "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -37,7 +37,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Matrix", "Exponentiation"],
+      "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
         "kind": "CPH",
         "section": "23.3"
@@ -50,7 +50,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Matrix", "Exponentiation"],
+      "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
         "kind": "CPH",
         "section": "23.3"
@@ -87,7 +87,7 @@
       "source": "Baltic OI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Matrix", "Exponentiation"],
+      "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/mostafa-saad/MyCompetitiveProgramming/blob/master/Olympiad/Baltic/Baltic-07-Points.txt"
@@ -100,7 +100,7 @@
       "source": "Balkan OI",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Matrix", "Exponentiation"],
+      "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/mostafa-saad/MyCompetitiveProgramming/blob/master/Olympiad/Balkan/Balkan-09-Reading.txt"
@@ -113,7 +113,7 @@
       "source": "DMOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Matrix", "Exponentiation"],
+      "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "DMOJ"
@@ -126,7 +126,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Matrix", "Exponentiation"],
+      "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "746"

--- a/content/5_Plat/Merging.problems.json
+++ b/content/5_Plat/Merging.problems.json
@@ -34,7 +34,7 @@
       "source": "Platinum",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Merging", "Indexed Set"],
+      "tags": ["Indexed Set", "Merging"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -58,7 +58,7 @@
       "source": "POI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Merging", "Indexed Set"],
+      "tags": ["Indexed Set", "Merging"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/PIE.problems.json
+++ b/content/5_Plat/PIE.problems.json
@@ -8,7 +8,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Divisibility"],
+      "tags": ["Divisibility", "PIE"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "PIE"
@@ -23,7 +23,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Bitset"],
+      "tags": ["Bitset", "PIE"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -52,7 +52,7 @@
       "source": "SPOJ",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PIE", "Divisibility", "Sieve"],
+      "tags": ["Divisibility", "PIE", "Sieve"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -64,7 +64,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Divisibility"],
+      "tags": ["Divisibility", "PIE"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -76,7 +76,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Divisibility"],
+      "tags": ["Divisibility", "PIE"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -100,7 +100,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Divisibility"],
+      "tags": ["Divisibility", "PIE"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/PIE.problems.json
+++ b/content/5_Plat/PIE.problems.json
@@ -8,7 +8,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Divisors"],
+      "tags": ["PIE", "Divisibility"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "PIE"
@@ -52,7 +52,7 @@
       "source": "SPOJ",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PIE", "Divisors", "Sieve"],
+      "tags": ["PIE", "Divisibility", "Sieve"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -64,7 +64,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Divisors"],
+      "tags": ["PIE", "Divisibility"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -76,7 +76,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Divisors"],
+      "tags": ["PIE", "Divisibility"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -100,7 +100,7 @@
       "source": "CSES",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["PIE", "Divisors"],
+      "tags": ["PIE", "Divisibility"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/RURQ.problems.json
+++ b/content/5_Plat/RURQ.problems.json
@@ -140,7 +140,7 @@
       "source": "IOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Lazy SegTree", "Coordinate Compression"],
+      "tags": ["Coordinate Compression", "Lazy SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -152,7 +152,7 @@
       "source": "Platinum",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Euler Tour", "PURS", "Lazy SegTree"],
+      "tags": ["Euler Tour", "Lazy SegTree", "PURS"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Range_Sweep.problems.json
+++ b/content/5_Plat/Range_Sweep.problems.json
@@ -86,7 +86,7 @@
       "source": "IZhO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Stack", "PURQ", "Lazy SegTree"],
+      "tags": ["Lazy SegTree", "PURQ", "Stack"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/5_Plat/Segtree_Ext.problems.json
+++ b/content/5_Plat/Segtree_Ext.problems.json
@@ -144,7 +144,7 @@
       "source": "Platinum",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["PURQ", "Greedy"],
+      "tags": ["Greedy", "PURQ"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Sparse_Segtree.problems.json
+++ b/content/5_Plat/Sparse_Segtree.problems.json
@@ -23,7 +23,7 @@
       "source": "IOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sparse SegTree", "Lazy SegTree"],
+      "tags": ["Lazy SegTree", "Sparse SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/5_Plat/Sqrt.problems.json
+++ b/content/5_Plat/Sqrt.problems.json
@@ -38,7 +38,7 @@
       "source": "SPOJ",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Sqrt", "Mo's Algorithm"],
+      "tags": ["Mo's Algorithm", "Sqrt"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "sqrt"
@@ -53,7 +53,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sqrt", "Mo's Algorithm", "Tree"],
+      "tags": ["Mo's Algorithm", "Sqrt", "Tree"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "sqrt"
@@ -119,7 +119,7 @@
       "source": "JOI",
       "difficulty": "Normal",
       "isStarred": true,
-      "tags": ["Sqrt", "DP"],
+      "tags": ["DP", "Sqrt"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -168,7 +168,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Sqrt", "Tree", "Euler Tour"],
+      "tags": ["Euler Tour", "Sqrt", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -233,7 +233,7 @@
       "source": "JOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Mo's Algorithm", "2DRQ"],
+      "tags": ["2DRQ", "Mo's Algorithm"],
       "solutionMetadata": {
         "kind": "none"
       }

--- a/content/5_Plat/VTree.problems.json
+++ b/content/5_Plat/VTree.problems.json
@@ -61,7 +61,7 @@
       "source": "Gym",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["Virtual Tree", "Block Cut Tree"],
+      "tags": ["Block Cut Tree", "Virtual Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/BCC_2CC.problems.json
+++ b/content/6_Advanced/BCC_2CC.problems.json
@@ -23,7 +23,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["BCC", "Articulation Points"],
+      "tags": ["BCC"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "BCC-2CC"

--- a/content/6_Advanced/Catalan.problems.json
+++ b/content/6_Advanced/Catalan.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Combinatorics", "Catalan"],
+      "tags": ["Catalan", "Combinatorics"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "catalan"
@@ -23,7 +23,7 @@
       "source": "LC",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Combinatorics", "Catalan"],
+      "tags": ["Catalan", "Combinatorics"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -35,7 +35,7 @@
       "source": "SPOJ",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Combinatorics", "Catalan"],
+      "tags": ["Catalan", "Combinatorics"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -47,7 +47,7 @@
       "source": "CSES",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Combinatorics", "Catalan"],
+      "tags": ["Catalan", "Combinatorics"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/Comb_Sub.problems.json
+++ b/content/6_Advanced/Comb_Sub.problems.json
@@ -48,7 +48,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/Eulers_Formula.problems.json
+++ b/content/6_Advanced/Eulers_Formula.problems.json
@@ -8,7 +8,7 @@
       "source": "APIO",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Persistent SegTree", "Euler's Formula", "2DRQ"],
+      "tags": ["2DRQ", "Euler's Formula", "Persistent SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -36,7 +36,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Flood Fill", "Euler's Formula"],
+      "tags": ["Euler's Formula", "Flood Fill"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -48,7 +48,7 @@
       "source": "Kattis",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Euler's Formula", "DSU"],
+      "tags": ["DSU", "Euler's Formula"],
       "solutionMetadata": {
         "kind": "none"
       }

--- a/content/6_Advanced/Game_Theory.problems.json
+++ b/content/6_Advanced/Game_Theory.problems.json
@@ -53,7 +53,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Tree", "Game", "Nimbers"],
+      "tags": ["Game", "Nimbers", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -66,7 +66,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Game", "DP", "Bitmasks", "Nimbers"],
+      "tags": ["Bitmasks", "DP", "Game", "Nimbers"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -79,7 +79,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Game", "DP", "Bitmasks", "Nimbers"],
+      "tags": ["Bitmasks", "DP", "Game", "Nimbers"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -181,7 +181,7 @@
       "source": "POI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Game", "Cactus"],
+      "tags": ["Cactus", "Game"],
       "solutionMetadata": {
         "kind": "none"
       }

--- a/content/6_Advanced/LineContainer.problems.json
+++ b/content/6_Advanced/LineContainer.problems.json
@@ -22,7 +22,7 @@
       "source": "CEOI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "line-container"
@@ -62,7 +62,7 @@
       "source": "Balkan OI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Geometry", "Binary Search"],
+      "tags": ["Binary Search", "Geometry"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://web.archive.org/web/20220820063422/http://boi2011.ro/resurse/tasks/2circles-sol.pdf"
@@ -89,7 +89,7 @@
       "source": "POI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -101,7 +101,7 @@
       "source": "CEOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -113,7 +113,7 @@
       "source": "FHC",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "FHC"

--- a/content/6_Advanced/Matroid.problems.json
+++ b/content/6_Advanced/Matroid.problems.json
@@ -23,7 +23,7 @@
       "source": "DMOJ",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Matroids", "Tree", "MST"],
+      "tags": ["MST", "Matroids", "Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -47,7 +47,7 @@
       "source": "Kattis",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Matroids", "MST"],
+      "tags": ["MST", "Matroids"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/Matroid_Isect.problems.json
+++ b/content/6_Advanced/Matroid_Isect.problems.json
@@ -8,7 +8,7 @@
       "source": "CC",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Matroid Intersection", "DSU"],
+      "tags": ["DSU", "Matroid Intersection"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "matroid-isect"
@@ -23,7 +23,7 @@
       "source": "SPOJ",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Matroid Intersection", "Euler Tour", "DSU"],
+      "tags": ["DSU", "Euler Tour", "Matroid Intersection"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/Offline_Del.problems.json
+++ b/content/6_Advanced/Offline_Del.problems.json
@@ -124,7 +124,7 @@
       "source": "Baltic OI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Divide and Conquer", "DSUrb"],
+      "tags": ["DSUrb", "Divide and Conquer"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/Persistent.problems.json
+++ b/content/6_Advanced/Persistent.problems.json
@@ -121,7 +121,7 @@
       "source": "APIO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Persistent SegTree", "Euler's Formula", "2DRQ"],
+      "tags": ["2DRQ", "Euler's Formula", "Persistent SegTree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -146,7 +146,7 @@
       "source": "IOI",
       "difficulty": "Very Hard",
       "isStarred": true,
-      "tags": ["Persistent SegTree", "2DRQ"],
+      "tags": ["2DRQ", "Persistent SegTree"],
       "solutionMetadata": {
         "kind": "IOI",
         "year": 2015

--- a/content/6_Advanced/SCC.problems.json
+++ b/content/6_Advanced/SCC.problems.json
@@ -22,7 +22,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SCC", "DP"],
+      "tags": ["DP", "SCC"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -34,7 +34,7 @@
       "source": "POI",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SCC", "DP"],
+      "tags": ["DP", "SCC"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -46,7 +46,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["SCC", "DP"],
+      "tags": ["DP", "SCC"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -165,7 +165,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2SAT", "DSU", "DFS"],
+      "tags": ["2SAT", "DFS", "DSU"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -178,7 +178,7 @@
       "source": "CC",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2SAT", "DSU", "Sliding Window", "Greedy"],
+      "tags": ["2SAT", "DSU", "Greedy", "Sliding Window"],
       "solutionMetadata": {
         "kind": "none"
       }

--- a/content/6_Advanced/String_Search.problems.json
+++ b/content/6_Advanced/String_Search.problems.json
@@ -359,7 +359,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Bitmasks", "Tree", "Trie"],
+      "tags": ["Trie"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/String_Search.problems.json
+++ b/content/6_Advanced/String_Search.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["Z Algorithm", "KMP"],
+      "tags": ["KMP", "Z Algorithm"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -20,7 +20,7 @@
       "source": "POI",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Strings", "KMP"],
+      "tags": ["KMP", "Strings"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/thecodingwizard/competitive-programming/blob/master/POI/POI%2006-Periods.cpp"
@@ -33,7 +33,7 @@
       "source": "Baltic OI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Strings", "KMP"],
+      "tags": ["KMP", "Strings"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -45,7 +45,7 @@
       "source": "Old Gold",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Strings", "KMP"],
+      "tags": ["KMP", "Strings"],
       "solutionMetadata": {
         "kind": "sketch",
         "sketch": "Run KMP, except each state needs to be considered as not only a length, but also mapping of pattern to # of spots"
@@ -58,7 +58,7 @@
       "source": "POI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Strings", "KMP"],
+      "tags": ["KMP", "Strings"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -121,7 +121,7 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["Z Algorithm", "KMP"],
+      "tags": ["KMP", "Z Algorithm"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -133,7 +133,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Strings", "DP"],
+      "tags": ["DP", "Strings"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -189,7 +189,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Strings", "DP"],
+      "tags": ["DP", "Strings"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "string-search"
@@ -230,7 +230,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Strings", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Strings"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -245,7 +245,7 @@
       "source": "COCI",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": ["Strings", "DFS", "Trie"],
+      "tags": ["DFS", "Strings", "Trie"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://hsin.hr/coci/contest3_solutions.zip"
@@ -258,7 +258,7 @@
       "source": "IOI",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": ["Strings", "DFS", "Trie"],
+      "tags": ["DFS", "Strings", "Trie"],
       "solutionMetadata": {
         "kind": "IOI",
         "year": 2008
@@ -271,7 +271,7 @@
       "source": "YS",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Trie", "Greedy"],
+      "tags": ["Greedy", "Trie"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -346,7 +346,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Trie", "Tree", "Small to Large"],
+      "tags": ["Small to Large", "Tree", "Trie"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -359,7 +359,7 @@
       "source": "CF",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Trie", "Tree", "Bitmasks"],
+      "tags": ["Bitmasks", "Tree", "Trie"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -372,7 +372,7 @@
       "source": "IZhO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Trie", "Greedy"],
+      "tags": ["Greedy", "Trie"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -384,7 +384,7 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Trie", "BIT"],
+      "tags": ["BIT", "Trie"],
       "solutionMetadata": {
         "kind": "link",
         "url": "http://s3-ap-northeast-1.amazonaws.com/data.cms.ioi-jp.org/open-2016/2016-open-selling_rna-sol-en.pdf"
@@ -397,7 +397,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Trie", "Tree"],
+      "tags": ["Tree", "Trie"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -464,7 +464,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Strings", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Strings"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/String_Suffix.problems.json
+++ b/content/6_Advanced/String_Suffix.problems.json
@@ -112,7 +112,7 @@
       "source": "Balkan OI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Suffix Structures", "DP"],
+      "tags": ["DP", "Suffix Structures"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -163,7 +163,7 @@
       "source": "CF",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Suffix Structures", "DP"],
+      "tags": ["DP", "Suffix Structures"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/Wavelet.problems.json
+++ b/content/6_Advanced/Wavelet.problems.json
@@ -35,7 +35,7 @@
       "source": "COCI",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Wavelet", "Persistent SegTree"],
+      "tags": ["Wavelet"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -47,7 +47,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Wavelet", "Persistent SegTree"],
+      "tags": ["Persistent SegTree", "Wavelet"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -59,7 +59,7 @@
       "source": "YS",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Wavelet", "Persistent SegTree"],
+      "tags": ["Persistent SegTree", "Wavelet"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/Wavelet.problems.json
+++ b/content/6_Advanced/Wavelet.problems.json
@@ -47,7 +47,7 @@
       "source": "AC",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Persistent SegTree", "Wavelet"],
+      "tags": ["Wavelet"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -59,7 +59,7 @@
       "source": "YS",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Persistent SegTree", "Wavelet"],
+      "tags": ["Wavelet"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/extraProblems.json
+++ b/content/extraProblems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["Complete Search", "Recursion", "Pruning"],
+      "tags": ["Complete Search", "Pruning", "Recursion"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -58,7 +58,7 @@
       "source": "Platinum",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2P"],
+      "tags": ["Two Pointers"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "794"
@@ -109,7 +109,7 @@
       "source": "Platinum",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DSU", "DP", "Graphs"],
+      "tags": ["DP", "DSU", "Graphs"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "996"
@@ -148,7 +148,7 @@
       "source": "Platinum",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Prefix Sums", "DP"],
+      "tags": ["DP", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -274,7 +274,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorting", "Greedy"],
+      "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -286,7 +286,7 @@
       "source": "Gold",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Prefix Sums", "Game"],
+      "tags": ["Game", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1113"
@@ -540,7 +540,7 @@
       "source": "Platinum",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["SP", "SegTree"],
+      "tags": ["SegTree", "Shortest Path"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1164"
@@ -566,7 +566,7 @@
       "source": "Platinum",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["DP", "Combinatorics"],
+      "tags": ["Combinatorics", "DP"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1166"
@@ -603,7 +603,7 @@
       "source": "Silver",
       "difficulty": "Normal",
       "isStarred": false,
-      "tags": ["Sorted Set", "Stack", "Linked List"],
+      "tags": ["Linked List", "Sorted Set", "Stack"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -691,7 +691,7 @@
       "source": "Platinum",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Euler's Formula", "DSU", "SegTree"],
+      "tags": ["DSU", "Euler's Formula", "SegTree"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1212"
@@ -894,7 +894,7 @@
       "source": "SAPO",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["2P", "Sorted Set"],
+      "tags": ["Sorted Set", "Two Pointers"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -954,7 +954,7 @@
       "source": "CF",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": ["SP"],
+      "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -1171,7 +1171,7 @@
       "source": "Silver",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Sorting", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -1261,7 +1261,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Tree", "Sorting"],
+      "tags": ["Sorting", "Tree"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1306"
@@ -1300,7 +1300,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["DP", "Connected Components", "Tree"],
+      "tags": ["Connected Components", "DP", "Tree"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1331"
@@ -1443,7 +1443,7 @@
       "source": "Platinum",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Binary Lifting"],
+      "tags": ["Binary Jumping"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1284"
@@ -1456,7 +1456,7 @@
       "source": "Platinum",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1286"
@@ -1482,7 +1482,7 @@
       "source": "Platinum",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Tree", "DP"],
+      "tags": ["DP", "Tree"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1310"
@@ -1598,7 +1598,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Toposort", "Sorting"],
+      "tags": ["Sorting", "TopoSort"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1354"
@@ -1611,7 +1611,7 @@
       "source": "Platinum",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Tree", "Greedy"],
+      "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1356"
@@ -1624,7 +1624,7 @@
       "source": "Platinum",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Graphs", "Spanning Tree", "DSU"],
+      "tags": ["DSU", "Graphs", "Spanning Tree"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1357"
@@ -1883,7 +1883,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Stack", "Prefix Sums"],
+      "tags": ["Prefix Sums", "Stack"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1402"
@@ -1896,7 +1896,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Priority Queue", "Linked List"],
+      "tags": ["Linked List", "Priority Queue"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1403"
@@ -1935,7 +1935,7 @@
       "source": "Platinum",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Binary Lifting"],
+      "tags": ["Binary Jumping"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1406"
@@ -2065,7 +2065,7 @@
       "source": "Platinum",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["DP", "Convex"],
+      "tags": ["Convex", "DP"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1428"
@@ -2078,7 +2078,7 @@
       "source": "Platinum",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["Binary Lifting", "BBST", "DSU"],
+      "tags": ["BBST", "Binary Jumping", "DSU"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1429"
@@ -2091,7 +2091,7 @@
       "source": "Platinum",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": ["DP", "Bitmask"],
+      "tags": ["Bitmasks", "DP"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1430"

--- a/solutions/gold/cf-1582F1.mdx
+++ b/solutions/gold/cf-1582F1.mdx
@@ -34,7 +34,13 @@ zero element.
 
 ## Implementation
 
-**Time Complexity:** $\mathcal{O}(n \cdot 2^{\lceil \log_2(\text{MAXA}) \rceil})$
+**Time Complexity:** $\mathcal{O}((n + 2^{\lceil \log_2(\text{MAXA}) \rceil}) \cdot 2^{\lceil \log_2(\text{MAXA}) \rceil})$
+
+The two nested loops account for the first term. The inner `while` loop is
+amortized: it only ever writes cells that were still false, and each of the
+$2^{\lceil \log_2(\text{MAXA}) \rceil} \times 2^{\lceil \log_2(\text{MAXA})
+\rceil}$ cells of $dp$ is set at most once over the whole run, which accounts
+for the second.
 
 <LanguageSection>
 <CPPSection>


### PR DESCRIPTION
Follow-up to #6560, continuing the tag cleanup from #6558. **155 distinct tags → 146**, across all 146 content files. Data only.

The guiding rule, settled in review: **a tag describes how the problem is expected to be solved in that module.** A problem listed in several modules carries different tags in each, on purpose — that is not an inconsistency to fix.

---

### 1. Nine tags that named the same topic as an existing tag

| tag | → | why |
| --- | --- | --- |
| `Expected Value` | `Probability` | same topic under two names |
| `Divisors` | `Divisibility` | same topic under two names; every use of `Divisors` was alongside `PIE` |
| `Articulation Points` | `BCC` | its only use, `spoj-submerge`, was **already** tagged `BCC` — pure redundancy, so this is a removal |
| `Trees` | `Tree` | reintroduced after #6560 by #6557 (`cf-2257C`) and #6563 (`cf-2258C`) |
| `2P` | `Two Pointers` | *see below* |
| `SP` | `Shortest Path` | " |
| `Bitmask` | `Bitmasks` | " |
| `Toposort` | `TopoSort` | " |
| `Binary Lifting` | `Binary Jumping` | " |

`APSP` is deliberately left as an abbreviation.

### 2. `extraProblems.json` was missed by every earlier pass

Its filename does not match the `content/**/*.problems.json` glob that #6560's scripts used, so it was invisible to them. It still carried `2P`, `SP` and `Bitmask` after those were reported as merged away, plus `Binary Lifting` and `Toposort` as duplicates of `Binary Jumping` and `TopoSort`. The last five rows of the table above are that file.

This also means #6560's headline figure was computed over an incomplete file set. The counts here cover all 146 files.

### 3. Every tags array sorted alphabetically

331 arrays across 71 files. `ProblemsListItem` already renders `problem.tags.sort()`, so the module tables are unchanged; the problem search renders stored order, so today the two disagree. Sorting makes them agree and keeps future diffs stable. (#6568 sorts suggested tags on submission to match.)

### 4. Four individual re-tags

| problem | module | change |
| --- | --- | --- |
| `cses-1073` Towers | Intro Sorted Sets / LIS | `["Binary Search", "Greedy", "Sorted Set"]` and `["LIS"]` — each module tagged with the approach it teaches, rather than one shared set |
| `coci-21-index`, `ac-abc339g`, `ys-RectangleSum` | Wavelet | drop `Persistent SegTree`, keep `Wavelet` — all seven problems in the module now carry `Wavelet` alone |
| `usaco-921` Cow Land | Gold Tree Euler | drop `HLD`, keep `Euler Tour` + `PURS` |
| `cf-665E` Beautiful Subarrays | Advanced String Searching | `["Trie"]` — it sits in the module's `trie` list and solves via a binary trie over XOR prefixes, so `Bitmasks` (subset enumeration) and `Tree` were both wrong |

`isStarred` also differs between the two Towers copies; out of scope, left as is.

### 5. One problem moved modules

`cf-1582F1` (Korney Korneevich and XOR) was listed in the Gold LIS module but tagged `["Bitmasks", "DP"]`, with nothing tying it to longest increasing subsequence. Moved to Gold Conclusion.

Its solution also understated the time complexity as $O(n \cdot 2^p)$, counting only the two nested loops. The inner `while` loop is amortized — it writes only cells that were still false, and each of the $2^p \times 2^p$ dp cells is set at most once over the whole run — so it contributes $O(4^p)$, which dominates when $n < 2^p$. Corrected to $O((n + 2^p) \cdot 2^p)$ with a note explaining each term. Its `Bitmasks` tag became `Bitwise` — the DP is over XOR values, not subsets.

### Verification

- 337 tag lines changed across 72 files. The only 6 non-`"tags":` lines are one multi-line array being reordered.
- All 146 content files parse; `prettier --check` passes on every changed file.
- No tag names were introduced — the 9 removed above are the entire vocabulary delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAtwgtWDg8mxDCGH7ZW59X