### PR TITLE
Pin toml to ^4.1.2 (GHSA-v5mp-jgw5-2x6j)

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
   "resolutions": {
     "postcss": "^8.5.24",
     "cacache/glob": "^10.5.0",
+    "remark-mdx-frontmatter/toml": "^4.1.2",
     "remark-mdx-frontmatter/yaml": "^2.8.3"
   },
   "packageManager": "yarn@4.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17175,10 +17175,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toml@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "toml@npm:3.0.0"
-  checksum: 10c0/8d7ed3e700ca602e5419fca343e1c595eb7aa177745141f0761a5b20874b58ee5c878cd045c408da9d130cb2b611c639912210ba96ce2f78e443569aa8060c18
+"toml@npm:^4.1.2":
+  version: 4.3.0
+  resolution: "toml@npm:4.3.0"
+  checksum: 10c0/4a0ad64d4ef0b47f672a7b6bd7e776b9e03ad845998968fb105f8d561c3648eaff0217baca3f562d17e865e5bd7393441a8e54528920f0c171e41fdc8dfb39d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes Dependabot alert [#729](https://github.com/cpinitiative/usaco-guide/security/dependabot/729) (`toml` prototype pollution, CVE-2026-63376, high / CVSS 8.2).

Dependabot can't fix this one itself: `toml` is transitive via `remark-mdx-frontmatter@5.2.0`, which pins `toml: ^3.0.0`, and the fix only landed in `toml@4.1.2` — a major. The latest `remark-mdx-frontmatter` still requires `^3.0.0`, so there's no upgrade path through the parent either. Hence the "Dependabot can't find the vulnerable dependency in the repository" banner on the alert.

This adds a scoped resolution, mirroring the existing `remark-mdx-frontmatter/yaml` entry. Lockfile resolves `toml` 3.0.0 → 4.3.0.

Compatibility checked: same maintainer as 3.0.0 (`binarymuse` — the package was dormant since 2019 and revived in March 2026, not a takeover), still CJS with `module.exports = { parse }`, so `import { parse as parseToml } from 'toml'` keeps working. `engines: node >=20` matches CI's Node 20.x.

Worth noting the vulnerability was never reachable here: `remark-mdx-frontmatter` only calls `toml.parse` on `toml` mdast nodes, and `remark-frontmatter` only emits those when configured with `'toml'`. Both call sites (`src/lib/parseMdxFile.ts:37`, `src/lib/compileMdxForEditor.ts:107`) use it bare, which defaults to YAML only. This is hygiene, not an incident — but it also means the alert stops being noise if anyone ever enables TOML frontmatter in the editor path, which does handle untrusted input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZfXnbcfNcmY8aWz6ZHwEe