### PR TITLE
Stop Dependabot from opening PRs for src/functions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,13 @@
 # package (e.g. brace-expansion 1.x/2.x/5.x) is fixed by a single PR instead of
 # one PR per version range.
 #
-# src/functions has its own npm lockfile and is deliberately not configured
-# here.
+# src/functions has its own npm lockfile. Security updates are on by default for
+# every manifest in the dependency graph, so leaving it unconfigured does *not*
+# opt it out -- Dependabot kept opening (and failing) update jobs for it. The
+# entry below opts it out explicitly: `open-pull-requests-limit: 0` stops
+# version updates, and the ignore-all rule stops security ones, since
+# `open-pull-requests-limit` does not apply to security PRs. Alerts for
+# src/functions still show up under Security; only the PRs stop.
 version: 2
 updates:
   # Next.js app (Yarn 4 workspace at the repo root).
@@ -21,6 +26,16 @@ updates:
         applies-to: security-updates
         patterns:
           - '*'
+
+  # Firebase Cloud Functions (npm lockfile of its own). Not maintained by
+  # Dependabot -- see the note above.
+  - package-ecosystem: npm
+    directory: /src/functions
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '*'
 
   # Keep the GitHub Actions used by CI patched.
   - package-ecosystem: github-actions


### PR DESCRIPTION
The config comment claimed `src/functions` was "deliberately not configured here", but omitting a directory doesn't opt it out — Dependabot **security** updates are on by default for every manifest in the dependency graph. So it has been queuing update jobs for `src/functions/package-lock.json` and failing them: runs [33976613740](https://github.com/cpinitiative/usaco-guide/actions/runs/33976613740) (toml) and [33976614553](https://github.com/cpinitiative/usaco-guide/actions/runs/33976614553) (browserslist) both died with `security_update_dependency_not_found`.

This adds an explicit entry that opts it out both ways:

- `open-pull-requests-limit: 0` stops version-update PRs.
- The ignore-all rule stops security PRs — the limit doesn't apply to those ([options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference): "*Security update* pull requests are not subject to this limit and do not count toward it"), but `ignore` does cover security updates.

Alerts for `src/functions` still show up under Security; only the PRs and the failing update jobs stop. If you'd rather keep security PRs for it and just fix the failures, say so and I'll take the other approach instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZfXnbcfNcmY8aWz6ZHwEe