### PR TITLE
Sort Gold Conclusion problems by difficulty

### DIFF
--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -498,6 +498,18 @@
       }
     },
     {
+      "uniqueId": "cf-1582F1",
+      "name": "Korney Korneevich and XOR (easy version)",
+      "url": "https://codeforces.com/problemset/problem/1582/F1",
+      "source": "CF",
+      "difficulty": "Normal",
+      "isStarred": false,
+      "tags": ["Bitwise", "DP"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
       "uniqueId": "cf-2021E2",
       "name": "Digital Village (Hard Version)",
       "url": "https://codeforces.com/contest/2021/problem/E2",
@@ -657,18 +669,6 @@
       "difficulty": "Very Hard",
       "isStarred": false,
       "tags": ["Shortest Path"],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
-      "uniqueId": "cf-1582F1",
-      "name": "Korney Korneevich and XOR (easy version)",
-      "url": "https://codeforces.com/problemset/problem/1582/F1",
-      "source": "CF",
-      "difficulty": "Normal",
-      "isStarred": false,
-      "tags": ["Bitwise", "DP"],
       "solutionMetadata": {
         "kind": "internal"
       }


### PR DESCRIPTION
`cf-1582F1` "Korney Korneevich and XOR (easy version)" (Normal) was sitting at the very end of the Gold Conclusion list, after two Very Hard problems.

Stable-sorted the list by difficulty so it lands at the end of the Normal block (right after `cf-1606E` "Arena"). Every other problem keeps its exact relative position — the diff is a pure block move.

Also checked the Bronze, Silver, and Platinum conclusion lists: all three were already in non-decreasing difficulty order, so no changes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2rsBuxuYPtH6EgkVq8akH