### PR TITLE
Rename problem difficulty "Normal" to "Medium"

### DIFF
--- a/content/1_General/Fast_IO.problems.json
+++ b/content/1_General/Fast_IO.problems.json
@@ -21,7 +21,7 @@
       "name": "Soldier and Number Game",
       "url": "https://codeforces.com/contest/546/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/1_General/Input_Output.problems.json
+++ b/content/1_General/Input_Output.problems.json
@@ -6,7 +6,7 @@
       "name": "Weird Algorithm",
       "url": "https://cses.fi/problemset/task/1068",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -20,7 +20,7 @@
       "name": "Fence Painting",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=567",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/1_General/Modules.mdx
+++ b/content/1_General/Modules.mdx
@@ -89,7 +89,7 @@ Difficulty ranges from **Very Easy** to **Insane**.
 - **Easy** problems can be solved relatively quickly by someone who is familiar
   with the module, and they should be approachable by someone who has just
   finished reading the starred resources.
-- **Normal** problems require a bit more thinking.
+- **Medium** problems require a bit more thinking.
 - **Hard** problems may require a lot (?) of time to approach.
 - **Very Hard** problems challenge even the strongest contestants in the
   corresponding division. Often require multiple levels of observation and more

--- a/content/1_General/USACO_FAQs.problems.json
+++ b/content/1_General/USACO_FAQs.problems.json
@@ -6,7 +6,7 @@
       "name": "Promotion Counting",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=591",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/1_General/Working_MDX.mdx
+++ b/content/1_General/Working_MDX.mdx
@@ -259,7 +259,7 @@ Zuma
 `src/models/problem.ts` `contests` and `probSources`_
 
 `difficulty` -- The difficulty of the problem **relative to the module it is
-in**. Valid options are `Very Easy`, `Easy`, `Normal`, `Hard`, `Very Hard`,
+in**. Valid options are `Very Easy`, `Easy`, `Medium`, `Hard`, `Very Hard`,
 `Insane`
 
 `isStarred` -- Whether this problem should be starred or not.

--- a/content/2_Bronze/Ad_Hoc.problems.json
+++ b/content/2_Bronze/Ad_Hoc.problems.json
@@ -6,7 +6,7 @@
       "name": "Photoshoot 2",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1204",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Ad Hoc"],
       "solutionMetadata": {

--- a/content/2_Bronze/Casework.problems.json
+++ b/content/2_Bronze/Casework.problems.json
@@ -6,7 +6,7 @@
       "name": "Sleepy Cow Herding",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=915",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -33,7 +33,7 @@
       "name": "Fence Painting",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=567",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Casework"],
       "solutionMetadata": {
@@ -45,7 +45,7 @@
       "name": "Social Distancing I",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1035",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Casework"],
       "solutionMetadata": {
@@ -57,7 +57,7 @@
       "name": "Hoof Paper Scissors Minus One",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1515",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Casework"],
       "solutionMetadata": {

--- a/content/2_Bronze/Complete_Rec.problems.json
+++ b/content/2_Bronze/Complete_Rec.problems.json
@@ -36,7 +36,7 @@
       "name": "Chessboard & Queens",
       "url": "https://cses.fi/problemset/task/1624",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search", "Permutation", "Recursion"],
       "solutionMetadata": {
@@ -51,7 +51,7 @@
       "name": "Air Cownditioning II",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1276",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Complete Search", "Recursion", "Subsets"],
       "solutionMetadata": {
@@ -63,7 +63,7 @@
       "name": "Livestock Lineup",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=965",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Complete Search", "Permutation", "Recursion"],
       "solutionMetadata": {
@@ -75,7 +75,7 @@
       "name": "Back and Forth",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=857",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search", "Recursion"],
       "solutionMetadata": {
@@ -88,7 +88,7 @@
       "name": "Twenty-four",
       "url": "https://dmoj.ca/problem/ccc08s4",
       "source": "CCC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search", "Permutation"],
       "solutionMetadata": {
@@ -100,7 +100,7 @@
       "name": "Beautiful Permutation II",
       "url": "https://cses.fi/problemset/task/3175",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search", "Permutation"],
       "solutionMetadata": {

--- a/content/2_Bronze/Conclusion.problems.json
+++ b/content/2_Bronze/Conclusion.problems.json
@@ -90,7 +90,7 @@
       "name": "Field Reduction",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=642",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry"],
       "solutionMetadata": {
@@ -102,7 +102,7 @@
       "name": "Palindromes Coloring",
       "url": "https://codeforces.com/problemset/problem/1624/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy"],
       "solutionMetadata": {
@@ -114,7 +114,7 @@
       "name": "Absolute Sorting",
       "url": "https://codeforces.com/contest/1772/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search", "Greedy"],
       "solutionMetadata": {
@@ -126,7 +126,7 @@
       "name": "It's All About the Base",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=509",
       "source": "Old Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -139,7 +139,7 @@
       "name": "ABBC or BACB",
       "url": "https://codeforces.com/problemset/problem/1873/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Ad Hoc"],
       "solutionMetadata": {
@@ -151,7 +151,7 @@
       "name": "GMO",
       "url": "https://open.kattis.com/problems/gmo",
       "source": "Kattis",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Strings"],
       "solutionMetadata": {

--- a/content/2_Bronze/Intro_Complete.problems.json
+++ b/content/2_Bronze/Intro_Complete.problems.json
@@ -57,7 +57,7 @@
       "name": "Counting Liars",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1228",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search", "Sorting"],
       "solutionMetadata": {
@@ -69,7 +69,7 @@
       "name": "Cow Gymnastics",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=963",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Complete Search"],
       "solutionMetadata": {
@@ -81,7 +81,7 @@
       "name": "Bovine Genomics",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=736",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Complete Search"],
       "solutionMetadata": {
@@ -93,7 +93,7 @@
       "name": "Triangles",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1011",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search"],
       "solutionMetadata": {
@@ -105,7 +105,7 @@
       "name": "Lifeguards",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=784",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search"],
       "solutionMetadata": {
@@ -117,7 +117,7 @@
       "name": "Why Did the Cow Cross the Road II",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=712",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Complete Search"],
       "solutionMetadata": {

--- a/content/2_Bronze/Intro_Greedy.problems.json
+++ b/content/2_Bronze/Intro_Greedy.problems.json
@@ -33,7 +33,7 @@
       "name": "Cow Tipping",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=689",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy"],
       "solutionMetadata": {
@@ -45,7 +45,7 @@
       "name": "Even More Odd Photos",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1084",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy"],
       "solutionMetadata": {
@@ -58,7 +58,7 @@
       "name": "Out of Place",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=785",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Greedy"],
       "solutionMetadata": {
@@ -70,7 +70,7 @@
       "name": "Astral Superposition",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1467",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy"],
       "solutionMetadata": {
@@ -82,7 +82,7 @@
       "name": "Purchasing Milk",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1565",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy"],
       "solutionMetadata": {

--- a/content/2_Bronze/Intro_Sets.problems.json
+++ b/content/2_Bronze/Intro_Sets.problems.json
@@ -59,7 +59,7 @@
       "name": "Team Tic Tac Toe",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=831",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Set", "Simulation"],
       "solutionMetadata": {
@@ -71,7 +71,7 @@
       "name": "Year of the Cow",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1107",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Map"],
       "solutionMetadata": {
@@ -83,7 +83,7 @@
       "name": "Don't Be Last!",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=687",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Map", "Sorting"],
       "solutionMetadata": {
@@ -95,7 +95,7 @@
       "name": "It's Mooin' Time II",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1468",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Map", "Set"],
       "solutionMetadata": {
@@ -107,7 +107,7 @@
       "name": "Cities & States",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=667",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Map"],
       "solutionMetadata": {
@@ -119,7 +119,7 @@
       "name": "Jury Marks",
       "url": "https://codeforces.com/contest/831/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums", "Set"],
       "solutionMetadata": {

--- a/content/2_Bronze/Intro_Sorting.problems.json
+++ b/content/2_Bronze/Intro_Sorting.problems.json
@@ -45,7 +45,7 @@
       "name": "Kayaking",
       "url": "https://codeforces.com/contest/863/problem/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
@@ -57,7 +57,7 @@
       "name": "Why Did the Cow Cross the Road III",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=713",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation", "Sorting"],
       "solutionMetadata": {
@@ -69,7 +69,7 @@
       "name": "Cow College",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1251",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sorting"],
       "solutionMetadata": {

--- a/content/2_Bronze/Rect_Geo.problems.json
+++ b/content/2_Bronze/Rect_Geo.problems.json
@@ -20,7 +20,7 @@
       "name": "Blocked Billboard",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=759",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Rectangle"],
       "solutionMetadata": {

--- a/content/2_Bronze/Simulation.problems.json
+++ b/content/2_Bronze/Simulation.problems.json
@@ -98,7 +98,7 @@
       "name": "Measuring Traffic",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=917",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation"],
       "solutionMetadata": {
@@ -110,7 +110,7 @@
       "name": "Circular Barn",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=616",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation"],
       "solutionMetadata": {
@@ -122,7 +122,7 @@
       "name": "Block Game",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=664",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Simulation"],
       "solutionMetadata": {
@@ -134,7 +134,7 @@
       "name": "Team Tic Tac Toe",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=831",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation"],
       "solutionMetadata": {
@@ -146,7 +146,7 @@
       "name": "Mowing the Field",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=593",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation"],
       "solutionMetadata": {
@@ -158,7 +158,7 @@
       "name": "Reflection",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1491",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation"],
       "solutionMetadata": {

--- a/content/3_Silver/Binary_Search.problems.json
+++ b/content/3_Silver/Binary_Search.problems.json
@@ -58,7 +58,7 @@
       "name": "Social Distancing",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1038",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Sorting"],
       "solutionMetadata": {
@@ -147,7 +147,7 @@
       "name": "TripTastic",
       "url": "https://www.codechef.com/problems/TRPTSTIC",
       "source": "CC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["2D Prefix Sums", "Binary Search"],
       "solutionMetadata": {
@@ -159,7 +159,7 @@
       "name": "Multiplication Table",
       "url": "https://cses.fi/problemset/task/2422",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search"],
       "solutionMetadata": {
@@ -171,7 +171,7 @@
       "name": "Edu C: Magic Ship",
       "url": "https://codeforces.com/problemset/problem/1117/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Binary Search", "Prefix Sums"],
       "solutionMetadata": {
@@ -183,7 +183,7 @@
       "name": "The Meeting Place Cannot Be Changed",
       "url": "https://codeforces.com/contest/782/problem/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Binary Search"],
       "solutionMetadata": {
@@ -195,7 +195,7 @@
       "name": "Packmen",
       "url": "https://codeforces.com/contest/847/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search"],
       "solutionMetadata": {

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -164,7 +164,7 @@
       "name": "Maximum Manhattan Distances",
       "url": "https://cses.fi/problemset/task/3410/",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry"],
       "solutionMetadata": {
@@ -176,7 +176,7 @@
       "name": "Save the Nature",
       "url": "https://codeforces.com/problemset/problem/1223/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Sorting"],
       "solutionMetadata": {
@@ -188,7 +188,7 @@
       "name": "Pond",
       "url": "https://atcoder.jp/contests/abc203/tasks/abc203_d?lang=en",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Prefix Sums"],
       "solutionMetadata": {
@@ -201,7 +201,7 @@
       "name": "Firehose",
       "url": "https://dmoj.ca/problem/ccc10s3",
       "source": "CCC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search"],
       "solutionMetadata": {
@@ -213,7 +213,7 @@
       "name": "Circular Barn - The Game",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1255",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game", "Number Theory"],
       "solutionMetadata": {
@@ -225,7 +225,7 @@
       "name": "Sabotage",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=419",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Prefix Sums"],
       "solutionMetadata": {
@@ -237,7 +237,7 @@
       "name": "Firecrackers",
       "url": "https://codeforces.com/contest/1468/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Sorting"],
       "solutionMetadata": {
@@ -249,7 +249,7 @@
       "name": "Just Green Enough",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1112",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -261,7 +261,7 @@
       "name": "Min Max Sort",
       "url": "https://codeforces.com/contest/1792/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Two Pointers"],
       "solutionMetadata": {
@@ -273,7 +273,7 @@
       "name": "Three Base Stations",
       "url": "https://codeforces.com/contest/51/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Two Pointers"],
       "solutionMetadata": {
@@ -286,7 +286,7 @@
       "name": "To Become Max",
       "url": "https://codeforces.com/contest/1856/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search"],
       "solutionMetadata": {
@@ -298,7 +298,7 @@
       "name": "Big Brush",
       "url": "https://codeforces.com/contest/1638/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Ad Hoc", "DFS", "Greedy"],
       "solutionMetadata": {
@@ -310,7 +310,7 @@
       "name": "Replace the Numbers",
       "url": "https://codeforces.com/contest/1620/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sorting"],
       "solutionMetadata": {
@@ -322,7 +322,7 @@
       "name": "Friendly Spiders",
       "url": "https://codeforces.com/contest/1775/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS", "Bipartite", "Graphs", "Number Theory", "Shortest Path"],
       "solutionMetadata": {
@@ -334,7 +334,7 @@
       "name": "Counting Rectangles",
       "url": "https://codeforces.com/problemset/problem/1722/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -346,7 +346,7 @@
       "name": "Count the Trains",
       "url": "https://codeforces.com/problemset/problem/1690/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sorted Set"],
       "solutionMetadata": {
@@ -358,7 +358,7 @@
       "name": "Array and Segments",
       "url": "https://codeforces.com/contest/1108/problem/E2",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sorted Set"],
       "solutionMetadata": {
@@ -371,7 +371,7 @@
       "name": "Set Or Decrease",
       "url": "https://codeforces.com/contest/1622/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Prefix Sums"],
       "solutionMetadata": {
@@ -383,7 +383,7 @@
       "name": "Adjust The Presentation",
       "url": "https://codeforces.com/problemset/problem/2021/C2",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy"],
       "solutionMetadata": {
@@ -396,7 +396,7 @@
       "name": "Medium Demon Problem (easy version)",
       "url": "https://codeforces.com/contest/2044/problem/G1",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Functional Graph"],
       "solutionMetadata": {
@@ -408,7 +408,7 @@
       "name": "Medium Demon Problem (hard version)",
       "url": "https://codeforces.com/contest/2044/problem/G2",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Functional Graph"],
       "solutionMetadata": {
@@ -420,7 +420,7 @@
       "name": "Medical Parity",
       "url": "https://codeforces.com/contest/2181/problem/M",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitwise", "Greedy", "Prefix Sums"],
       "solutionMetadata": {
@@ -432,7 +432,7 @@
       "name": "Salary Changing",
       "url": "https://codeforces.com/contest/1251/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search"],
       "solutionMetadata": {
@@ -444,7 +444,7 @@
       "name": "Escape Room",
       "url": "https://dmoj.ca/problem/ccc20s2",
       "source": "CCC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Flood Fill"],
       "solutionMetadata": {
@@ -456,7 +456,7 @@
       "name": "Phenomenal Reviews",
       "url": "https://dmoj.ca/problem/ccc16s3",
       "source": "CCC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Tree"],
       "solutionMetadata": {
@@ -468,7 +468,7 @@
       "name": "2017 - Sabotage",
       "url": "https://szkopul.edu.pl/problemset/problem/CUjJDGGSEZmO7HvdZU4FKrL6/site/?key=statement",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Tree"],
       "solutionMetadata": {
@@ -480,7 +480,7 @@
       "name": "Split Into Two Sets",
       "url": "https://codeforces.com/contest/1702/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bipartite", "DFS"],
       "solutionMetadata": {
@@ -492,7 +492,7 @@
       "name": "Giving Awards",
       "url": "https://codeforces.com/contest/412/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DFS", "TopoSort"],
       "solutionMetadata": {
@@ -504,7 +504,7 @@
       "name": "Trapmigiano Reggiano",
       "url": "https://codeforces.com/contest/2071/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
@@ -517,7 +517,7 @@
       "name": "Robot Queries",
       "url": "https://codeforces.com/contest/1902/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Prefix Sums"],
       "solutionMetadata": {
@@ -530,7 +530,7 @@
       "name": "Hypercarp and Interdimensional Jumps",
       "url": "https://codeforces.com/contest/2253/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -543,7 +543,7 @@
       "name": "Round Dance",
       "url": "https://codeforces.com/contest/1833/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Connected Components", "DFS"],
       "solutionMetadata": {
@@ -555,7 +555,7 @@
       "name": "Mahmoud & Ehab & Function",
       "url": "https://codeforces.com/contest/862/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search"],
       "solutionMetadata": {
@@ -567,7 +567,7 @@
       "name": "Ammar-utiful Array",
       "url": "https://codeforces.com/gym/104468/problem/H",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Prefix Sums"],
       "solutionMetadata": {
@@ -580,7 +580,7 @@
       "name": "Preparing for Merge Sort",
       "url": "https://codeforces.com/contest/847/problem/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search"],
       "solutionMetadata": {
@@ -592,7 +592,7 @@
       "name": "Minimizing Difference",
       "url": "https://codeforces.com/contest/1244/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Greedy", "Prefix Sums"],
       "solutionMetadata": {
@@ -604,7 +604,7 @@
       "name": "Far Cities",
       "url": "https://codeforces.com/contest/2258/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Tree"],
       "solutionMetadata": {

--- a/content/3_Silver/Flood_Fill.problems.json
+++ b/content/3_Silver/Flood_Fill.problems.json
@@ -70,7 +70,7 @@
       "name": "Switching on the Lights",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=570",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Flood Fill"],
       "solutionMetadata": {
@@ -83,7 +83,7 @@
       "name": "Build Gates",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=596",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Flood Fill"],
       "solutionMetadata": {
@@ -95,7 +95,7 @@
       "name": "Milk Pails",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=620",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Flood Fill"],
       "solutionMetadata": {
@@ -107,7 +107,7 @@
       "name": "Where's Bessie?",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=740",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Flood Fill"],
       "solutionMetadata": {
@@ -119,7 +119,7 @@
       "name": "Why Did the Cow Cross the Road III",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=716",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Flood Fill"],
       "solutionMetadata": {
@@ -131,7 +131,7 @@
       "name": "Mooyo Mooyo",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=860",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Flood Fill"],
       "solutionMetadata": {
@@ -143,7 +143,7 @@
       "name": "Comfortable Cows",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1110",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Flood Fill"],
       "solutionMetadata": {

--- a/content/3_Silver/Func_Graphs.problems.json
+++ b/content/3_Silver/Func_Graphs.problems.json
@@ -60,7 +60,7 @@
       "name": "Visits",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1230",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SCC"],
       "solutionMetadata": {
@@ -72,7 +72,7 @@
       "name": "Luxury River Cruise",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=284",
       "source": "Old Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Functional Graph"],
       "solutionMetadata": {

--- a/content/3_Silver/Graph_Traversal.problems.json
+++ b/content/3_Silver/Graph_Traversal.problems.json
@@ -82,7 +82,7 @@
       "name": "Flight Routes Check",
       "url": "https://cses.fi/problemset/task/1682",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["DFS"],
       "solutionMetadata": {
@@ -94,7 +94,7 @@
       "name": "BFS-DFS",
       "url": "https://csacademy.com/contest/archive/task/bfs-dfs",
       "source": "CSA",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS", "DFS"],
       "solutionMetadata": {
@@ -106,7 +106,7 @@
       "name": "Moocast",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=669",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Connected Components"],
       "solutionMetadata": {
@@ -118,7 +118,7 @@
       "name": "Wormhole Sort",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=992",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Binary Search", "Connected Components"],
       "solutionMetadata": {
@@ -130,7 +130,7 @@
       "name": "Moo Route II",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1304",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS"],
       "solutionMetadata": {
@@ -143,7 +143,7 @@
       "name": "Connecting Two Barns",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1159",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Connected Components", "Two Pointers"],
       "solutionMetadata": {
@@ -155,7 +155,7 @@
       "name": "Redistributing Gifts",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1206",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DFS"],
       "solutionMetadata": {
@@ -167,7 +167,7 @@
       "name": "Subarray Sum Constraints",
       "url": "https://cses.fi/problemset/task/3294",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Connected Components", "DFS", "Prefix Sums"],
       "solutionMetadata": {

--- a/content/3_Silver/Greedy_Sorting.problems.json
+++ b/content/3_Silver/Greedy_Sorting.problems.json
@@ -157,7 +157,7 @@
       "name": "Bovine Acrobatics",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1350",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Deque", "Greedy", "Sorting"],
       "solutionMetadata": {
@@ -169,7 +169,7 @@
       "name": "Berry Picking",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=990",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
@@ -181,7 +181,7 @@
       "name": "Ciel and Duel",
       "url": "https://codeforces.com/contest/321/problem/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy"],
       "solutionMetadata": {
@@ -193,7 +193,7 @@
       "name": "Yet Another Tournament",
       "url": "https://codeforces.com/contest/1783/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {

--- a/content/3_Silver/Intro_Bitwise.problems.json
+++ b/content/3_Silver/Intro_Bitwise.problems.json
@@ -7,7 +7,7 @@
       "name": "Take a Guess",
       "url": "https://codeforces.com/contest/1556/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitwise"],
       "solutionMetadata": {
@@ -23,7 +23,7 @@
       "name": "Xor Sigma Problem",
       "url": "https://atcoder.jp/contests/abc365/tasks/abc365_e",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitwise", "Prefix Sums"],
       "solutionMetadata": {
@@ -122,7 +122,7 @@
       "name": "Field Day",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1327",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitwise", "Graphs"],
       "solutionMetadata": {
@@ -134,7 +134,7 @@
       "name": "Sheikh (Easy version)",
       "url": "https://codeforces.com/problemset/problem/1732/C1",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Bitwise", "Prefix Sums"],
       "solutionMetadata": {
@@ -146,7 +146,7 @@
       "name": "Sum of XOR Functions",
       "url": "https://codeforces.com/contest/1879/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitwise", "Prefix Sums"],
       "solutionMetadata": {
@@ -159,7 +159,7 @@
       "name": "Prime Multiples",
       "url": "https://cses.fi/problemset/task/2185",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Bitwise", "PIE"],
       "solutionMetadata": {
@@ -171,7 +171,7 @@
       "name": "AND, OR, and square sum",
       "url": "https://codeforces.com/contest/1368/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Math"],
       "solutionMetadata": {
@@ -184,7 +184,7 @@
       "name": "Sequence Construction",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1518",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitwise"],
       "solutionMetadata": {
@@ -197,7 +197,7 @@
       "name": "Sliding Window Summation",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1544",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitwise", "Prefix Sums"],
       "solutionMetadata": {

--- a/content/3_Silver/Intro_Tree.problems.json
+++ b/content/3_Silver/Intro_Tree.problems.json
@@ -107,7 +107,7 @@
       "name": "Tree Diameter",
       "url": "https://cses.fi/problemset/task/1131",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Tree"],
       "solutionMetadata": {
@@ -119,7 +119,7 @@
       "name": "Minimize the Diameter",
       "url": "https://codeforces.com/gym/104536/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Tree"],
       "solutionMetadata": {
@@ -131,7 +131,7 @@
       "name": "Tree Distances I",
       "url": "https://cses.fi/problemset/task/1132",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Tree"],
       "solutionMetadata": {
@@ -143,7 +143,7 @@
       "name": "Tree Distances II",
       "url": "https://cses.fi/problemset/task/1133",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Tree"],
       "solutionMetadata": {
@@ -155,7 +155,7 @@
       "name": "Ski Slope",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1520",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Sorting", "Tree"],
       "solutionMetadata": {
@@ -167,7 +167,7 @@
       "name": "Clock Tree",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1016",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bipartite", "Tree"],
       "solutionMetadata": {

--- a/content/3_Silver/More_Prefix_Sums.problems.json
+++ b/content/3_Silver/More_Prefix_Sums.problems.json
@@ -36,7 +36,7 @@
       "name": "Greg and Array",
       "url": "https://codeforces.com/contest/295/problem/A",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Difference Array"],
       "solutionMetadata": {
@@ -64,7 +64,7 @@
       "name": "Little Girl and Maximum Sum",
       "url": "https://codeforces.com/contest/276/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Difference Array"],
       "solutionMetadata": {
@@ -76,7 +76,7 @@
       "name": "QED's Favorite Permutation",
       "url": "https://codeforces.com/contest/2030/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Difference Array", "Sorting"],
       "solutionMetadata": {
@@ -88,7 +88,7 @@
       "name": "Haybale Stacking",
       "url": "https://www.spoj.com/problems/HAYBALE/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -101,7 +101,7 @@
       "name": "Painting the Barn",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=919",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["2D Prefix Sums"],
       "solutionMetadata": {
@@ -128,7 +128,7 @@
       "name": "Nusret Gökçe",
       "url": "https://codeforces.com/gym/104114/problem/N",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -140,7 +140,7 @@
       "name": "Queries for Number of Palindromes",
       "url": "https://codeforces.com/contest/245/problem/H",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -152,7 +152,7 @@
       "name": "Sjeltzer?",
       "url": "https://atcoder.jp/contests/abc465/tasks/abc465_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {

--- a/content/3_Silver/Prefix_Sums.problems.json
+++ b/content/3_Silver/Prefix_Sums.problems.json
@@ -105,7 +105,7 @@
       "name": "Alternating String",
       "url": "https://codeforces.com/contest/2008/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -117,7 +117,7 @@
       "name": "Multiple of 2019",
       "url": "https://atcoder.jp/contests/abc164/tasks/abc164_d",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -129,7 +129,7 @@
       "name": "Running Miles",
       "url": "https://codeforces.com/contest/1826/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -141,7 +141,7 @@
       "name": "Farmer John's Favorite Operation",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1471",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {

--- a/content/3_Silver/Priority_Queues.problems.json
+++ b/content/3_Silver/Priority_Queues.problems.json
@@ -6,7 +6,7 @@
       "name": "Room Allocation",
       "url": "https://cses.fi/problemset/task/1164",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Priority Queue", "Sorting"],
       "solutionMetadata": {
@@ -57,7 +57,7 @@
       "name": "William and Robot",
       "url": "https://codeforces.com/gym/104002/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Priority Queue"],
       "solutionMetadata": {
@@ -69,7 +69,7 @@
       "name": "Packing Under Range Regulations",
       "url": "https://atcoder.jp/contests/abc214/tasks/abc214_e",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Priority Queue", "Sorting"],
       "solutionMetadata": {
@@ -81,7 +81,7 @@
       "name": "Why Did the Cow Cross the Road",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=714",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Priority Queue", "Sorting"],
       "solutionMetadata": {

--- a/content/3_Silver/Sorting_Custom.problems.json
+++ b/content/3_Silver/Sorting_Custom.problems.json
@@ -47,7 +47,7 @@
       "name": "Covered Points Count",
       "url": "https://codeforces.com/problemset/problem/1000/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Coordinate Compression", "Prefix Sums", "Sorting"],
       "solutionMetadata": {
@@ -59,7 +59,7 @@
       "name": "Lifeguards",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=786",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
@@ -71,7 +71,7 @@
       "name": "Rental Service",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=787",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
@@ -83,7 +83,7 @@
       "name": "Mountain View",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=896",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Sorting"],
       "solutionMetadata": {
@@ -95,7 +95,7 @@
       "name": "Stuck in a Rut",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1064",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sorting"],
       "solutionMetadata": {
@@ -107,7 +107,7 @@
       "name": "Splitting the Field",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=645",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
@@ -119,7 +119,7 @@
       "name": "The Smallest String Concatenation",
       "url": "https://codeforces.com/problemset/problem/632/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sorting"],
       "solutionMetadata": {
@@ -131,7 +131,7 @@
       "name": "Nezzar and Symmetric Array",
       "url": "https://codeforces.com/problemset/problem/1478/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums", "Sorting"],
       "solutionMetadata": {
@@ -144,7 +144,7 @@
       "name": "Correct Placement",
       "url": "https://codeforces.com/problemset/problem/1472/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sorting"],
       "solutionMetadata": {

--- a/content/3_Silver/Two_Pointers.problems.json
+++ b/content/3_Silver/Two_Pointers.problems.json
@@ -107,7 +107,7 @@
       "name": "Diamond Collector",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=643",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Sorting", "Two Pointers"],
       "solutionMetadata": {
@@ -119,7 +119,7 @@
       "name": "Sleepy Cow Herding",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=918",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sorting", "Two Pointers"],
       "solutionMetadata": {
@@ -131,7 +131,7 @@
       "name": "An impassioned circulation of affection",
       "url": "https://codeforces.com/problemset/problem/814/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Two Pointers"],
       "solutionMetadata": {

--- a/content/4_Gold/All_Roots.problems.json
+++ b/content/4_Gold/All_Roots.problems.json
@@ -32,7 +32,7 @@
       "name": "Subtree",
       "url": "https://atcoder.jp/contests/dp/tasks/dp_v",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -44,7 +44,7 @@
       "name": "2017 - City Attractions",
       "url": "https://csacademy.com/contest/archive/task/city-attractions/statement/",
       "source": "Balkan OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Functional Graph"],
       "solutionMetadata": {
@@ -56,7 +56,7 @@
       "name": "Directory Traversal",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=814",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Tree"],
       "solutionMetadata": {

--- a/content/4_Gold/Combinatorics.problems.json
+++ b/content/4_Gold/Combinatorics.problems.json
@@ -66,7 +66,7 @@
       "name": "Erasing Vertices",
       "url": "https://atcoder.jp/contests/agc049/tasks/agc049_a",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -130,7 +130,7 @@
       "name": "Bots",
       "url": "https://dmoj.ca/problem/bbc08h",
       "source": "Bubble Cup",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Combinatorics"],
       "solutionMetadata": {
@@ -142,7 +142,7 @@
       "name": "Xor Pyramid",
       "url": "https://cses.fi/problemset/task/2419",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitwise", "Combinatorics"],
       "solutionMetadata": {
@@ -154,7 +154,7 @@
       "name": "Med and Mex",
       "url": "https://codeforces.com/gym/104520/problem/K",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Combinatorics"],
       "solutionMetadata": {
@@ -166,7 +166,7 @@
       "name": "Strivore",
       "url": "https://atcoder.jp/contests/abc171/tasks/abc171_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Combinatorics"],
       "solutionMetadata": {
@@ -179,7 +179,7 @@
       "name": "Moo Route",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1283",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Combinatorics"],
       "solutionMetadata": {
@@ -192,7 +192,7 @@
       "name": "Cowpatibility",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=862",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitset", "PIE"],
       "solutionMetadata": {
@@ -205,7 +205,7 @@
       "name": "Help Yourself",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1018",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Combinatorics", "Prefix Sums"],
       "solutionMetadata": {
@@ -218,7 +218,7 @@
       "name": "Sakura Adachi and Optimal Sequences",
       "url": "https://codeforces.com/contest/2171/problem/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "Combinatorics", "Math"],
       "solutionMetadata": {
@@ -231,7 +231,7 @@
       "name": "Sasha and the Wedding Binary Search Tree",
       "url": "https://codeforces.com/contest/1929/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Combinatorics", "Modular Arithmetic"],
       "solutionMetadata": {

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -160,7 +160,7 @@
       "name": "Yura and Deadlines",
       "url": "https://codeforces.com/contest/2244/problem/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "SegTree"],
       "solutionMetadata": {
@@ -173,7 +173,7 @@
       "name": "Jeopardized Projects",
       "url": "https://codeforces.com/gym/103886/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Combinatorics", "Prefix Sums"],
       "solutionMetadata": {
@@ -185,7 +185,7 @@
       "name": "Yet Another Minimization Problem 2",
       "url": "https://codeforces.com/contest/1637/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Knapsack", "Math"],
       "solutionMetadata": {
@@ -198,7 +198,7 @@
       "name": "Fossil Excavation",
       "url": "https://codeforces.com/gym/103886/problem/L",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "DP", "Shortest Path"],
       "solutionMetadata": {
@@ -211,7 +211,7 @@
       "name": "Different Arrays",
       "url": "https://codeforces.com/contest/1783/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -224,7 +224,7 @@
       "name": "What's Up With Gravity?",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=282",
       "source": "Old Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS"],
       "solutionMetadata": {
@@ -236,7 +236,7 @@
       "name": "Palindromic Characteristics",
       "url": "https://codeforces.com/contest/835/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Hashing"],
       "solutionMetadata": {
@@ -249,7 +249,7 @@
       "name": "Cow Navigation",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=695",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS"],
       "solutionMetadata": {
@@ -261,7 +261,7 @@
       "name": "Bessie's Dream",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=575",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS"],
       "solutionMetadata": {
@@ -274,7 +274,7 @@
       "name": "Flood Fill",
       "url": "https://codeforces.com/contest/1114/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -286,7 +286,7 @@
       "name": "MST Unification",
       "url": "https://codeforces.com/contest/1108/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DSU", "MST"],
       "solutionMetadata": {
@@ -299,7 +299,7 @@
       "name": "Backpacking",
       "url": "https://orac2.info/problem/aio24backpacking/",
       "source": "AIO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Deque"],
       "solutionMetadata": {
@@ -312,7 +312,7 @@
       "name": "Studentsko",
       "url": "https://open.kattis.com/problems/studentsko?tab=submissions",
       "source": "Kattis",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "LIS"],
       "solutionMetadata": {
@@ -325,7 +325,7 @@
       "name": "Monsters",
       "url": "https://codeforces.com/contest/1810/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DSU", "Greedy", "Set"],
       "solutionMetadata": {
@@ -338,7 +338,7 @@
       "name": "Flowers",
       "url": "https://kilonova.ro/problems/2890",
       "source": "IIOT",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Tree"],
       "solutionMetadata": {
@@ -350,7 +350,7 @@
       "name": "The Endspeaker (Hard Version)",
       "url": "https://codeforces.com/contest/2027/problem/D2",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "DP", "PURS", "Two Pointers"],
       "solutionMetadata": {
@@ -363,7 +363,7 @@
       "name": "Maximum Glutton",
       "url": "https://atcoder.jp/contests/abc364/tasks/abc364_e",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -375,7 +375,7 @@
       "name": "Blocking Elements",
       "url": "https://codeforces.com/contest/1918/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "DP", "PURS"],
       "solutionMetadata": {
@@ -387,7 +387,7 @@
       "name": "Cook and Porridge",
       "url": "https://codeforces.com/contest/1945/problem/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Priority Queue", "Sorted Set"],
       "solutionMetadata": {
@@ -400,7 +400,7 @@
       "name": "Mycraft Sand Sort",
       "url": "https://codeforces.com/problemset/problem/2064/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Combinatorics", "DSU", "Sorted Set"],
       "solutionMetadata": {
@@ -413,7 +413,7 @@
       "name": "Cube",
       "url": "https://codeforces.com/contest/2041/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "DP"],
       "solutionMetadata": {
@@ -426,7 +426,7 @@
       "name": "Bus Stops",
       "url": "https://atcoder.jp/contests/abc319/tasks/abc319_e",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Number Theory"],
       "solutionMetadata": {
@@ -439,7 +439,7 @@
       "name": "Clique Connect",
       "url": "https://atcoder.jp/contests/abc352/tasks/abc352_e",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Graphs", "Math"],
       "solutionMetadata": {
@@ -452,7 +452,7 @@
       "name": "Counting Numbers",
       "url": "https://cses.fi/problemset/task/2220",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -464,7 +464,7 @@
       "name": "Cake Trial",
       "url": "https://codeforces.com/contest/2238/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -477,7 +477,7 @@
       "name": "Another Exercise on Graphs (Easy Version)",
       "url": "https://codeforces.com/contest/2057/problem/E1",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["0/1 BFS", "Binary Search", "DP", "DSU"],
       "solutionMetadata": {
@@ -490,7 +490,7 @@
       "name": "Control Of Randomness",
       "url": "https://codeforces.com/contest/2040/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Probability", "Tree"],
       "solutionMetadata": {
@@ -503,7 +503,7 @@
       "name": "Arena",
       "url": "https://codeforces.com/problemset/problem/1606/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Combinatorics", "DP"],
       "solutionMetadata": {
@@ -515,7 +515,7 @@
       "name": "Korney Korneevich and XOR (easy version)",
       "url": "https://codeforces.com/problemset/problem/1582/F1",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitwise", "DP"],
       "solutionMetadata": {

--- a/content/4_Gold/DP_Bitmasks.problems.json
+++ b/content/4_Gold/DP_Bitmasks.problems.json
@@ -96,7 +96,7 @@
       "name": "Uddered but not Herd",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1089",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "DP"],
       "solutionMetadata": {
@@ -109,7 +109,7 @@
       "name": "Elevator Rides",
       "url": "https://cses.fi/problemset/task/1653",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "DP"],
       "solutionMetadata": {
@@ -121,7 +121,7 @@
       "name": "2014 - Bank",
       "url": "https://oj.uz/problem/view/IZhO14_bank",
       "source": "IZhO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "DP"],
       "solutionMetadata": {
@@ -133,7 +133,7 @@
       "name": "Cat & Mice",
       "url": "https://open.kattis.com/problems/catandmice",
       "source": "Kattis",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Bitmasks", "DP", "Geometry"],
       "solutionMetadata": {

--- a/content/4_Gold/DP_Ranges.problems.json
+++ b/content/4_Gold/DP_Ranges.problems.json
@@ -34,7 +34,7 @@
       "name": "248",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=647",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Range DP"],
       "solutionMetadata": {
@@ -46,7 +46,7 @@
       "name": "Zuma",
       "url": "https://codeforces.com/problemset/problem/607/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Range DP"],
       "solutionMetadata": {
@@ -58,7 +58,7 @@
       "name": "Empty String",
       "url": "https://cses.fi/problemset/task/1080",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Range DP"],
       "solutionMetadata": {
@@ -70,7 +70,7 @@
       "name": "2014 - The Stables of Genghis Khan",
       "url": "https://saco-evaluator.org.za/cms/sapo2014z/tasks/genghis/description",
       "source": "SAPO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Range DP"],
       "solutionMetadata": {
@@ -82,7 +82,7 @@
       "name": "Brackets",
       "url": "https://www.codechef.com/practice/course/zco-inoi-problems/INOIPRAC/problems/INOI1602",
       "source": "CC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Range DP"],
       "solutionMetadata": {

--- a/content/4_Gold/DP_Trees.problems.json
+++ b/content/4_Gold/DP_Trees.problems.json
@@ -58,7 +58,7 @@
       "name": "Distance in Tree",
       "url": "https://codeforces.com/contest/161/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Tree"],
       "solutionMetadata": {
@@ -71,7 +71,7 @@
       "name": "2020 - Village (Minimum)",
       "url": "https://codeforces.com/contest/1387/problem/B1",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
@@ -83,7 +83,7 @@
       "name": "Nastia Plays with a Tree",
       "url": "https://codeforces.com/contest/1521/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
@@ -96,7 +96,7 @@
       "name": "Parade",
       "url": "https://szkopul.edu.pl/problemset/problem/1QaUWE_ePAmitZjgAszOVD1U/site/?key=statement",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Tree"],
       "solutionMetadata": {
@@ -108,7 +108,7 @@
       "name": "Berland Federalization",
       "url": "https://codeforces.com/problemset/problem/440/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Tree"],
       "solutionMetadata": {
@@ -120,7 +120,7 @@
       "name": "Parsa's Humongous Tree",
       "url": "https://codeforces.com/problemset/problem/1528/A",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Tree"],
       "solutionMetadata": {
@@ -132,7 +132,7 @@
       "name": "Select Edges",
       "url": "https://atcoder.jp/contests/abc259/tasks/abc259_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Tree"],
       "solutionMetadata": {
@@ -144,7 +144,7 @@
       "name": "Delegation",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1019",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Tree"],
       "solutionMetadata": {
@@ -156,7 +156,7 @@
       "name": "Bessie's Function",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1497",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Tree"],
       "solutionMetadata": {

--- a/content/4_Gold/DSU.problems.json
+++ b/content/4_Gold/DSU.problems.json
@@ -93,7 +93,7 @@
       "name": "Mountain Time",
       "url": "https://csacademy.com/contest/archive/task/mountain-time",
       "source": "CSA",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DSU"],
       "solutionMetadata": {
@@ -106,7 +106,7 @@
       "name": "Two Sets",
       "url": "https://codeforces.com/contest/468/problem/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DSU"],
       "solutionMetadata": {
@@ -119,7 +119,7 @@
       "name": "Reachable Pairs",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1474",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DSU"],
       "solutionMetadata": {

--- a/content/4_Gold/Digit_DP.problems.json
+++ b/content/4_Gold/Digit_DP.problems.json
@@ -46,7 +46,7 @@
       "name": "Magic Numbers",
       "url": "https://codeforces.com/contest/628/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -60,7 +60,7 @@
       "name": "Piling Papers",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1307",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["DP"],
       "solutionMetadata": {

--- a/content/4_Gold/Divisibility.problems.json
+++ b/content/4_Gold/Divisibility.problems.json
@@ -123,7 +123,7 @@
       "name": "Common Divisors",
       "url": "https://cses.fi/problemset/task/1081",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Divisibility"],
       "solutionMetadata": {
@@ -135,7 +135,7 @@
       "name": "Orac and LCM",
       "url": "https://codeforces.com/contest/1349/problem/A",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prime Factorization"],
       "solutionMetadata": {
@@ -147,7 +147,7 @@
       "name": "Maximum of GCDs",
       "url": "https://www.codechef.com/problems/KSIZEGCD",
       "source": "CC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Divisibility"],
       "solutionMetadata": {

--- a/content/4_Gold/Hashing.problems.json
+++ b/content/4_Gold/Hashing.problems.json
@@ -82,7 +82,7 @@
       "name": "Bovine Genomics",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=741",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Hashing"],
       "solutionMetadata": {
@@ -94,7 +94,7 @@
       "name": "Lights Out",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=599",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Hashing", "Simulation"],
       "solutionMetadata": {
@@ -106,7 +106,7 @@
       "name": "2017 - Hangman 2",
       "url": "https://csacademy.com/contest/rmi-2017-day-1/task/hangman2/",
       "source": "RMI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Hashing"],
       "solutionMetadata": {
@@ -119,7 +119,7 @@
       "name": "2017 - Osmosmjerka",
       "url": "https://oj.uz/problem/view/COCI17_osmosmjerka",
       "source": "COCI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Hashing", "Probability"],
       "solutionMetadata": {

--- a/content/4_Gold/Hashmaps.problems.json
+++ b/content/4_Gold/Hashmaps.problems.json
@@ -6,7 +6,7 @@
       "name": "3SUM",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=994",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -20,7 +20,7 @@
       "name": "Sum of Four Values",
       "url": "https://cses.fi/problemset/task/1642",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Set"],
       "solutionMetadata": {

--- a/content/4_Gold/Intro_DP.problems.json
+++ b/content/4_Gold/Intro_DP.problems.json
@@ -70,7 +70,7 @@
       "name": "Teamwork",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=863",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -84,7 +84,7 @@
       "name": "Snakes",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=945",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -98,7 +98,7 @@
       "name": "Phidias",
       "url": "https://dmoj.ca/problem/ioi04p4",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {

--- a/content/4_Gold/Intro_Sorted_Sets.problems.json
+++ b/content/4_Gold/Intro_Sorted_Sets.problems.json
@@ -70,7 +70,7 @@
       "name": "Milk Measurement",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=763",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Priority Queue", "Sorted Set"],
       "solutionMetadata": {
@@ -82,7 +82,7 @@
       "name": "Array Destruction",
       "url": "https://codeforces.com/problemset/problem/1474/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Sorted Set", "Sorting"],
       "solutionMetadata": {
@@ -94,7 +94,7 @@
       "name": "Movie Festival II",
       "url": "https://cses.fi/problemset/task/1632",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Greedy", "Sorted Set", "Sorting"],
       "solutionMetadata": {
@@ -106,7 +106,7 @@
       "name": "Snow Boots",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=813",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Linked List", "Sorted Set"],
       "solutionMetadata": {

--- a/content/4_Gold/Knapsack_DP.problems.json
+++ b/content/4_Gold/Knapsack_DP.problems.json
@@ -130,7 +130,7 @@
       "name": "Knapsack",
       "url": "https://oj.uz/problem/view/NOI18_knapsack",
       "source": "NOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Knapsack"],
       "solutionMetadata": {
@@ -168,7 +168,7 @@
       "name": "Talent Show",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=839",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "DP", "Knapsack"],
       "solutionMetadata": {
@@ -207,7 +207,7 @@
       "name": "Round Subset",
       "url": "http://codeforces.com/contest/837/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Knapsack"],
       "solutionMetadata": {
@@ -220,7 +220,7 @@
       "name": "Cow Poetry",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=897",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Exponentiation", "Knapsack"],
       "solutionMetadata": {
@@ -232,7 +232,7 @@
       "name": "Exercise",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1043",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Knapsack", "Prime Factorization"],
       "solutionMetadata": {
@@ -245,7 +245,7 @@
       "name": "2004 - Maximal",
       "url": "https://szkopul.edu.pl/problemset/problem/lGqKS9urITMjTXhpdaHqyoEL/site/?key=statement",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Knapsack", "Prime Factorization"],
       "solutionMetadata": {

--- a/content/4_Gold/LIS.problems.json
+++ b/content/4_Gold/LIS.problems.json
@@ -21,7 +21,7 @@
       "name": "2010 - PCB",
       "url": "https://qoj.ac/contest/3027/problem/16693",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": [],
       "solutionMetadata": {
@@ -60,7 +60,7 @@
       "name": " Suitable Edit for LIS",
       "url": "https://atcoder.jp/contests/abc360/tasks/abc360_g",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "LIS"],
       "solutionMetadata": {
@@ -72,7 +72,7 @@
       "name": "Kite",
       "url": "https://atcoder.jp/contests/abc439/tasks/abc439_e",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LIS"],
       "solutionMetadata": {
@@ -84,7 +84,7 @@
       "name": "LCS on Permutations",
       "url": "https://codeforces.com/gym/102951/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["DP", "LIS"],
       "solutionMetadata": {
@@ -97,7 +97,7 @@
       "name": "Cow Jog",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=496",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -109,7 +109,7 @@
       "name": "LCIS",
       "url": "https://codeforces.com/problemset/problem/10/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "LIS"],
       "solutionMetadata": {
@@ -121,7 +121,7 @@
       "name": "Rabbit Carrot",
       "url": "https://oj.uz/problem/view/LMIO19_triusis",
       "source": "LMiO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {

--- a/content/4_Gold/MST.problems.json
+++ b/content/4_Gold/MST.problems.json
@@ -58,7 +58,7 @@
       "name": "GCD and MST",
       "url": "https://codeforces.com/problemset/problem/1513/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["MST", "Math"],
       "solutionMetadata": {
@@ -70,7 +70,7 @@
       "name": "Choose Two and Eat One",
       "url": "https://atcoder.jp/contests/abc282/tasks/abc282_e",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DSU"],
       "solutionMetadata": {
@@ -82,7 +82,7 @@
       "name": "I Would Walk 500 Miles",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=946",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["MST"],
       "solutionMetadata": {
@@ -94,7 +94,7 @@
       "name": "Spanning Tree Fraction",
       "url": "https://www.hackerrank.com/contests/w31/challenges/spanning-tree-fraction/problem",
       "source": "HR",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "MST"],
       "solutionMetadata": {
@@ -107,7 +107,7 @@
       "name": "Moo Network",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1211",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["MST"],
       "solutionMetadata": {
@@ -120,7 +120,7 @@
       "name": "2015 - Inheritance",
       "url": "https://qoj.ac/problem/1213",
       "source": "JOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "MST"],
       "solutionMetadata": {
@@ -132,7 +132,7 @@
       "name": "Portals",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1138",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["MST"],
       "solutionMetadata": {

--- a/content/4_Gold/Meet_In_The_Middle.problems.json
+++ b/content/4_Gold/Meet_In_The_Middle.problems.json
@@ -58,7 +58,7 @@
       "name": "Max Indep Set",
       "url": "https://judge.yosupo.jp/problem/maximum_independent_set",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "DP", "Meet in the Middle"],
       "solutionMetadata": {

--- a/content/4_Gold/Modular.problems.json
+++ b/content/4_Gold/Modular.problems.json
@@ -45,7 +45,7 @@
       "name": "Sumdiv",
       "url": "https://kilonova.ro/problems/127",
       "source": "Kilonova",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Math", "Prime Factorization"],
       "solutionMetadata": {
@@ -57,7 +57,7 @@
       "name": "Queue Composite",
       "url": "https://judge.yosupo.jp/problem/queue_operate_all_composite",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Modular Arithmetic"],
       "solutionMetadata": {
@@ -69,7 +69,7 @@
       "name": "Divisor Analysis",
       "url": "https://cses.fi/problemset/task/2182",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Modular Arithmetic"],
       "solutionMetadata": {

--- a/content/4_Gold/PURS.problems.json
+++ b/content/4_Gold/PURS.problems.json
@@ -123,7 +123,7 @@
       "name": "Distinct Values Queries",
       "url": "https://cses.fi/problemset/task/1734",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Offline", "PURS"],
       "solutionMetadata": {

--- a/content/4_Gold/Paths_Grids.problems.json
+++ b/content/4_Gold/Paths_Grids.problems.json
@@ -96,7 +96,7 @@
       "name": "Minimal Grid Path",
       "url": "https://cses.fi/problemset/task/3359/",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -108,7 +108,7 @@
       "name": "The Cow Run",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=265",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {

--- a/content/4_Gold/Shortest_Paths.problems.json
+++ b/content/4_Gold/Shortest_Paths.problems.json
@@ -70,7 +70,7 @@
       "name": "Shortcut",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=899",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Shortest Path"],
       "solutionMetadata": {
@@ -82,7 +82,7 @@
       "name": "Telephone",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1090",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Shortest Path"],
       "solutionMetadata": {
@@ -95,7 +95,7 @@
       "name": "Not Escaping",
       "url": "https://codeforces.com/contest/1627/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [
         "Binary Search",
@@ -112,7 +112,7 @@
       "name": "Investigation",
       "url": "https://cses.fi/problemset/task/1202",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Shortest Path"],
       "solutionMetadata": {
@@ -124,7 +124,7 @@
       "name": "Robot Turtles",
       "url": "https://open.kattis.com/problems/robotturtles",
       "source": "Kattis",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Shortest Path"],
       "solutionMetadata": {
@@ -136,7 +136,7 @@
       "name": "Flight Routes",
       "url": "https://cses.fi/problemset/task/1196",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Shortest Path"],
       "solutionMetadata": {

--- a/content/4_Gold/Sliding_Window.problems.json
+++ b/content/4_Gold/Sliding_Window.problems.json
@@ -21,7 +21,7 @@
       "name": "Max Subarray Sum II",
       "url": "https://cses.fi/problemset/task/1644",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums", "Sliding Window"],
       "solutionMetadata": {
@@ -33,7 +33,7 @@
       "name": "Sliding Median",
       "url": "https://cses.fi/problemset/task/1076",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Set", "Sliding Window"],
       "solutionMetadata": {
@@ -122,7 +122,7 @@
       "name": "2015 - Palembang Bridges",
       "url": "https://oj.uz/problem/view/APIO15_bridge",
       "source": "APIO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Median", "Sliding Window"],
       "solutionMetadata": {
@@ -134,7 +134,7 @@
       "name": "Painting the Barn",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=923",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Sliding Window"],
       "solutionMetadata": {
@@ -147,7 +147,7 @@
       "name": "Fort Moo",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=600",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sliding Window"],
       "solutionMetadata": {
@@ -159,7 +159,7 @@
       "name": "Little Bird",
       "url": "https://cses.fi/poi/task/527",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Sliding Window"],
       "solutionMetadata": {
@@ -209,7 +209,7 @@
       "name": "Razlika",
       "url": "https://dmoj.ca/problem/coci12c4p4",
       "source": "COCI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sliding Window"],
       "solutionMetadata": {

--- a/content/4_Gold/Stacks.problems.json
+++ b/content/4_Gold/Stacks.problems.json
@@ -33,7 +33,7 @@
       "name": "Mike and Feet",
       "url": "https://codeforces.com/contest/547/problem/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Stack"],
       "solutionMetadata": {
@@ -45,7 +45,7 @@
       "name": "2011 - Balloons",
       "url": "https://oj.uz/problem/view/CEOI11_bal",
       "source": "CEOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry", "Stack"],
       "solutionMetadata": {
@@ -57,7 +57,7 @@
       "name": "2012 - Mobile",
       "url": "https://oj.uz/problem/view/BOI12_mobile",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Stack"],
       "solutionMetadata": {
@@ -69,7 +69,7 @@
       "name": "Modern Art 2",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=743",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Stack"],
       "solutionMetadata": {
@@ -81,7 +81,7 @@
       "name": "Dishwashing",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=922",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Stack"],
       "solutionMetadata": {
@@ -93,7 +93,7 @@
       "name": "Maximum Building I",
       "url": "https://cses.fi/problemset/task/1147",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Stack"],
       "solutionMetadata": {
@@ -106,7 +106,7 @@
       "name": "2020 - Fancy Fence",
       "url": "https://codeforces.com/contest/1402/problem/A",
       "source": "CEOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Stack"],
       "solutionMetadata": {
@@ -119,7 +119,7 @@
       "name": "Rectangles",
       "url": "https://codeforces.com/gym/101102/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Stack"],
       "solutionMetadata": {

--- a/content/4_Gold/Ternary_Search.problems.json
+++ b/content/4_Gold/Ternary_Search.problems.json
@@ -7,7 +7,7 @@
       "name": "Haybale Distribution",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1355",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Ternary Search"],
       "solutionMetadata": {
@@ -86,7 +86,7 @@
       "name": "Simple Skewness",
       "url": "https://codeforces.com/problemset/problem/626/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Ternary Search"],
       "solutionMetadata": {

--- a/content/4_Gold/TopoSort.problems.json
+++ b/content/4_Gold/TopoSort.problems.json
@@ -125,7 +125,7 @@
       "name": "Milking Order",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=838",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "TopoSort"],
       "solutionMetadata": {
@@ -138,7 +138,7 @@
       "name": "Pattern Matching",
       "url": "https://codeforces.com/problemset/problem/1476/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "TopoSort"],
       "solutionMetadata": {

--- a/content/4_Gold/Tree_Euler.problems.json
+++ b/content/4_Gold/Tree_Euler.problems.json
@@ -76,7 +76,7 @@
       "name": "Path Queries",
       "url": "https://cses.fi/problemset/task/1138",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour", "PURS"],
       "solutionMetadata": {
@@ -89,7 +89,7 @@
       "name": "Cow Land",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=921",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour", "PURS"],
       "solutionMetadata": {
@@ -101,7 +101,7 @@
       "name": "Milk Visits",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=970",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour", "LCA"],
       "solutionMetadata": {
@@ -113,7 +113,7 @@
       "name": "Promotion Counting",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=696",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour", "PURS"],
       "solutionMetadata": {
@@ -125,7 +125,7 @@
       "name": "Exactly K Steps",
       "url": "https://atcoder.jp/contests/abc267/tasks/abc267_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour"],
       "solutionMetadata": {
@@ -138,7 +138,7 @@
       "name": "The Shortest Statement",
       "url": "https://codeforces.com/contest/1051/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour"],
       "solutionMetadata": {
@@ -150,7 +150,7 @@
       "name": "Count Descendants",
       "url": "https://atcoder.jp/contests/abc202/tasks/abc202_e",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Euler Tour"],
       "solutionMetadata": {
@@ -163,7 +163,7 @@
       "name": "Distance Queries on a Tree",
       "url": "https://atcoder.jp/contests/abc294/tasks/abc294_g",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["LCA", "PURS"],
       "solutionMetadata": {

--- a/content/4_Gold/Unweighted_Shortest_Paths.problems.json
+++ b/content/4_Gold/Unweighted_Shortest_Paths.problems.json
@@ -84,7 +84,7 @@
       "name": "Graph Girth",
       "url": "https://cses.fi/problemset/task/1707",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Cycle"],
       "solutionMetadata": {
@@ -96,7 +96,7 @@
       "name": "Lasers and Mirrors",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=671",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["BFS"],
       "solutionMetadata": {
@@ -108,7 +108,7 @@
       "name": "Construct a Palindrome",
       "url": "https://atcoder.jp/contests/abc197/tasks/abc197_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["BFS"],
       "solutionMetadata": {
@@ -120,7 +120,7 @@
       "name": "Cow At Large",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=790",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS"],
       "solutionMetadata": {
@@ -132,7 +132,7 @@
       "name": "2009 - Mecho",
       "url": "https://oj.uz/problem/view/IOI09_mecho",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS", "Binary Search"],
       "solutionMetadata": {
@@ -144,7 +144,7 @@
       "name": "Swap Game",
       "url": "https://cses.fi/problemset/task/1670/",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS"],
       "solutionMetadata": {
@@ -157,7 +157,7 @@
       "name": "Walls",
       "url": "https://dmoj.ca/problem/ioi00p4",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS"],
       "solutionMetadata": {
@@ -169,7 +169,7 @@
       "name": "D/D/D",
       "url": "https://codeforces.com/contest/2109/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Shortest Path"],
       "solutionMetadata": {

--- a/content/5_Plat/2DRQ.problems.json
+++ b/content/5_Plat/2DRQ.problems.json
@@ -21,7 +21,7 @@
       "name": "Crowded Cities",
       "url": "https://dmoj.ca/problem/bfs17p6",
       "source": "Back From Summer",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["2DRQ", "BIT"],
       "solutionMetadata": {
@@ -34,7 +34,7 @@
       "name": "2007 - Pairs",
       "url": "https://oj.uz/problem/view/IOI07_pairs",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["3DRQ", "BIT"],
       "solutionMetadata": {
@@ -49,7 +49,7 @@
       "name": "Soriya's Programming Project",
       "url": "https://dmoj.ca/problem/dmopc19c7p5",
       "source": "DMOPC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["2DRQ", "BIT", "Divide and Conquer"],
       "solutionMetadata": {
@@ -64,7 +64,7 @@
       "name": "Friendcross",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=722",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["2DRQ", "BIT"],
       "solutionMetadata": {
@@ -76,7 +76,7 @@
       "name": "Mowing the Field",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=601",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["2DRQ", "BIT"],
       "solutionMetadata": {
@@ -89,7 +89,7 @@
       "name": "2019 - Street Lamps",
       "url": "https://oj.uz/problem/view/APIO19_street_lamps",
       "source": "APIO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["2DRQ", "BIT"],
       "solutionMetadata": {

--- a/content/5_Plat/Binary_Jump.problems.json
+++ b/content/5_Plat/Binary_Jump.problems.json
@@ -62,7 +62,7 @@
       "name": "Planets Queries II",
       "url": "https://cses.fi/problemset/task/1160",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Functional Graph"],
       "solutionMetadata": {
@@ -74,7 +74,7 @@
       "name": "Cyclic Array",
       "url": "https://cses.fi/problemset/task/1191/",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Jumping", "Binary Search", "Two Pointers"],
       "solutionMetadata": {
@@ -86,7 +86,7 @@
       "name": "2010 - Frog",
       "url": "https://szkopul.edu.pl/problemset/problem/qDH9CkBHZKHY4vbKRBlXPrA7/site/?key=statement",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Jumping", "Sliding Window"],
       "solutionMetadata": {
@@ -98,7 +98,7 @@
       "name": "Lynyrd Skynyrd",
       "url": "https://codeforces.com/contest/1142/problem/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -111,7 +111,7 @@
       "name": "2019 - Valley",
       "url": "https://oj.uz/problem/view/BOI19_valley",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -124,7 +124,7 @@
       "name": "2017 - Toll",
       "url": "https://oj.uz/problem/view/BOI17_toll",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -175,7 +175,7 @@
       "name": "Disruption",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=842",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCA"],
       "solutionMetadata": {
@@ -187,7 +187,7 @@
       "name": "Running Away From the Barn",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=213",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Jumping", "Euler Tour", "Small to Large"],
       "solutionMetadata": {
@@ -266,7 +266,7 @@
       "name": "Duff in the Army",
       "url": "https://codeforces.com/contest/588/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCA"],
       "solutionMetadata": {
@@ -278,7 +278,7 @@
       "name": "2017 - Railway",
       "url": "https://oj.uz/problem/view/BOI17_railway",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -290,7 +290,7 @@
       "name": "MST for Each Edge",
       "url": "https://codeforces.com/contest/609/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCA"],
       "solutionMetadata": {
@@ -302,7 +302,7 @@
       "name": "Omsk Metro (hard version)",
       "url": "https://codeforces.com/contest/1843/problem/F2",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["LCA"],
       "solutionMetadata": {
@@ -314,7 +314,7 @@
       "name": "Root LCA Queries",
       "url": "https://csacademy.com/contest/archive/task/root-lca-queries",
       "source": "CSA",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCA"],
       "solutionMetadata": {
@@ -327,7 +327,7 @@
       "name": "Two Paths",
       "url": "https://codeforces.com/contest/1000/problem/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCA"],
       "solutionMetadata": {
@@ -340,7 +340,7 @@
       "name": "Hot & Cold",
       "url": "https://dmoj.ca/problem/bts17p7",
       "source": "Back to School",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCA"],
       "solutionMetadata": {

--- a/content/5_Plat/Bitsets.problems.json
+++ b/content/5_Plat/Bitsets.problems.json
@@ -21,7 +21,7 @@
       "name": "Cowpatibility",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=862",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitset", "PIE"],
       "solutionMetadata": {
@@ -35,7 +35,7 @@
       "name": "Lots of Triangles",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=672",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitset", "Geometry"],
       "solutionMetadata": {
@@ -116,7 +116,7 @@
       "name": "2019 - Nautilus",
       "url": "https://oj.uz/problem/view/BOI19_nautilus",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitset"],
       "solutionMetadata": {
@@ -129,7 +129,7 @@
       "name": "2010 - Candies",
       "url": "https://qoj.ac/problem/16695",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitset", "Knapsack"],
       "solutionMetadata": {
@@ -141,7 +141,7 @@
       "name": "2015 - Uzastopni",
       "url": "https://oj.uz/problem/view/COCI15_uzastopni",
       "source": "COCI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitset"],
       "solutionMetadata": {

--- a/content/5_Plat/Centroid.problems.json
+++ b/content/5_Plat/Centroid.problems.json
@@ -20,7 +20,7 @@
       "name": "Xenia & Tree",
       "url": "https://codeforces.com/problemset/problem/342/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Centroid"],
       "solutionMetadata": {
@@ -98,7 +98,7 @@
       "name": "2011 - Race",
       "url": "https://oj.uz/problem/view/IOI11_race",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Centroid", "Merging"],
       "solutionMetadata": {
@@ -110,7 +110,7 @@
       "name": "New Barns",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=817",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Centroid"],
       "solutionMetadata": {
@@ -123,7 +123,7 @@
       "name": "Sherlock's bet to Moriarty",
       "url": "https://codeforces.com/contest/776/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Centroid"],
       "solutionMetadata": {
@@ -136,7 +136,7 @@
       "name": "Digit Tree",
       "url": "https://codeforces.com/contest/715/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Centroid", "Number Theory"],
       "solutionMetadata": {
@@ -149,7 +149,7 @@
       "name": "Double Tree",
       "url": "https://codeforces.com/contest/1140/problem/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Centroid", "DP"],
       "solutionMetadata": {
@@ -162,7 +162,7 @@
       "name": "2014 - Factories",
       "url": "https://oj.uz/problem/view/JOI14_factories",
       "source": "JOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Centroid"],
       "solutionMetadata": {
@@ -175,7 +175,7 @@
       "name": "2019 - Lampice",
       "url": "https://dmoj.ca/problem/coci19c3p4",
       "source": "COCI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Centroid", "Hashing"],
       "solutionMetadata": {

--- a/content/5_Plat/Conclusion.problems.json
+++ b/content/5_Plat/Conclusion.problems.json
@@ -45,7 +45,7 @@
       "name": "Julia and Snail",
       "url": "https://codeforces.com/problemset/problem/793/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "SegTree", "Sqrt"],
       "solutionMetadata": {
@@ -58,7 +58,7 @@
       "name": "Escape Through Leaf",
       "url": "https://codeforces.com/problemset/problem/932/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex"],
       "solutionMetadata": {
@@ -71,7 +71,7 @@
       "name": "Shuttle Tour",
       "url": "https://qoj.ac/contest/1221/problem/6404",
       "source": "QOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SegTree", "Virtual Tree"],
       "solutionMetadata": {
@@ -83,7 +83,7 @@
       "name": "Sum Queries?",
       "url": "https://codeforces.com/contest/1217/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SegTree"],
       "solutionMetadata": {

--- a/content/5_Plat/Convex_Hull.problems.json
+++ b/content/5_Plat/Convex_Hull.problems.json
@@ -49,7 +49,7 @@
       "name": "Balance Beam",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=864",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex"],
       "solutionMetadata": {
@@ -62,7 +62,7 @@
       "name": "Geometers Anonymous",
       "url": "https://codeforces.com/problemset/problem/1195/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex", "PURS"],
       "solutionMetadata": {
@@ -75,7 +75,7 @@
       "name": "Cow Curling",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=382",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex"],
       "solutionMetadata": {

--- a/content/5_Plat/Convex_Hull_Trick.problems.json
+++ b/content/5_Plat/Convex_Hull_Trick.problems.json
@@ -57,7 +57,7 @@
       "name": "2009 - Harbingers",
       "url": "https://oj.uz/problem/view/CEOI09_harbingers",
       "source": "CEOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex", "DP"],
       "solutionMetadata": {
@@ -69,7 +69,7 @@
       "name": "Bear and Bowling 4",
       "url": "https://codeforces.com/problemset/problem/660/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
@@ -81,7 +81,7 @@
       "name": "2002 - Batch Scheduling",
       "url": "https://dmoj.ca/problem/ioi02p4",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex", "DP"],
       "solutionMetadata": {
@@ -93,7 +93,7 @@
       "name": "2014 - Split the Sequence",
       "url": "https://oj.uz/problem/view/APIO14_sequence",
       "source": "APIO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex", "DP"],
       "solutionMetadata": {
@@ -105,7 +105,7 @@
       "name": "2011 - Lightning Conductor",
       "url": "https://szkopul.edu.pl/problemset/problem/iYVwsAcHHCRZzAtQh0QFKbsu/site/",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex", "DP"],
       "solutionMetadata": {
@@ -117,7 +117,7 @@
       "name": "2006 - Frogs",
       "url": "https://szkopul.edu.pl/problemset/problem/HH7LQVRVHom1g8YRe9423d1P/site/",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex", "DP"],
       "solutionMetadata": {
@@ -129,7 +129,7 @@
       "name": "Circular Barn",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=626",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex", "DP"],
       "solutionMetadata": {
@@ -141,7 +141,7 @@
       "name": "Falling Portals",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=998",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex"],
       "solutionMetadata": {

--- a/content/5_Plat/DC-DP.problems.json
+++ b/content/5_Plat/DC-DP.problems.json
@@ -20,7 +20,7 @@
       "name": "2004 - Two Sawmills",
       "url": "https://szkopul.edu.pl/problemset/problem/ovRIpLFK3IhyFPjnVXeZtGxH/site/?key=statement",
       "source": "CEOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
@@ -32,7 +32,7 @@
       "name": "2015 - Nafta",
       "url": "https://oj.uz/problem/view/COI15_nafta",
       "source": "COI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
@@ -45,7 +45,7 @@
       "name": "Bear and Bowling 4",
       "url": "https://codeforces.com/problemset/problem/660/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {
@@ -57,7 +57,7 @@
       "name": "Yakiniku Restaurants",
       "url": "https://atcoder.jp/contests/arc067/tasks/arc067_d",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Divide and Conquer"],
       "solutionMetadata": {

--- a/content/5_Plat/DC-SRQ.problems.json
+++ b/content/5_Plat/DC-SRQ.problems.json
@@ -46,7 +46,7 @@
       "name": "2017 - Toll",
       "url": "https://oj.uz/problem/view/BOI17_toll",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -58,7 +58,7 @@
       "name": "Continued Fractions",
       "url": "https://dmoj.ca/problem/dmopc19c7p4",
       "source": "DMOPC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -71,7 +71,7 @@
       "name": "Estelle's Supper Box",
       "url": "https://codebreaker.xyz/problem/supperbox",
       "source": "NOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Divide and Conquer", "Knapsack", "SRQ"],
       "solutionMetadata": {

--- a/content/5_Plat/DP_SOS.problems.json
+++ b/content/5_Plat/DP_SOS.problems.json
@@ -46,7 +46,7 @@
       "name": "Bits and Pieces",
       "url": "https://codeforces.com/contest/1208/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "SOS DP"],
       "solutionMetadata": {
@@ -58,7 +58,7 @@
       "name": "Sleeping in Class",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1213",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Number Theory", "Prefix Sums"],
       "solutionMetadata": {
@@ -71,7 +71,7 @@
       "name": "Compatible Numbers",
       "url": "https://codeforces.com/contest/165/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "SOS DP"],
       "solutionMetadata": {
@@ -84,7 +84,7 @@
       "name": "Jzzhu and Numbers",
       "url": "https://codeforces.com/problemset/problem/449/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "SOS DP"],
       "solutionMetadata": {

--- a/content/5_Plat/Geo_Pri.problems.json
+++ b/content/5_Plat/Geo_Pri.problems.json
@@ -6,7 +6,7 @@
       "name": "Polygon Lattice Points",
       "url": "https://cses.fi/problemset/task/2193",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry"],
       "solutionMetadata": {
@@ -36,7 +36,7 @@
       "name": "Line Segment Intersection",
       "url": "https://cses.fi/problemset/task/2190",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry"],
       "solutionMetadata": {
@@ -51,7 +51,7 @@
       "name": "Polygon Area",
       "url": "https://cses.fi/problemset/task/2191",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry", "Math"],
       "solutionMetadata": {
@@ -66,7 +66,7 @@
       "name": "Point in Polygon",
       "url": "https://cses.fi/problemset/task/2192",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry", "Math"],
       "solutionMetadata": {
@@ -81,7 +81,7 @@
       "name": "Maximum Number of Visible Points",
       "url": "https://leetcode.com/problems/maximum-number-of-visible-points/description/",
       "source": "LC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry", "Sliding Window"],
       "solutionMetadata": {
@@ -168,7 +168,7 @@
       "name": "The Troublesome Frog",
       "url": "https://ioi.contest.codeforces.com/group/32KGsXgiKA/contest/103699/problem/A",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -195,7 +195,7 @@
       "name": "Laser Takahashi",
       "url": "https://atcoder.jp/contests/abc442/tasks/abc442_e",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry", "Sorting"],
       "solutionMetadata": {

--- a/content/5_Plat/HLD.problems.json
+++ b/content/5_Plat/HLD.problems.json
@@ -57,7 +57,7 @@
       "name": "Milk Visits",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=970",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["HLD"],
       "solutionMetadata": {
@@ -69,7 +69,7 @@
       "name": "Disruption",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=842",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["HLD"],
       "solutionMetadata": {
@@ -81,7 +81,7 @@
       "name": "Subtrees & Paths",
       "url": "https://www.hackerrank.com/challenges/subtrees-and-paths",
       "source": "HR",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["HLD", "RURQ"],
       "solutionMetadata": {
@@ -93,7 +93,7 @@
       "name": "Grass Planting",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=102",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["HLD", "PURS"],
       "solutionMetadata": {
@@ -106,7 +106,7 @@
       "name": "Vertex Set Path Composite",
       "url": "https://judge.yosupo.jp/problem/vertex_set_path_composite",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["HLD", "SegTree"],
       "solutionMetadata": {

--- a/content/5_Plat/Matrix_Expo.problems.json
+++ b/content/5_Plat/Matrix_Expo.problems.json
@@ -73,7 +73,7 @@
       "name": "Sasha and Array",
       "url": "https://codeforces.com/problemset/problem/718/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Exponentiation", "Matrix", "PURS"],
       "solutionMetadata": {
@@ -85,7 +85,7 @@
       "name": "2007 - Connected Points",
       "url": "https://cses.fi/112/list/",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
@@ -98,7 +98,7 @@
       "name": "2009 - Reading",
       "url": "https://vjudge.net/problem/%E6%B4%9B%E8%B0%B7-P6841",
       "source": "Balkan OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {
@@ -111,7 +111,7 @@
       "name": "Ray Needs Help",
       "url": "https://dmoj.ca/problem/ray",
       "source": "DMOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Exponentiation", "Matrix"],
       "solutionMetadata": {

--- a/content/5_Plat/Merging.problems.json
+++ b/content/5_Plat/Merging.problems.json
@@ -20,7 +20,7 @@
       "name": "Lomsat gelral",
       "url": "https://codeforces.com/contest/600/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Merging"],
       "solutionMetadata": {
@@ -32,7 +32,7 @@
       "name": "Promotion Counting",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=696",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Indexed Set", "Merging"],
       "solutionMetadata": {
@@ -44,7 +44,7 @@
       "name": "Disruption",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=842",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Merging"],
       "solutionMetadata": {
@@ -56,7 +56,7 @@
       "name": "2011 - Tree Rotations",
       "url": "https://szkopul.edu.pl/problemset/problem/sUe3qzxBtasek-RAWmZaxY_p/site/?key=statement",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Indexed Set", "Merging"],
       "solutionMetadata": {
@@ -68,7 +68,7 @@
       "name": "2011 - Race",
       "url": "https://oj.uz/problem/view/IOI11_race",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Centroid", "Merging"],
       "solutionMetadata": {

--- a/content/5_Plat/PIE.problems.json
+++ b/content/5_Plat/PIE.problems.json
@@ -6,7 +6,7 @@
       "name": "SQFREE - Square-free integers",
       "url": "https://www.spoj.com/problems/SQFREE/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Divisibility", "PIE"],
       "solutionMetadata": {
@@ -21,7 +21,7 @@
       "name": "Cowpatibility",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=862",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitset", "PIE"],
       "solutionMetadata": {
@@ -62,7 +62,7 @@
       "name": "KPRIMESB - Almost Prime Numbers Again",
       "url": "https://www.spoj.com/problems/KPRIMESB/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Divisibility", "PIE"],
       "solutionMetadata": {
@@ -74,7 +74,7 @@
       "name": "MSKYCODE - Sky Code",
       "url": "https://www.spoj.com/problems/MSKYCODE/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Divisibility", "PIE"],
       "solutionMetadata": {
@@ -86,7 +86,7 @@
       "name": "Counting Reorders",
       "url": "https://cses.fi/problemset/task/2421",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["PIE"],
       "solutionMetadata": {
@@ -98,7 +98,7 @@
       "name": "Counting Coprime Pairs",
       "url": "https://cses.fi/problemset/task/2417",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Divisibility", "PIE"],
       "solutionMetadata": {
@@ -110,7 +110,7 @@
       "name": "Grid Completion",
       "url": "https://cses.fi/problemset/task/2429",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["PIE"],
       "solutionMetadata": {

--- a/content/5_Plat/RURQ.problems.json
+++ b/content/5_Plat/RURQ.problems.json
@@ -34,7 +34,7 @@
       "name": "2011 - Growing Trees",
       "url": "https://oj.uz/problem/view/BOI11_grow",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["1DRQ", "Binary Search"],
       "solutionMetadata": {
@@ -46,7 +46,7 @@
       "name": "2007 - Sails",
       "url": "http://oj.uz/problem/view/IOI07_sails",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["1DRQ", "Binary Search"],
       "solutionMetadata": {
@@ -125,7 +125,7 @@
       "name": "2014 - Wall",
       "url": "https://oj.uz/problem/view/IOI14_wall",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Lazy SegTree"],
       "solutionMetadata": {
@@ -138,7 +138,7 @@
       "name": "2005 - Mountain",
       "url": "https://dmoj.ca/problem/ioi05p2",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Coordinate Compression", "Lazy SegTree"],
       "solutionMetadata": {
@@ -150,7 +150,7 @@
       "name": "Bessie's Snow Cow",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=973",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour", "Lazy SegTree", "PURS"],
       "solutionMetadata": {
@@ -162,7 +162,7 @@
       "name": "Diverging Directions",
       "url": "https://codeforces.com/contest/838/problem/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour", "RURQ"],
       "solutionMetadata": {

--- a/content/5_Plat/Range_Sweep.problems.json
+++ b/content/5_Plat/Range_Sweep.problems.json
@@ -21,7 +21,7 @@
       "name": "Springboards",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=995",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["PURQ"],
       "solutionMetadata": {
@@ -48,7 +48,7 @@
       "name": "Slingshot",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=816",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["PURQ"],
       "solutionMetadata": {
@@ -60,7 +60,7 @@
       "name": "Load Balancing",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=624",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/5_Plat/Segtree_Ext.problems.json
+++ b/content/5_Plat/Segtree_Ext.problems.json
@@ -36,7 +36,7 @@
       "name": "Seating",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=231",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -48,7 +48,7 @@
       "name": "Serge and Dining Room",
       "url": "https://codeforces.com/contest/1179/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["PURQ"],
       "solutionMetadata": {
@@ -78,7 +78,7 @@
       "name": "Subarray Sum Queries",
       "url": "https://cses.fi/problemset/task/1190",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["PURQ"],
       "solutionMetadata": {
@@ -154,7 +154,7 @@
       "name": "Optimal Milking",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=365",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -167,7 +167,7 @@
       "name": "2014 - Cards",
       "url": "https://szkopul.edu.pl/problemset/problem/qpsk3ygf8MU7D_1Es0oc_xd8/site/?key=statement",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -179,7 +179,7 @@
       "name": "Pareidolia",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1332",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Matrix", "PURQ"],
       "solutionMetadata": {

--- a/content/5_Plat/Sparse_Segtree.problems.json
+++ b/content/5_Plat/Sparse_Segtree.problems.json
@@ -6,7 +6,7 @@
       "name": "2012 - Monkey and Apple-trees",
       "url": "https://oj.uz/problem/view/IZhO12_apple",
       "source": "IZhO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -21,7 +21,7 @@
       "name": "2005 - Mountain",
       "url": "https://dmoj.ca/problem/ioi05p2",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Lazy SegTree", "Sparse SegTree"],
       "solutionMetadata": {
@@ -33,7 +33,7 @@
       "name": "2015 - Happiness",
       "url": "https://oj.uz/problem/view/Balkan15_HAPPINESS",
       "source": "Balkan OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/5_Plat/Sqrt.problems.json
+++ b/content/5_Plat/Sqrt.problems.json
@@ -6,7 +6,7 @@
       "name": "Hop Sugoroku",
       "url": "https://atcoder.jp/contests/abc335/tasks/abc335_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sqrt"],
       "solutionMetadata": {
@@ -51,7 +51,7 @@
       "name": "COT2 - Count on a tree II",
       "url": "https://www.spoj.com/problems/COT2/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Mo's Algorithm", "Sqrt", "Tree"],
       "solutionMetadata": {
@@ -117,7 +117,7 @@
       "name": "2018 - Bitaro's Birthday",
       "url": "https://oj.uz/problem/view/JOI18_bitaro",
       "source": "JOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["DP", "Sqrt"],
       "solutionMetadata": {
@@ -129,7 +129,7 @@
       "name": "Static Range Inversions Query",
       "url": "https://judge.yosupo.jp/problem/static_range_inversions_query",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sqrt"],
       "solutionMetadata": {
@@ -141,7 +141,7 @@
       "name": "Powerful array",
       "url": "https://codeforces.com/contest/86/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Mo's Algorithm"],
       "solutionMetadata": {
@@ -231,7 +231,7 @@
       "name": "2019 - Examination",
       "url": "https://oj.uz/problem/view/JOI19_examination",
       "source": "JOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["2DRQ", "Mo's Algorithm"],
       "solutionMetadata": {
@@ -243,7 +243,7 @@
       "name": "2009 - Regions",
       "url": "https://oj.uz/problem/view/IOI09_regions",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sqrt"],
       "solutionMetadata": {
@@ -256,7 +256,7 @@
       "name": "Minimizing Haybales",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1188",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sqrt"],
       "solutionMetadata": {

--- a/content/5_Plat/Sweep_Line.problems.json
+++ b/content/5_Plat/Sweep_Line.problems.json
@@ -20,7 +20,7 @@
       "name": "Closest Pair",
       "url": "https://open.kattis.com/problems/closestpair2",
       "source": "Kattis",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sweep Line"],
       "solutionMetadata": {
@@ -35,7 +35,7 @@
       "name": "Cow Steeplechase II",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=943",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sweep Line"],
       "solutionMetadata": {
@@ -63,7 +63,7 @@
       "name": "Hill Walk",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=266",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sweep Line"],
       "solutionMetadata": {
@@ -130,7 +130,7 @@
       "name": "Grid MST",
       "url": "https://open.kattis.com/problems/gridmst",
       "source": "Kattis",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Manhattan MST"],
       "solutionMetadata": {
@@ -187,7 +187,7 @@
       "name": "2018 - Stone",
       "url": "https://szkopul.edu.pl/problemset/problem/NZSCUwz2ACePsBKuVCIVzrRt/site/",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Radial Sweep"],
       "solutionMetadata": {

--- a/content/5_Plat/VTree.problems.json
+++ b/content/5_Plat/VTree.problems.json
@@ -6,7 +6,7 @@
       "name": "Leaf Color",
       "url": "https://atcoder.jp/contests/abc340/tasks/abc340_g",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Virtual Tree"],
       "solutionMetadata": {
@@ -21,7 +21,7 @@
       "name": "Color the Tree",
       "url": "https://codeforces.com/gym/104128/problem/E",
       "source": "Gym",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Virtual Tree"],
       "solutionMetadata": {

--- a/content/5_Plat/kruskal-tree.problems.json
+++ b/content/5_Plat/kruskal-tree.problems.json
@@ -6,7 +6,7 @@
       "name": "Qpwoeirut and Vertices",
       "url": "https://codeforces.com/contest/1706/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["KRT"],
       "solutionMetadata": {
@@ -21,7 +21,7 @@
       "name": "TULIPS",
       "url": "https://www.codechef.com/problems/TULIPS",
       "source": "CC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["KRT"],
       "solutionMetadata": {

--- a/content/6_Advanced/BCC_2CC.problems.json
+++ b/content/6_Advanced/BCC_2CC.problems.json
@@ -21,7 +21,7 @@
       "name": "SUBMERGE - Submerging Islands",
       "url": "https://www.spoj.com/problems/SUBMERGE/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BCC"],
       "solutionMetadata": {
@@ -36,7 +36,7 @@
       "name": "Disruption",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=842",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Merging"],
       "solutionMetadata": {
@@ -65,7 +65,7 @@
       "name": "Forbidden Cities",
       "url": "https://cses.fi/problemset/task/1705",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BCC"],
       "solutionMetadata": {
@@ -92,7 +92,7 @@
       "name": "2008 - Blockade",
       "url": "https://szkopul.edu.pl/problemset/problem/eDt8w290owtatmCjad0O0ywk/site/?key=statement",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BCC"],
       "solutionMetadata": {
@@ -104,7 +104,7 @@
       "name": "2018 - Duathlon",
       "url": "https://oj.uz/problem/view/APIO18_duathlon",
       "source": "APIO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BCC"],
       "solutionMetadata": {
@@ -116,7 +116,7 @@
       "name": "2016 - Amusing Journeys",
       "url": "https://szkopul.edu.pl/problemset/problem/YY6-3ua-C1rt7q-97laWc0UP/site/",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BCC"],
       "solutionMetadata": {

--- a/content/6_Advanced/Catalan.problems.json
+++ b/content/6_Advanced/Catalan.problems.json
@@ -33,7 +33,7 @@
       "name": "SKYLINE - Skyline",
       "url": "https://www.spoj.com/problems/SKYLINE/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Catalan", "Combinatorics"],
       "solutionMetadata": {

--- a/content/6_Advanced/Comb_Sub.problems.json
+++ b/content/6_Advanced/Comb_Sub.problems.json
@@ -6,7 +6,7 @@
       "name": "Karen & Supermarket",
       "url": "https://codeforces.com/contest/815/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -34,7 +34,7 @@
       "name": "2019 - Dzumbus",
       "url": "https://oj.uz/problem/view/COCI19_dzumbus",
       "source": "COCI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -46,7 +46,7 @@
       "name": "Cereal Trees II",
       "url": "https://codeforces.com/gym/103886/problem/Q",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Tree"],
       "solutionMetadata": {
@@ -59,7 +59,7 @@
       "name": "2005 - Rivers",
       "url": "http://dmoj.ca/problem/ioi05p6",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -71,7 +71,7 @@
       "name": "Tree Patrolling",
       "url": "https://atcoder.jp/contests/abc207/tasks/abc207_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Tree"],
       "solutionMetadata": {
@@ -84,7 +84,7 @@
       "name": "Ostap & Tree",
       "url": "https://codeforces.com/contest/735/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -96,7 +96,7 @@
       "name": "Div 1 D - Miss Punyverse",
       "url": "https://codeforces.com/contest/1280/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/Count_Min.problems.json
+++ b/content/6_Advanced/Count_Min.problems.json
@@ -6,7 +6,7 @@
       "name": "Area of Rectangles",
       "url": "https://cses.fi/problemset/task/1741",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Lazy SegTree"],
       "solutionMetadata": {
@@ -35,7 +35,7 @@
       "url": "https://codeforces.com/gym/102621/problem/L",
       "source": "mBIT",
       "sourceDescription": "Montgomery Blair Informatics Tournament",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/DP_Broken-Profile.problems.json
+++ b/content/6_Advanced/DP_Broken-Profile.problems.json
@@ -6,7 +6,7 @@
       "name": "Counting Tilings",
       "url": "https://cses.fi/problemset/task/2181",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Broken Profile"],
       "solutionMetadata": {
@@ -21,7 +21,7 @@
       "name": "Guards in the Storehouse",
       "url": "https://codeforces.com/problemset/problem/845/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Broken Profile"],
       "solutionMetadata": {
@@ -34,7 +34,7 @@
       "name": "2020 - Selotejp",
       "url": "https://dmoj.ca/problem/coci20c3p4",
       "source": "COCI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Broken Profile"],
       "solutionMetadata": {

--- a/content/6_Advanced/DP_More.problems.json
+++ b/content/6_Advanced/DP_More.problems.json
@@ -19,7 +19,7 @@
       "name": "Breaking Strings",
       "url": "https://www.spoj.com/problems/BRKSTRNG/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -31,7 +31,7 @@
       "name": "Gain Battle Power",
       "url": "https://onlinejudge.org/index.php?option=com_onlinejudge&Itemid=8&page=show_problem&problem=4701",
       "source": "onlinejudge.org",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -83,7 +83,7 @@
       "name": "2016 - Kangaroo",
       "url": "https://qoj.ac/contest/1107/problem/5532",
       "source": "CEOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -96,7 +96,7 @@
       "name": "MCO - Magical Teleporter",
       "url": "https://codeforces.com/group/R2SERIff4f/contest/213171/problem/R",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -109,7 +109,7 @@
       "name": "2016 - Skyscraper",
       "url": "https://oj.uz/problem/view/JOI16_skyscraper",
       "source": "JOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": [],
       "solutionMetadata": {
@@ -121,7 +121,7 @@
       "name": "Phoenix and Computers",
       "url": "https://codeforces.com/contest/1515/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/Eulerian_Tours.problems.json
+++ b/content/6_Advanced/Eulerian_Tours.problems.json
@@ -77,7 +77,7 @@
       "name": "Matching Substrings",
       "url": "https://csacademy.com/contest/archive/task/matching-substrings",
       "source": "CSA",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -90,7 +90,7 @@
       "name": "Turtle and Multiplication",
       "url": "https://codeforces.com/contest/1981/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -103,7 +103,7 @@
       "name": "Johnny and Megan's Necklace",
       "url": "https://codeforces.com/contest/1361/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour"],
       "solutionMetadata": {
@@ -116,7 +116,7 @@
       "name": "Data Center Drama",
       "url": "https://codeforces.com/contest/528/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour"],
       "solutionMetadata": {
@@ -129,7 +129,7 @@
       "name": "2016 - Acrobat",
       "url": "https://vjudge.net/problem/Baekjoon-13973",
       "source": "Balkan OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler Tour"],
       "solutionMetadata": {

--- a/content/6_Advanced/Eulers_Formula.problems.json
+++ b/content/6_Advanced/Eulers_Formula.problems.json
@@ -34,7 +34,7 @@
       "name": "Build Gates",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=596",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Euler's Formula", "Flood Fill"],
       "solutionMetadata": {

--- a/content/6_Advanced/FFT.problems.json
+++ b/content/6_Advanced/FFT.problems.json
@@ -21,7 +21,7 @@
       "name": "Convolution Mod 10^9+7",
       "url": "https://judge.yosupo.jp/problem/convolution_mod_1000000007",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["FFT"],
       "solutionMetadata": {
@@ -60,7 +60,7 @@
       "name": "Matchings",
       "url": "https://open.kattis.com/problems/matchings",
       "source": "Kattis",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/Flow_LB.problems.json
+++ b/content/6_Advanced/Flow_LB.problems.json
@@ -6,7 +6,7 @@
       "name": "Hungry Squirrels",
       "url": "https://dmoj.ca/problem/wac4p6",
       "source": "Wesley's Anger Contest",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -21,7 +21,7 @@
       "name": "Diverse Singing",
       "url": "https://codeforces.com/gym/102156/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -34,7 +34,7 @@
       "name": "Captain America",
       "url": "https://codeforces.com/contest/704/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -47,7 +47,7 @@
       "name": "Incorrect Flow",
       "url": "https://codeforces.com/contest/708/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -60,7 +60,7 @@
       "name": "Multi-Path Story",
       "url": "https://atcoder.jp/contests/jag2013summer-day4/tasks/icpc2013summer_day4_i",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/Fracturing_Search.problems.json
+++ b/content/6_Advanced/Fracturing_Search.problems.json
@@ -6,7 +6,7 @@
       "name": "Robotic Cow Herd",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=674",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -21,7 +21,7 @@
       "name": "2019 - Olympiads",
       "url": "https://qoj.ac/contest/2090/problem/11449",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/Game_Theory.problems.json
+++ b/content/6_Advanced/Game_Theory.problems.json
@@ -6,7 +6,7 @@
       "name": "Chessboard Game, Again!",
       "url": "https://www.hackerrank.com/contests/5-days-of-game-theory/challenges/a-chessboard-game/problem",
       "source": "Hackerrank",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game", "Nimbers"],
       "solutionMetadata": {
@@ -51,7 +51,7 @@
       "name": "Apple Tree",
       "url": "https://codeforces.com/contest/812/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game", "Nimbers", "Tree"],
       "solutionMetadata": {
@@ -64,7 +64,7 @@
       "name": "Game Of Stones",
       "url": "https://codeforces.com/problemset/problem/768/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "DP", "Game", "Nimbers"],
       "solutionMetadata": {
@@ -77,7 +77,7 @@
       "name": "Arpa & Game",
       "url": "https://codeforces.com/contest/850/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Bitmasks", "DP", "Game", "Nimbers"],
       "solutionMetadata": {
@@ -90,7 +90,7 @@
       "name": "2005 - Rectangle Game",
       "url": "https://ioi.contest.codeforces.com/group/32KGsXgiKA/contest/103747/problem/E",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game", "Nimbers"],
       "solutionMetadata": {
@@ -103,7 +103,7 @@
       "name": "2001 - Ioiwari Game",
       "url": "https://dmoj.ca/problem/ioi01p2",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game"],
       "solutionMetadata": {
@@ -116,7 +116,7 @@
       "name": "2014 - Cop and Robber",
       "url": "https://oj.uz/problem/view/BOI14_coprobber",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game", "Graphs"],
       "solutionMetadata": {
@@ -129,7 +129,7 @@
       "name": "Game on Tree",
       "url": "https://atcoder.jp/contests/agc017/tasks/agc017_d",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game", "Nimbers", "Tree"],
       "solutionMetadata": {
@@ -141,7 +141,7 @@
       "name": "Interval Game 2",
       "url": "https://atcoder.jp/contests/abc206/tasks/abc206_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game", "Nimbers"],
       "solutionMetadata": {
@@ -154,7 +154,7 @@
       "name": "Bacterial Tactics",
       "url": "https://zibada.guru/gcj/2019r1c/problems/#C",
       "source": "GCJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game", "Nimbers"],
       "solutionMetadata": {

--- a/content/6_Advanced/Interactive.problems.json
+++ b/content/6_Advanced/Interactive.problems.json
@@ -47,7 +47,7 @@
       "name": "2017 - The Big Prize",
       "url": "https://oj.uz/problem/view/IOI17_prize",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -60,7 +60,7 @@
       "name": "2016 - Messy Bug",
       "url": "https://oj.uz/problem/view/IOI16_messy",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": [],
       "solutionMetadata": {
@@ -73,7 +73,7 @@
       "name": "2022 - Magic Cards",
       "url": "https://qoj.ac/contest/1336/problem/6206",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -86,7 +86,7 @@
       "name": "2016 - Gap",
       "url": "https://oj.uz/problem/view/APIO16_gap",
       "source": "APIO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -247,7 +247,7 @@
       "name": "2014 - Question",
       "url": "https://oj.uz/problem/view/CEOI14_question_grader",
       "source": "CEOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -259,7 +259,7 @@
       "name": "2015 - Navigation",
       "url": "https://qoj.ac/problem/1212",
       "source": "JOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -271,7 +271,7 @@
       "name": "2010 - Saveit!",
       "url": "https://oj.uz/problem/view/IOI10_saveit",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -284,7 +284,7 @@
       "name": "2012 - Last Supper",
       "url": "https://oj.uz/problem/view/IOI12_supper",
       "source": "IOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -297,7 +297,7 @@
       "name": "2018 - Airline",
       "url": "https://oj.uz/problem/view/JOI18_airline",
       "source": "JOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/LCT.problems.json
+++ b/content/6_Advanced/LCT.problems.json
@@ -21,7 +21,7 @@
       "name": "Dynamic LCA",
       "url": "https://www.spoj.com/problems/DYNALCA",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCT"],
       "solutionMetadata": {
@@ -63,7 +63,7 @@
       "name": "Squirrel Cities",
       "url": "https://dmoj.ca/problem/wac4p7",
       "source": "Wesley's Anger Contest",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCT"],
       "solutionMetadata": {
@@ -76,7 +76,7 @@
       "name": "Balanced Tokens",
       "url": "https://www.hackerrank.com/contests/pwshpc-online-round/challenges/pwsh-tokens/problem",
       "source": "HR",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCT"],
       "solutionMetadata": {
@@ -89,7 +89,7 @@
       "name": "2011 - Treasure Hunt",
       "url": "https://qoj.ac/contest/2444/problem/14955",
       "source": "CEOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCT"],
       "solutionMetadata": {
@@ -182,7 +182,7 @@
       "name": "Vertex Add Subtree Sum",
       "url": "https://judge.yosupo.jp/problem/dynamic_tree_vertex_add_subtree_sum",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCT"],
       "solutionMetadata": {
@@ -197,7 +197,7 @@
       "name": "Pastoral Oddities",
       "url": "https://codeforces.com/contest/603/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["LCT"],
       "solutionMetadata": {

--- a/content/6_Advanced/Lagrange.problems.json
+++ b/content/6_Advanced/Lagrange.problems.json
@@ -33,7 +33,7 @@
       "name": "New Year & Handle Change",
       "url": "https://codeforces.com/contest/1279/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -46,7 +46,7 @@
       "name": "Teleporters",
       "url": "https://codeforces.com/problemset/problem/1661/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": [],
       "solutionMetadata": {
@@ -59,7 +59,7 @@
       "name": "Vacation",
       "url": "https://www.facebook.com/codingcompetitions/hacker-cup/2021/final-round/problems/D",
       "source": "FHC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -72,7 +72,7 @@
       "name": "Blazing New Trails",
       "url": "https://open.kattis.com/problems/blazingnewtrails",
       "source": "Kattis",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -84,7 +84,7 @@
       "name": "2019 - Tennis",
       "url": "http://81.4.170.42:8980/problems/training/Tennis",
       "source": "Balkan OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/LineContainer.problems.json
+++ b/content/6_Advanced/LineContainer.problems.json
@@ -6,7 +6,7 @@
       "name": "Line Add Get Min",
       "url": "https://judge.yosupo.jp/problem/line_add_get_min",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -20,7 +20,7 @@
       "name": "2017 - Building Bridges",
       "url": "https://oj.uz/problem/view/CEOI17_building",
       "source": "CEOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex", "DP"],
       "solutionMetadata": {
@@ -35,7 +35,7 @@
       "name": "Marshland Rescues",
       "url": "https://open.kattis.com/problems/marshlandrescues",
       "source": "Kattis",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -75,7 +75,7 @@
       "name": "Segment Add Get Min",
       "url": "https://judge.yosupo.jp/problem/segment_add_get_min",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -87,7 +87,7 @@
       "name": "2014 - Supercomputer",
       "url": "https://szkopul.edu.pl/problemset/problem/e9ycK_efBDBt4aPs-QeqYpwR/site/",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex", "DP"],
       "solutionMetadata": {

--- a/content/6_Advanced/Matroid.problems.json
+++ b/content/6_Advanced/Matroid.problems.json
@@ -6,7 +6,7 @@
       "name": "Serval and Kaitenzushi Buffet",
       "url": "https://codeforces.com/problemset/problem/2085/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Matroids"],
       "solutionMetadata": {

--- a/content/6_Advanced/MinCostFlow.problems.json
+++ b/content/6_Advanced/MinCostFlow.problems.json
@@ -6,7 +6,7 @@
       "name": "Build String",
       "url": "https://codeforces.com/contest/237/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Min Cost Flow"],
       "solutionMetadata": {
@@ -19,7 +19,7 @@
       "name": "Four Melodies",
       "url": "https://codeforces.com/contest/818/problem/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Min Cost Flow"],
       "solutionMetadata": {
@@ -32,7 +32,7 @@
       "name": "April Fools' Problem (medium)",
       "url": "https://codeforces.com/contest/802/problem/N",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/Min_Cut.problems.json
+++ b/content/6_Advanced/Min_Cut.problems.json
@@ -61,7 +61,7 @@
       "name": "Fashion",
       "url": "https://csacademy.com/contest/archive/task/fashion",
       "source": "CSA",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -74,7 +74,7 @@
       "name": "Card Game",
       "url": "https://codeforces.com/problemset/problem/808/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -87,7 +87,7 @@
       "name": "Bricks",
       "url": "https://codeforces.com/contest/1404/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/Offline_Del.problems.json
+++ b/content/6_Advanced/Offline_Del.problems.json
@@ -32,7 +32,7 @@
       "name": "Vertex Add Component Sum",
       "url": "https://judge.yosupo.jp/problem/dynamic_graph_vertex_add_component_sum",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Dynacon"],
       "solutionMetadata": {
@@ -59,7 +59,7 @@
       "name": "Envy",
       "url": "https://codeforces.com/contest/891/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DSUrb"],
       "solutionMetadata": {
@@ -71,7 +71,7 @@
       "name": "Disconnected Graph",
       "url": "https://codeforces.com/gym/100551/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["DSUrb"],
       "solutionMetadata": {
@@ -83,7 +83,7 @@
       "name": "Extending Set of Points",
       "url": "https://codeforces.com/contest/1140/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DSUrb"],
       "solutionMetadata": {

--- a/content/6_Advanced/Persistent.problems.json
+++ b/content/6_Advanced/Persistent.problems.json
@@ -46,7 +46,7 @@
       "name": "Gao on a tree",
       "url": "https://www.spoj.com/problems/GOT/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Persistent SegTree"],
       "solutionMetadata": {
@@ -58,7 +58,7 @@
       "name": "Query on a tree III",
       "url": "https://www.spoj.com/problems/PT07J/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Persistent SegTree"],
       "solutionMetadata": {
@@ -70,7 +70,7 @@
       "name": "K-th Number",
       "url": "https://www.spoj.com/problems/MKTHNUM/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Persistent SegTree"],
       "solutionMetadata": {
@@ -82,7 +82,7 @@
       "name": "2021 - Index",
       "url": "https://qoj.ac/problem/13424",
       "source": "COCI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Persistent SegTree"],
       "solutionMetadata": {
@@ -94,7 +94,7 @@
       "name": "2010 - Super Piano",
       "url": "https://dmoj.ca/problem/noi10p2",
       "source": "NOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Persistent SegTree"],
       "solutionMetadata": {

--- a/content/6_Advanced/PrefixSumsNT1.problems.json
+++ b/content/6_Advanced/PrefixSumsNT1.problems.json
@@ -36,7 +36,7 @@
       "name": "Dirichlet Convolution and Prefix Sums",
       "url": "https://judge.yosupo.jp/problem/dirichlet_convolution_and_prefix_sums",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -51,7 +51,7 @@
       "name": "Dirichlet Inverse and Prefix Sums",
       "url": "https://judge.yosupo.jp/problem/dirichlet_inverse_and_prefix_sums",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -66,7 +66,7 @@
       "name": "Sum of Totient Function",
       "url": "https://judge.yosupo.jp/problem/sum_of_totient_function",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -81,7 +81,7 @@
       "name": "Counting Primes",
       "url": "https://judge.yosupo.jp/problem/counting_primes",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -96,7 +96,7 @@
       "name": "Function",
       "url": "https://vjudge.net/problem/HDU-5608",
       "source": "HDU",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/PrefixSumsNT2.problems.json
+++ b/content/6_Advanced/PrefixSumsNT2.problems.json
@@ -6,7 +6,7 @@
       "name": "Counting Primes",
       "url": "https://judge.yosupo.jp/problem/counting_primes",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/SCC.problems.json
+++ b/content/6_Advanced/SCC.problems.json
@@ -44,7 +44,7 @@
       "name": "Ralph and Mushrooms",
       "url": "https://codeforces.com/problemset/problem/894/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "SCC"],
       "solutionMetadata": {
@@ -57,7 +57,7 @@
       "name": "Grass Cownoisseur",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=516",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SCC"],
       "solutionMetadata": {
@@ -70,7 +70,7 @@
       "name": "Catowice City",
       "url": "https://codeforces.com/contest/1239/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SCC"],
       "solutionMetadata": {
@@ -135,7 +135,7 @@
       "name": "Giant Pizza",
       "url": "https://cses.fi/problemset/task/1684",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -200,7 +200,7 @@
       "name": "Coprime Solitaire",
       "url": "https://atcoder.jp/contests/abc210/tasks/abc210_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["2SAT"],
       "solutionMetadata": {

--- a/content/6_Advanced/SPneg.problems.json
+++ b/content/6_Advanced/SPneg.problems.json
@@ -36,7 +36,7 @@
       "name": "Restore Array",
       "url": "https://oj.uz/problem/view/RMI19_restore",
       "source": "RMI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/Segtree_Beats.problems.json
+++ b/content/6_Advanced/Segtree_Beats.problems.json
@@ -61,7 +61,7 @@
       "name": "Bear and Bad Powers of 42",
       "url": "https://codeforces.com/contest/679/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SegTree Beats"],
       "solutionMetadata": {
@@ -74,7 +74,7 @@
       "name": "Box Operations",
       "url": "https://www.hackerrank.com/challenges/box-operations/problem",
       "source": "HR",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SegTree Beats"],
       "solutionMetadata": {
@@ -87,7 +87,7 @@
       "name": "Nagini",
       "url": "https://codeforces.com/contest/855/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SegTree Beats"],
       "solutionMetadata": {
@@ -100,7 +100,7 @@
       "name": "Little Pony and Lord Tirek",
       "url": "https://codeforces.com/problemset/problem/453/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SegTree Beats"],
       "solutionMetadata": {
@@ -113,7 +113,7 @@
       "name": "Julia and Snail",
       "url": "https://codeforces.com/problemset/problem/793/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["SegTree Beats"],
       "solutionMetadata": {

--- a/content/6_Advanced/Slope_Trick.problems.json
+++ b/content/6_Advanced/Slope_Trick.problems.json
@@ -35,7 +35,7 @@
       "name": "2019 - Potatoes & Fertilizers",
       "url": "https://oj.uz/problem/view/LMIO19_bulves",
       "source": "LMiO",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Slope Trick"],
       "solutionMetadata": {
@@ -65,7 +65,7 @@
       "name": "Bookface",
       "url": "https://codeforces.com/gym/102576/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Slope Trick"],
       "solutionMetadata": {
@@ -78,7 +78,7 @@
       "name": "CCDSAP Exam",
       "url": "https://www.codechef.com/problems/CCDSAP",
       "source": "CC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Slope Trick"],
       "solutionMetadata": {
@@ -91,7 +91,7 @@
       "name": "2019 - Magic Tree",
       "url": "https://qoj.ac/problem/946",
       "source": "CEOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Slope Trick"],
       "solutionMetadata": {

--- a/content/6_Advanced/String_Search.problems.json
+++ b/content/6_Advanced/String_Search.problems.json
@@ -31,7 +31,7 @@
       "name": "2019 - Necklace",
       "url": "https://oj.uz/problem/view/BOI19_necklace4",
       "source": "Baltic OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["KMP", "Strings"],
       "solutionMetadata": {
@@ -131,7 +131,7 @@
       "name": "Vasya and Big Integers",
       "url": "https://codeforces.com/contest/1051/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Strings"],
       "solutionMetadata": {
@@ -144,7 +144,7 @@
       "name": "Prefixes and Suffixes",
       "url": "https://codeforces.com/problemset/problem/432/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Z Algorithm"],
       "solutionMetadata": {
@@ -202,7 +202,7 @@
       "name": "Sonya and Matrix Beauty",
       "url": "https://codeforces.com/contest/1080/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Strings"],
       "solutionMetadata": {
@@ -215,7 +215,7 @@
       "name": "Prefix-Suffix Palindrome",
       "url": "https://codeforces.com/contest/1326/problem/D2",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Strings"],
       "solutionMetadata": {
@@ -281,7 +281,7 @@
       "name": "Xor-MST",
       "url": "https://codeforces.com/contest/888/problem/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["MST", "Trie"],
       "solutionMetadata": {
@@ -293,7 +293,7 @@
       "name": "Find and Replace",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1281",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Strings", "Trie"],
       "solutionMetadata": {
@@ -305,7 +305,7 @@
       "name": "Old Berland Language",
       "url": "https://codeforces.com/contest/37/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Strings", "Trie"],
       "solutionMetadata": {
@@ -318,7 +318,7 @@
       "name": "2020 - Klasika",
       "url": "https://oj.uz/problem/view/COCI20_klasika",
       "source": "COCI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Trie"],
       "solutionMetadata": {
@@ -331,7 +331,7 @@
       "name": "XOR Game",
       "url": "https://atcoder.jp/contests/arc122/tasks/arc122_d",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -344,7 +344,7 @@
       "name": "Short Code",
       "url": "https://codeforces.com/contest/965/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Small to Large", "Tree", "Trie"],
       "solutionMetadata": {
@@ -357,7 +357,7 @@
       "name": "Beautiful Subarrays",
       "url": "https://codeforces.com/problemset/problem/665/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Trie"],
       "solutionMetadata": {
@@ -422,7 +422,7 @@
       "name": "Censoring",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=533",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Strings"],
       "solutionMetadata": {
@@ -435,7 +435,7 @@
       "name": "You Are Given Some Strings...",
       "url": "https://codeforces.com/contest/1202/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Strings"],
       "solutionMetadata": {
@@ -505,7 +505,7 @@
       "name": "Finding Periods",
       "url": "https://cses.fi/problemset/task/1733",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": [],
       "solutionMetadata": {
@@ -520,7 +520,7 @@
       "name": "Finding Borders",
       "url": "https://cses.fi/problemset/task/1732/",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -532,7 +532,7 @@
       "name": "Minimal Rotation",
       "url": "https://cses.fi/problemset/task/1110/",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -544,7 +544,7 @@
       "name": "Maximum Xor Subarray",
       "url": "https://cses.fi/problemset/task/1655",
       "source": "CSES",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/String_Suffix.problems.json
+++ b/content/6_Advanced/String_Suffix.problems.json
@@ -85,7 +85,7 @@
       "name": "Power of String 3",
       "url": "https://www.hackerearth.com/practice/data-structures/advanced-data-structures/suffix-trees/practice-problems/algorithm/power-of-string-3/description/",
       "source": "HE",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Suffix Structures"],
       "solutionMetadata": {
@@ -97,7 +97,7 @@
       "name": "Cyclical Quest",
       "url": "https://codeforces.com/contest/235/problem/C",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Suffix Structures"],
       "solutionMetadata": {
@@ -110,7 +110,7 @@
       "name": "2015 - Clarkson",
       "url": "https://vjudge.net/problem/Baekjoon-11555",
       "source": "Balkan OI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Suffix Structures"],
       "solutionMetadata": {

--- a/content/6_Advanced/Treaps.problems.json
+++ b/content/6_Advanced/Treaps.problems.json
@@ -60,7 +60,7 @@
       "name": "2011 - Tree Rotations 2",
       "url": "https://szkopul.edu.pl/problemset/problem/b0BM0al2crQBt6zovEtJfOc6/site/?key=statement",
       "source": "POI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Treap"],
       "solutionMetadata": {
@@ -72,7 +72,7 @@
       "name": "Maintaining a Sequence",
       "url": "https://dmoj.ca/problem/noi05p2",
       "source": "NOI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Treap"],
       "solutionMetadata": {
@@ -84,7 +84,7 @@
       "name": "Airplane Boarding",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=402",
       "source": "Old Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Treap"],
       "solutionMetadata": {
@@ -97,7 +97,7 @@
       "name": "Strings",
       "url": "https://csacademy.com/contest/archive/task/strings/",
       "source": "CSA",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Treap"],
       "solutionMetadata": {
@@ -110,7 +110,7 @@
       "name": "Points and Distances",
       "url": "https://www.hackerearth.com/problem/algorithm/septembereasy-points-and-distances-d30d0e6b",
       "source": "HE",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Treap"],
       "solutionMetadata": {

--- a/content/6_Advanced/Wavelet.problems.json
+++ b/content/6_Advanced/Wavelet.problems.json
@@ -6,7 +6,7 @@
       "name": "Range K-th Smallest",
       "url": "https://judge.yosupo.jp/problem/range_kth_smallest",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Wavelet"],
       "solutionMetadata": {
@@ -21,7 +21,7 @@
       "name": "K-query",
       "url": "https://www.spoj.com/problems/KQUERY/",
       "source": "SPOJ",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Wavelet"],
       "solutionMetadata": {
@@ -33,7 +33,7 @@
       "name": "2021 - Index",
       "url": "https://qoj.ac/problem/13424",
       "source": "COCI",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Wavelet"],
       "solutionMetadata": {
@@ -45,7 +45,7 @@
       "name": "Smaller Sum",
       "url": "https://atcoder.jp/contests/abc339/tasks/abc339_g",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Wavelet"],
       "solutionMetadata": {
@@ -57,7 +57,7 @@
       "name": "Rectangle Sum",
       "url": "https://judge.yosupo.jp/problem/rectangle_sum",
       "source": "YS",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Wavelet"],
       "solutionMetadata": {

--- a/content/6_Advanced/XOR_Basis.problems.json
+++ b/content/6_Advanced/XOR_Basis.problems.json
@@ -6,7 +6,7 @@
       "name": "Trees and XOR Queries Again",
       "url": "https://codeforces.com/contest/1902/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -21,7 +21,7 @@
       "name": "Xor Closure",
       "url": "https://csacademy.com/contest/archive/task/xor-closure/statement/",
       "source": "CSA",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -36,7 +36,7 @@
       "name": "XOR Battle",
       "url": "https://atcoder.jp/contests/agc045/tasks/agc045_a",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -49,7 +49,7 @@
       "name": "Xor Sum 3",
       "url": "https://atcoder.jp/contests/abc141/tasks/abc141_f",
       "source": "AC",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -62,7 +62,7 @@
       "name": "Xum",
       "url": "https://codeforces.com/problemset/problem/1427/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -75,7 +75,7 @@
       "name": "The Tree Has Fallen!",
       "url": "https://codeforces.com/contest/1778/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -88,7 +88,7 @@
       "name": "Ivan and Burgers",
       "url": "https://codeforces.com/contest/1100/problem/F",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -101,7 +101,7 @@
       "name": "(Zero XOR Subset)-less",
       "url": "https://codeforces.com/contest/1101/problem/G",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/6_Advanced/random.problems.json
+++ b/content/6_Advanced/random.problems.json
@@ -6,7 +6,7 @@
       "name": "Ghd",
       "url": "https://codeforces.com/contest/364/problem/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": true,
       "tags": ["Random"],
       "solutionMetadata": {
@@ -48,7 +48,7 @@
       "name": "Destiny",
       "url": "https://codeforces.com/problemset/problem/840/D",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Random"],
       "solutionMetadata": {
@@ -61,7 +61,7 @@
       "name": "DZY Loves FFT",
       "url": "https://codeforces.com/problemset/problem/444/B",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Random"],
       "solutionMetadata": {
@@ -74,7 +74,7 @@
       "name": "Gena and Second Distance",
       "url": "https://codeforces.com/contest/442/problem/E",
       "source": "CF",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Random"],
       "solutionMetadata": {

--- a/content/extraProblems.json
+++ b/content/extraProblems.json
@@ -18,7 +18,7 @@
       "name": "Why Did the Cow Cross the Road",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=711",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation"],
       "solutionMetadata": {
@@ -30,7 +30,7 @@
       "name": "Greedy Gift Takers",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=770",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search"],
       "solutionMetadata": {
@@ -43,7 +43,7 @@
       "name": "Lifeguards",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=792",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -82,7 +82,7 @@
       "name": "Redistricting",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=900",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Deque"],
       "solutionMetadata": {
@@ -95,7 +95,7 @@
       "name": "Photoshoot",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=988",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation"],
       "solutionMetadata": {
@@ -107,7 +107,7 @@
       "name": "Cave Paintings",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=996",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "DSU", "Graphs"],
       "solutionMetadata": {
@@ -120,7 +120,7 @@
       "name": "The Moo Particle",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1040",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Connected Components", "Prefix Sums"],
       "solutionMetadata": {
@@ -146,7 +146,7 @@
       "name": "Sprinklers 2: Return of the Alfalfa",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1044",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Prefix Sums"],
       "solutionMetadata": {
@@ -184,7 +184,7 @@
       "name": "Sleeping Cows",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1068",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP"],
       "solutionMetadata": {
@@ -209,7 +209,7 @@
       "name": "Sum of Distances",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1092",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS", "PIE"],
       "solutionMetadata": {
@@ -222,7 +222,7 @@
       "name": "Minimum Cost Paths",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1093",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Convex"],
       "solutionMetadata": {
@@ -235,7 +235,7 @@
       "name": "No Time To Paint",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1087",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -248,7 +248,7 @@
       "name": "Comfortable Cows",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1108",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation"],
       "solutionMetadata": {
@@ -260,7 +260,7 @@
       "name": "Clockwise Fence",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1109",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Geometry"],
       "solutionMetadata": {
@@ -272,7 +272,7 @@
       "name": "Year of the Cow",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1111",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
@@ -284,7 +284,7 @@
       "name": "Stone Game",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1113",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Game", "Prefix Sums"],
       "solutionMetadata": {
@@ -297,7 +297,7 @@
       "name": "No Time to Dry",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1116",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["1DRQ"],
       "solutionMetadata": {
@@ -310,7 +310,7 @@
       "name": "Minimizing Edges",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1117",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS", "Greedy"],
       "solutionMetadata": {
@@ -323,7 +323,7 @@
       "name": "Counting Graphs",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1118",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["BFS", "Combinatorics", "PIE"],
       "solutionMetadata": {
@@ -336,7 +336,7 @@
       "name": "Dance Mooves",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1086",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Connected Components", "Graphs"],
       "solutionMetadata": {
@@ -348,7 +348,7 @@
       "name": "Swapity Swapity Swap",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1014",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Simulation"],
       "solutionMetadata": {
@@ -360,7 +360,7 @@
       "name": "Acowdemia III",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1133",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy"],
       "solutionMetadata": {
@@ -373,7 +373,7 @@
       "name": "Do You Know Your ABCs?",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1135",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Set"],
       "solutionMetadata": {
@@ -385,7 +385,7 @@
       "name": "Acowdemia",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1136",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search", "Sorting"],
       "solutionMetadata": {
@@ -398,7 +398,7 @@
       "name": "UCFJ",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1137",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["1DRQ"],
       "solutionMetadata": {
@@ -410,7 +410,7 @@
       "name": "Permutation",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1139",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Geometry"],
       "solutionMetadata": {
@@ -423,7 +423,7 @@
       "name": "UCFJ",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1140",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["1DRQ"],
       "solutionMetadata": {
@@ -436,7 +436,7 @@
       "name": "Routing",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1141",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Determinant"],
       "solutionMetadata": {
@@ -449,7 +449,7 @@
       "name": "Balanced Subsets",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1142",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["DP", "Prefix Sums"],
       "solutionMetadata": {
@@ -462,7 +462,7 @@
       "name": "Lonely Photo",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1155",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search"],
       "solutionMetadata": {
@@ -488,7 +488,7 @@
       "name": "Walking Home",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1157",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search"],
       "solutionMetadata": {
@@ -564,7 +564,7 @@
       "name": "HILO",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1166",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Combinatorics", "DP"],
       "solutionMetadata": {
@@ -589,7 +589,7 @@
       "name": "Non-Transitive Dice",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1180",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search"],
       "solutionMetadata": {
@@ -601,7 +601,7 @@
       "name": "Cow Frisbee",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1183",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Linked List", "Sorted Set", "Stack"],
       "solutionMetadata": {
@@ -613,7 +613,7 @@
       "name": "Farm Updates",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1186",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Connected Components"],
       "solutionMetadata": {
@@ -727,7 +727,7 @@
       "name": "Subset Equality",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1231",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -740,7 +740,7 @@
       "name": "COW Operations",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1232",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Prefix Sums"],
       "solutionMetadata": {
@@ -752,7 +752,7 @@
       "name": "Balancing a Tree",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1235",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Tree"],
       "solutionMetadata": {
@@ -765,7 +765,7 @@
       "name": "Feeding the Cows",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1252",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy"],
       "solutionMetadata": {
@@ -778,7 +778,7 @@
       "name": "Reverse Engineering",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1253",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Constructive"],
       "solutionMetadata": {
@@ -791,7 +791,7 @@
       "name": "Barn Tree",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1254",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Tree"],
       "solutionMetadata": {
@@ -803,7 +803,7 @@
       "name": "Range Reconstruction",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1256",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Constructive"],
       "solutionMetadata": {
@@ -816,7 +816,7 @@
       "name": "Mountains",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1258",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Amortized Analysis", "Sorted Set"],
       "solutionMetadata": {
@@ -829,7 +829,7 @@
       "name": "Breakdown",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1260",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Shortest Path"],
       "solutionMetadata": {
@@ -842,7 +842,7 @@
       "name": "Making Friends",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1261",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Small to Large"],
       "solutionMetadata": {
@@ -855,7 +855,7 @@
       "name": "Palindromes",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1262",
       "source": "Platinum",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -868,7 +868,7 @@
       "name": "Dance Mooves",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1091",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Set"],
       "solutionMetadata": {
@@ -880,7 +880,7 @@
       "name": "Hoof, Paper, Scissors",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=688",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Complete Search", "Simulation"],
       "solutionMetadata": {
@@ -964,7 +964,7 @@
       "name": "Acowdemia I",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1131",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Binary Search"],
       "solutionMetadata": {
@@ -1816,7 +1816,7 @@
       "name": "Maximizing Productivity",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1397",
       "source": "Bronze",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -2255,7 +2255,7 @@
       "name": "The Best Lineup",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1494",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Greedy", "Stack"],
       "solutionMetadata": {
@@ -2280,7 +2280,7 @@
       "name": "Transforming Pairs",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1496",
       "source": "Silver",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -2447,7 +2447,7 @@
       "name": "COW Traversals",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1545",
       "source": "Gold",
-      "difficulty": "Normal",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Connected Components"],
       "solutionMetadata": {

--- a/public/problems.schema.json
+++ b/public/problems.schema.json
@@ -72,7 +72,7 @@
         "difficulty": {
           "description": "The difficulty of a problem, _relative to the module it is in_.",
           "type": "string",
-          "enum": ["Very Easy", "Easy", "Normal", "Hard", "Very Hard", "Insane"]
+          "enum": ["Very Easy", "Easy", "Medium", "Hard", "Very Hard", "Insane"]
         },
         "isStarred": {
           "description": "Whether or not the problem should be starred in the module problem table.",

--- a/src/components/Dashboard/ActiveItems.tsx
+++ b/src/components/Dashboard/ActiveItems.tsx
@@ -17,7 +17,7 @@ export type ActiveItem = {
 };
 
 const statusClasses: { [key in ActiveItemStatus]: string } = {
-  Skipped: difficultyClasses.Normal,
+  Skipped: difficultyClasses.Medium,
   Ignored: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-100',
   Reading:
     'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100',

--- a/src/components/DifficultyBox.tsx
+++ b/src/components/DifficultyBox.tsx
@@ -5,7 +5,7 @@ export const difficultyClasses = {
   'N/A': 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100',
   'Very Easy': 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100',
   Easy: 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100',
-  Normal: 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100',
+  Medium: 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100',
   Hard: 'bg-purple-100 text-purple-800 dark:bg-purple-800 dark:text-purple-100',
   'Very Hard':
     'bg-orange-100 text-orange-800 dark:bg-orange-800 dark:text-orange-100',

--- a/src/components/Index/features/ProblemsetsFeature.tsx
+++ b/src/components/Index/features/ProblemsetsFeature.tsx
@@ -99,7 +99,7 @@ export const ProblemsetsFeature = (): JSX.Element => {
                     <TableRow
                       source="USACO Gold"
                       title="Mootube"
-                      difficulty="Normal"
+                      difficulty="Medium"
                       starred
                     />
                     <TableRow

--- a/src/components/ProblemsPage/ProblemHits.tsx
+++ b/src/components/ProblemsPage/ProblemHits.tsx
@@ -33,7 +33,7 @@ interface ProblemHitProps {
 const difficultySortOrder = {
   'Very Easy': 1,
   Easy: 2,
-  Normal: 3,
+  Medium: 3,
   Hard: 4,
   'Very Hard': 5,
   Insane: 6,

--- a/src/hooks/groups/usePostActions.ts
+++ b/src/hooks/groups/usePostActions.ts
@@ -104,7 +104,7 @@ export function usePostActions(groupId: string) {
         body: '',
         source: '',
         points: 100,
-        difficulty: 'Normal',
+        difficulty: 'Medium',
         hints: [],
         solution: null,
         isDeleted: false,

--- a/src/models/problem.ts
+++ b/src/models/problem.ts
@@ -545,14 +545,14 @@ export type ProblemDifficulty =
   | 'N/A'
   | 'Very Easy'
   | 'Easy'
-  | 'Normal'
+  | 'Medium'
   | 'Hard'
   | 'Very Hard'
   | 'Insane';
 export const PROBLEM_DIFFICULTY_OPTIONS: ProblemDifficulty[] = [
   'Very Easy',
   'Easy',
-  'Normal',
+  'Medium',
   'Hard',
   'Very Hard',
   'Insane',


### PR DESCRIPTION
Renames the `Normal` problem difficulty to `Medium` everywhere.

## Changes

- `src/models/problem.ts` — `ProblemDifficulty` union and `PROBLEM_DIFFICULTY_OPTIONS`
- `public/problems.schema.json` — the `difficulty` enum
- 635 `"difficulty": "Normal"` entries across `content/**/*.problems.json` and `content/extraProblems.json`
- UI: `DifficultyBox` badge classes, `ProblemHits` sort order, `ActiveItems` status class, `ProblemsetsFeature` sample row, `usePostActions` default for new group problems
- Docs: `content/1_General/Modules.mdx` and `content/1_General/Working_MDX.mdx`

Ordering is preserved everywhere (`Medium` stays between `Easy` and `Hard`), including the key order of `difficultyClasses`, which `src/pages/problems/index.tsx` relies on for difficulty sorting.

## Notes

- `yarn check-ts-errors` and `prettier --check` pass on the changed files.
- Every `DifficultyBox` / `difficultyClasses` consumer is fed by build-time content or the Algolia index (rebuilt on deploy), so no user-facing badge reads a persisted `"Normal"` string.
- Firestore data written before this change (group problems, problem-difficulty suggestions) still holds `"Normal"`. Group problems render difficulty as plain text so they're unaffected; `submitProblemSuggestion` sorts by `PROBLEM_DIFFICULTY_OPTIONS.indexOf`, which will return `-1` for a pre-existing `"Normal"` suggestion, placing it first in its module. Worth a one-off data migration if that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld15PL5jeYxRrY5zLnErXK