### PR TITLE
Fix callable handlers reading v2 request shape under the v1 API

### DIFF
--- a/src/functions/src/getUsers.ts
+++ b/src/functions/src/getUsers.ts
@@ -5,11 +5,11 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-export default functions.https.onCall(async request => {
-  const { users } = request.data as {
+export default functions.https.onCall(async (data, context) => {
+  const { users } = data as {
     users: ({ uid: string } | { email: string })[];
   };
-  const callerUid = request.auth?.uid;
+  const callerUid = context.auth?.uid;
   const caller = await admin.auth().getUser(callerUid);
 
   if (!callerUid || !users || users.length === 0) {

--- a/src/functions/src/groups/getJoinKeyInfo.ts
+++ b/src/functions/src/groups/getJoinKeyInfo.ts
@@ -9,8 +9,8 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-export default functions.https.onCall(async request => {
-  const { key } = request.data as submitToProblemArgs;
+export default functions.https.onCall(async data => {
+  const { key } = data as submitToProblemArgs;
   let keyData;
   try {
     keyData = await getJoinKeyData(key);

--- a/src/functions/src/groups/getMembers.ts
+++ b/src/functions/src/groups/getMembers.ts
@@ -6,11 +6,11 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-export default functions.https.onCall(async request => {
-  const { groupId } = request.data as {
+export default functions.https.onCall(async (data, context) => {
+  const { groupId } = data as {
     groupId: string;
   };
-  const callerUid = request.auth?.uid;
+  const callerUid = context.auth?.uid;
 
   if (!callerUid || !groupId) {
     throw new functions.https.HttpsError(

--- a/src/functions/src/groups/join.ts
+++ b/src/functions/src/groups/join.ts
@@ -9,9 +9,9 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-export default functions.https.onCall(async request => {
-  const { key } = request.data as submitToProblemArgs;
-  const callerUid = request.auth?.uid;
+export default functions.https.onCall(async (data, context) => {
+  const { key } = data as submitToProblemArgs;
+  const callerUid = context.auth?.uid;
 
   let keyData;
   try {
@@ -49,7 +49,7 @@ export default functions.https.onCall(async request => {
     };
   }
   if (keyData.allowedEmails != null) {
-    const callerEmail = request.auth?.token.email?.toLowerCase();
+    const callerEmail = context.auth?.token.email?.toLowerCase();
     const allowedEmails = keyData.allowedEmails.map(email =>
       email.trim().toLowerCase()
     );

--- a/src/functions/src/groups/leave.ts
+++ b/src/functions/src/groups/leave.ts
@@ -12,9 +12,9 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-export default functions.https.onCall(async request => {
-  const { groupId } = request.data as LeaveGroupArgs;
-  const callerUid = request.auth?.uid;
+export default functions.https.onCall(async (data, context) => {
+  const { groupId } = data as LeaveGroupArgs;
+  const callerUid = context.auth?.uid;
   const groupDataSnapshot = await admin
     .firestore()
     .collection('groups')

--- a/src/functions/src/groups/removeMember.ts
+++ b/src/functions/src/groups/removeMember.ts
@@ -12,9 +12,9 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-export default functions.https.onCall(async request => {
-  const { groupId, targetUid } = request.data as RemoveFromGroupArgs;
-  const callerUid = request.auth?.uid;
+export default functions.https.onCall(async (data, context) => {
+  const { groupId, targetUid } = data as RemoveFromGroupArgs;
+  const callerUid = context.auth?.uid;
 
   if (targetUid === callerUid) {
     return {

--- a/src/functions/src/groups/updateMemberPermissions.ts
+++ b/src/functions/src/groups/updateMemberPermissions.ts
@@ -13,10 +13,10 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-export default functions.https.onCall(async request => {
+export default functions.https.onCall(async (data, context) => {
   const { groupId, targetUid, newPermissionLevel } =
-    request.data as UpdateMemberPermissionsArgs;
-  const callerUid = request.auth?.uid;
+    data as UpdateMemberPermissionsArgs;
+  const callerUid = context.auth?.uid;
 
   if (targetUid === callerUid) {
     return {

--- a/src/functions/src/setUserClaims.ts
+++ b/src/functions/src/setUserClaims.ts
@@ -5,14 +5,14 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-export default functions.https.onCall(async request => {
-  const { target, claims, merge } = request.data as {
+export default functions.https.onCall(async (data, context) => {
+  const { target, claims, merge } = data as {
     target: string;
     // default true
     merge?: boolean;
     claims: Record<string, any>;
   };
-  const callerUid = request.auth?.uid;
+  const callerUid = context.auth?.uid;
 
   const caller = await admin.auth().getUser(callerUid);
   if (

--- a/src/functions/src/submitContactForm.ts
+++ b/src/functions/src/submitContactForm.ts
@@ -7,16 +7,15 @@ if (admin.apps.length === 0) {
 }
 
 const submitContactForm = functions.https.onCall(async data => {
-  const { name, email, moduleName, url, lang, topic, message } =
-    data as {
-      name: string;
-      email: string;
-      moduleName?: string;
-      url?: string;
-      lang?: string;
-      topic: string;
-      message: string;
-    };
+  const { name, email, moduleName, url, lang, topic, message } = data as {
+    name: string;
+    email: string;
+    moduleName?: string;
+    url?: string;
+    lang?: string;
+    topic: string;
+    message: string;
+  };
   if (!name || !topic || !message || !email) {
     throw new functions.https.HttpsError(
       'invalid-argument',

--- a/src/functions/src/submitContactForm.ts
+++ b/src/functions/src/submitContactForm.ts
@@ -6,9 +6,9 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-const submitContactForm = functions.https.onCall(async request => {
+const submitContactForm = functions.https.onCall(async data => {
   const { name, email, moduleName, url, lang, topic, message } =
-    request.data as {
+    data as {
       name: string;
       email: string;
       moduleName?: string;

--- a/src/functions/src/submitProblemSuggestion.ts
+++ b/src/functions/src/submitProblemSuggestion.ts
@@ -23,8 +23,8 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-const submitProblemSuggestion = functions.https.onCall(async request => {
-  if (!request.auth?.uid) {
+const submitProblemSuggestion = functions.https.onCall(async (data, context) => {
+  if (!context.auth?.uid) {
     throw new functions.https.HttpsError(
       'permission-denied',
       'You must be logged in to suggest a problem!'
@@ -32,7 +32,7 @@ const submitProblemSuggestion = functions.https.onCall(async request => {
   }
   const submitterName = await admin
     .auth()
-    .getUser(request.auth.uid)
+    .getUser(context.auth.uid)
     .then(userRecord => userRecord.displayName);
 
   const {
@@ -47,7 +47,7 @@ const submitProblemSuggestion = functions.https.onCall(async request => {
     problemListName,
     source,
     filePath,
-  } = request.data as {
+  } = data as {
     name: string;
     moduleName: string;
     link: string;
@@ -100,7 +100,7 @@ const submitProblemSuggestion = functions.https.onCall(async request => {
   };
 
   const body =
-    `User \`${request.auth?.uid}\` suggested adding the problem [${name}](${link}) ` +
+    `User \`${context.auth?.uid}\` suggested adding the problem [${name}](${link}) ` +
     `to the \`${problemListName}\` table of the module [${moduleName}](${problemTableLink}).\n\n` +
     `**Automatically Generated JSON:**\n` +
     '```json\n' +

--- a/src/functions/src/submitProblemSuggestion.ts
+++ b/src/functions/src/submitProblemSuggestion.ts
@@ -23,251 +23,256 @@ if (admin.apps.length === 0) {
   admin.initializeApp();
 }
 
-const submitProblemSuggestion = functions.https.onCall(async (data, context) => {
-  if (!context.auth?.uid) {
-    throw new functions.https.HttpsError(
-      'permission-denied',
-      'You must be logged in to suggest a problem!'
-    );
-  }
-  const submitterName = await admin
-    .auth()
-    .getUser(context.auth.uid)
-    .then(userRecord => userRecord.displayName);
-
-  const {
-    name,
-    moduleName,
-    link,
-    difficulty,
-    tags,
-    additionalNotes,
-    problemTableLink,
-    section,
-    problemListName,
-    source,
-    filePath,
-  } = data as {
-    name: string;
-    moduleName: string;
-    link: string;
-    difficulty: string;
-    tags: string;
-    additionalNotes?: string;
-    problemTableLink: string;
-    section: string;
-    problemListName: string;
-    source: string;
-    filePath: string;
-  };
-  if (
-    !name ||
-    !moduleName ||
-    !link ||
-    !problemTableLink ||
-    !section ||
-    !filePath
-  ) {
-    throw new functions.https.HttpsError(
-      'invalid-argument',
-      'One or more required arguments were not passed.'
-    );
-  }
-
-  // TODO: increase validation?
-  if (filePath.indexOf('..') > -1) {
-    throw new functions.https.HttpsError(
-      'invalid-argument',
-      'The filePath argument contained an unexpected value.'
-    );
-  }
-  const tagsArr = tags
-    .split(',')
-    .map(tag => tag.trim())
-    .filter(tag => tag.length > 0);
-  const generatedProblemId = generateProblemUniqueId(source, name, link);
-  const suggestedProblem: ProblemMetadata = {
-    uniqueId: generatedProblemId,
-    name,
-    url: link,
-    source,
-    difficulty: difficulty as ProblemDifficulty,
-    isStarred: false,
-    tags: tagsArr,
-    solutionMetadata: autoGenerateSolutionMetadata(source, name, link) || {
-      kind: 'none',
-    },
-  };
-
-  const body =
-    `User \`${context.auth?.uid}\` suggested adding the problem [${name}](${link}) ` +
-    `to the \`${problemListName}\` table of the module [${moduleName}](${problemTableLink}).\n\n` +
-    `**Automatically Generated JSON:**\n` +
-    '```json\n' +
-    JSON.stringify(suggestedProblem, null, 2) +
-    '\n```\n' +
-    `**Additional Notes**:${
-      additionalNotes ? '\n' + additionalNotes : ' None'
-    }\n\n` +
-    (source === 'other'
-      ? `**Warning: The source of this problem is currently set to \`other\`. You must correct the problem source and the solution before merging.**\n`
-      : '') +
-    `*This PR was automatically generated from a user-submitted problem suggestion on the USACO guide.*`;
-  const key = functions.config().problemsuggestion.issueapikey;
-  const githubAPI = axios.create({
-    baseURL: 'https://api.github.com',
-    auth: {
-      username: 'maggieliu05',
-      password: key,
-    },
-  });
-
-  const masterRefsReq = await githubAPI.get(
-    '/repos/cpinitiative/usaco-guide/git/refs/heads'
-  );
-  const masterRef = masterRefsReq.data.find(r => r.ref == 'refs/heads/master');
-  const masterHash = masterRef.object.sha;
-
-  const branchNameBase = 'problem-suggestion/' + generatedProblemId;
-  let increment = 0;
-  let foundEmptyBranch = false;
-  for (increment; increment < 5; increment++) {
-    try {
-      await githubAPI.get(
-        `/repos/cpinitiative/usaco-guide/branches/${
-          branchNameBase + (increment === 0 ? '' : '-' + increment)
-        }`
+const submitProblemSuggestion = functions.https.onCall(
+  async (data, context) => {
+    if (!context.auth?.uid) {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        'You must be logged in to suggest a problem!'
       );
-    } catch (error: any) {
-      if (error.response && error.response.status === 404) {
-        foundEmptyBranch = true;
-        break;
-      }
     }
-  }
-  if (!foundEmptyBranch) {
-    throw new functions.https.HttpsError(
-      'already-exists',
-      'More than five suggestions with the same generated problem ID already exist.'
-    );
-  }
-  const branchName = branchNameBase + (increment === 0 ? '' : '-' + increment);
-  await githubAPI.post('/repos/cpinitiative/usaco-guide/git/refs', {
-    ref: 'refs/heads/' + branchName,
-    sha: masterHash,
-  });
+    const submitterName = await admin
+      .auth()
+      .getUser(context.auth.uid)
+      .then(userRecord => userRecord.displayName);
 
-  const oldFileDataReq = await githubAPI.get(
-    `/repos/cpinitiative/usaco-guide/contents/content/${filePath.replace(
-      /\.mdx$/,
-      '.problems.json'
-    )}?ref=${branchName}`
-  );
-  const oldFileHash = oldFileDataReq.data.sha;
-  const oldFileData = Buffer.from(
-    oldFileDataReq.data.content,
-    'base64'
-  ).toString();
-
-  const parsedOldFileData = JSON.parse(oldFileData);
-  const tableToEdit = parsedOldFileData[problemListName];
-
-  // sort the table such that the suggested problem is inserted below the bottommost
-  // problem with the same difficulty as the suggested problem.
-  parsedOldFileData[problemListName] = (
-    [
-      ...tableToEdit.map((el, i) => ({ index: i, data: el })),
-      { index: tableToEdit.length, data: suggestedProblem },
-    ] as { index: number; data: ProblemMetadata }[]
-  )
-    .sort((a, b) => {
-      const difficultyDiff =
-        PROBLEM_DIFFICULTY_OPTIONS.indexOf(a.data.difficulty) -
-        PROBLEM_DIFFICULTY_OPTIONS.indexOf(b.data.difficulty);
-      return difficultyDiff !== 0 ? difficultyDiff : a.index - b.index;
-    })
-    .map(prob => prob.data);
-
-  // Use pretty JSON.stringify because it inserts a newline before all objects, which forces prettier to then convert
-  // these objects into multiline ones.
-  const newContent = JSON.stringify(parsedOldFileData, null, 2) + '\n';
-  const formattedNewContent = await prettier.format(newContent, {
-    endOfLine: 'lf',
-    semi: true,
-    singleQuote: true,
-    tabWidth: 2,
-    useTabs: false,
-    trailingComma: 'es5',
-    arrowParens: 'avoid',
-    parser: 'json',
-  });
-
-  await githubAPI.put(
-    `/repos/cpinitiative/usaco-guide/contents/content/${filePath.replace(
-      /\.mdx$/,
-      '.problems.json'
-    )}`,
-    {
-      content: Buffer.from(formattedNewContent).toString('base64'),
-      message: `Feat: add suggested problem '${name}'`,
-      branch: branchName,
-      sha: oldFileHash,
-    }
-  );
-
-  const createdPullRequestReq = await githubAPI.post(
-    '/repos/cpinitiative/usaco-guide/pulls',
-    {
-      head: branchName,
-      base: 'master',
-      maintainer_can_modify: true,
-      title: `Problem Suggestion: Add "${name}" to ${moduleName}`,
-      body: body,
-    }
-  );
-
-  const useProblemSuggestionReviewers = false;
-  if (useProblemSuggestionReviewers) {
-    const reviewersReq = await githubAPI.get(
-      `/repos/cpinitiative/usaco-guide/pulls/${createdPullRequestReq.data.number}/requested_reviewers`
-    );
-    const reviewersToRemove = reviewersReq.data.users
-      .map(user => user.login)
-      .filter(user => !problemSuggestionReviewers[section].includes(user));
-    const keptReviewers = reviewersReq.data.users
-      .map(user => user.login)
-      .filter(user => problemSuggestionReviewers[section].includes(user));
-    await githubAPI.delete(
-      `/repos/cpinitiative/usaco-guide/pulls/${createdPullRequestReq.data.number}/requested_reviewers`,
-      {
-        data: {
-          reviewers: reviewersToRemove,
-          team_reviewers: reviewersReq.data.teams.map(team => team.slug),
-        },
-      }
-    );
+    const {
+      name,
+      moduleName,
+      link,
+      difficulty,
+      tags,
+      additionalNotes,
+      problemTableLink,
+      section,
+      problemListName,
+      source,
+      filePath,
+    } = data as {
+      name: string;
+      moduleName: string;
+      link: string;
+      difficulty: string;
+      tags: string;
+      additionalNotes?: string;
+      problemTableLink: string;
+      section: string;
+      problemListName: string;
+      source: string;
+      filePath: string;
+    };
     if (
-      problemSuggestionReviewers[section].filter(
-        u => !keptReviewers.includes(u)
-      ).length > 0
+      !name ||
+      !moduleName ||
+      !link ||
+      !problemTableLink ||
+      !section ||
+      !filePath
     ) {
-      await githubAPI.post(
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'One or more required arguments were not passed.'
+      );
+    }
+
+    // TODO: increase validation?
+    if (filePath.indexOf('..') > -1) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'The filePath argument contained an unexpected value.'
+      );
+    }
+    const tagsArr = tags
+      .split(',')
+      .map(tag => tag.trim())
+      .filter(tag => tag.length > 0);
+    const generatedProblemId = generateProblemUniqueId(source, name, link);
+    const suggestedProblem: ProblemMetadata = {
+      uniqueId: generatedProblemId,
+      name,
+      url: link,
+      source,
+      difficulty: difficulty as ProblemDifficulty,
+      isStarred: false,
+      tags: tagsArr,
+      solutionMetadata: autoGenerateSolutionMetadata(source, name, link) || {
+        kind: 'none',
+      },
+    };
+
+    const body =
+      `User \`${context.auth?.uid}\` suggested adding the problem [${name}](${link}) ` +
+      `to the \`${problemListName}\` table of the module [${moduleName}](${problemTableLink}).\n\n` +
+      `**Automatically Generated JSON:**\n` +
+      '```json\n' +
+      JSON.stringify(suggestedProblem, null, 2) +
+      '\n```\n' +
+      `**Additional Notes**:${
+        additionalNotes ? '\n' + additionalNotes : ' None'
+      }\n\n` +
+      (source === 'other'
+        ? `**Warning: The source of this problem is currently set to \`other\`. You must correct the problem source and the solution before merging.**\n`
+        : '') +
+      `*This PR was automatically generated from a user-submitted problem suggestion on the USACO guide.*`;
+    const key = functions.config().problemsuggestion.issueapikey;
+    const githubAPI = axios.create({
+      baseURL: 'https://api.github.com',
+      auth: {
+        username: 'maggieliu05',
+        password: key,
+      },
+    });
+
+    const masterRefsReq = await githubAPI.get(
+      '/repos/cpinitiative/usaco-guide/git/refs/heads'
+    );
+    const masterRef = masterRefsReq.data.find(
+      r => r.ref == 'refs/heads/master'
+    );
+    const masterHash = masterRef.object.sha;
+
+    const branchNameBase = 'problem-suggestion/' + generatedProblemId;
+    let increment = 0;
+    let foundEmptyBranch = false;
+    for (increment; increment < 5; increment++) {
+      try {
+        await githubAPI.get(
+          `/repos/cpinitiative/usaco-guide/branches/${
+            branchNameBase + (increment === 0 ? '' : '-' + increment)
+          }`
+        );
+      } catch (error: any) {
+        if (error.response && error.response.status === 404) {
+          foundEmptyBranch = true;
+          break;
+        }
+      }
+    }
+    if (!foundEmptyBranch) {
+      throw new functions.https.HttpsError(
+        'already-exists',
+        'More than five suggestions with the same generated problem ID already exist.'
+      );
+    }
+    const branchName =
+      branchNameBase + (increment === 0 ? '' : '-' + increment);
+    await githubAPI.post('/repos/cpinitiative/usaco-guide/git/refs', {
+      ref: 'refs/heads/' + branchName,
+      sha: masterHash,
+    });
+
+    const oldFileDataReq = await githubAPI.get(
+      `/repos/cpinitiative/usaco-guide/contents/content/${filePath.replace(
+        /\.mdx$/,
+        '.problems.json'
+      )}?ref=${branchName}`
+    );
+    const oldFileHash = oldFileDataReq.data.sha;
+    const oldFileData = Buffer.from(
+      oldFileDataReq.data.content,
+      'base64'
+    ).toString();
+
+    const parsedOldFileData = JSON.parse(oldFileData);
+    const tableToEdit = parsedOldFileData[problemListName];
+
+    // sort the table such that the suggested problem is inserted below the bottommost
+    // problem with the same difficulty as the suggested problem.
+    parsedOldFileData[problemListName] = (
+      [
+        ...tableToEdit.map((el, i) => ({ index: i, data: el })),
+        { index: tableToEdit.length, data: suggestedProblem },
+      ] as { index: number; data: ProblemMetadata }[]
+    )
+      .sort((a, b) => {
+        const difficultyDiff =
+          PROBLEM_DIFFICULTY_OPTIONS.indexOf(a.data.difficulty) -
+          PROBLEM_DIFFICULTY_OPTIONS.indexOf(b.data.difficulty);
+        return difficultyDiff !== 0 ? difficultyDiff : a.index - b.index;
+      })
+      .map(prob => prob.data);
+
+    // Use pretty JSON.stringify because it inserts a newline before all objects, which forces prettier to then convert
+    // these objects into multiline ones.
+    const newContent = JSON.stringify(parsedOldFileData, null, 2) + '\n';
+    const formattedNewContent = await prettier.format(newContent, {
+      endOfLine: 'lf',
+      semi: true,
+      singleQuote: true,
+      tabWidth: 2,
+      useTabs: false,
+      trailingComma: 'es5',
+      arrowParens: 'avoid',
+      parser: 'json',
+    });
+
+    await githubAPI.put(
+      `/repos/cpinitiative/usaco-guide/contents/content/${filePath.replace(
+        /\.mdx$/,
+        '.problems.json'
+      )}`,
+      {
+        content: Buffer.from(formattedNewContent).toString('base64'),
+        message: `Feat: add suggested problem '${name}'`,
+        branch: branchName,
+        sha: oldFileHash,
+      }
+    );
+
+    const createdPullRequestReq = await githubAPI.post(
+      '/repos/cpinitiative/usaco-guide/pulls',
+      {
+        head: branchName,
+        base: 'master',
+        maintainer_can_modify: true,
+        title: `Problem Suggestion: Add "${name}" to ${moduleName}`,
+        body: body,
+      }
+    );
+
+    const useProblemSuggestionReviewers = false;
+    if (useProblemSuggestionReviewers) {
+      const reviewersReq = await githubAPI.get(
+        `/repos/cpinitiative/usaco-guide/pulls/${createdPullRequestReq.data.number}/requested_reviewers`
+      );
+      const reviewersToRemove = reviewersReq.data.users
+        .map(user => user.login)
+        .filter(user => !problemSuggestionReviewers[section].includes(user));
+      const keptReviewers = reviewersReq.data.users
+        .map(user => user.login)
+        .filter(user => problemSuggestionReviewers[section].includes(user));
+      await githubAPI.delete(
         `/repos/cpinitiative/usaco-guide/pulls/${createdPullRequestReq.data.number}/requested_reviewers`,
         {
-          reviewers: problemSuggestionReviewers[section].filter(
-            u => !keptReviewers.includes(u)
-          ),
+          data: {
+            reviewers: reviewersToRemove,
+            team_reviewers: reviewersReq.data.teams.map(team => team.slug),
+          },
         }
       );
+      if (
+        problemSuggestionReviewers[section].filter(
+          u => !keptReviewers.includes(u)
+        ).length > 0
+      ) {
+        await githubAPI.post(
+          `/repos/cpinitiative/usaco-guide/pulls/${createdPullRequestReq.data.number}/requested_reviewers`,
+          {
+            reviewers: problemSuggestionReviewers[section].filter(
+              u => !keptReviewers.includes(u)
+            ),
+          }
+        );
+      }
     }
+
+    // post to /issues/ because github treats all PRs as issues, so the shared features between them (such as labels) use issue api
+    await githubAPI.post(
+      `/repos/cpinitiative/usaco-guide/issues/${createdPullRequestReq.data.number}/labels`,
+      ['Problem Suggestion']
+    );
+
+    return createdPullRequestReq.data.html_url;
   }
-
-  // post to /issues/ because github treats all PRs as issues, so the shared features between them (such as labels) use issue api
-  await githubAPI.post(
-    `/repos/cpinitiative/usaco-guide/issues/${createdPullRequestReq.data.number}/labels`,
-    ['Problem Suggestion']
-  );
-
-  return createdPullRequestReq.data.html_url;
-});
+);
 export default submitProblemSuggestion;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,12 @@
     "outDir": "./dist" // Output directory for compiled files
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
-  "exclude": ["node_modules"]
+  // src/functions has its own tsconfig and its own npm tree, pinned to
+  // firebase-functions v5 (whose root export is the v1 API). The root tree is
+  // on v6, whose root export is v2 -- so typechecking those files here graded
+  // them against a different major with an incompatible callable signature.
+  // That is how the v2-shaped handlers in #6592 passed this build for months
+  // while being wrong for the runtime they deploy to. The Cloud Functions
+  // workflow typechecks them against their own tsconfig instead.
+  "exclude": ["node_modules", "src/functions"]
 }


### PR DESCRIPTION
Follow-up to #6591. **This is already deployed** for `submitProblemSuggestion` and `submitContactForm` — it fixes a production break I introduced by deploying #6591, so the code is live and this PR lands the source.

## What was wrong

The Next.js migration rewrote every callable to the **v2** signature — `async request => …` reading `request.data` and `request.auth` — while leaving the **v1** import (`import * as functions from 'firebase-functions'`) in place. It typechecked, because v1 types the first parameter as `any`.

v1 does not pass a `CallableRequest`. It wraps the handler so the arity sniff in `onCallHandler` always takes the two-argument branch:

```js
// v1/providers/https.js — "Wrap their handler in another handler
// to avoid accidentally triggering the v2 API"
const fixedLen = (data, context) => withInit(handler)(data, context);
```

So `request` received the raw payload. `request.data` and `request.auth` were both `undefined`, meaning callers hit the `!request.auth?.uid` gate and got `permission-denied`, and the handlers without an auth gate destructured undefined fields.

All ten callables had it: `submitProblemSuggestion`, `submitContactForm`, `getUsers`, `setUserClaims`, and the six under `groups/`.

## Why nobody noticed

The package hadn't been deployable since that same migration (#6591), so the live functions were still running pre-migration code that used `(data, context)` correctly. Deploying on top of #6591 is what surfaced it.

## Verification

Exercised against the compiled output through `func.run`, which is the same wrapper the runtime invokes:

| case | before | after |
| --- | --- | --- |
| `submitProblemSuggestion`, no auth | `permission-denied` | `permission-denied` ✓ |
| `submitProblemSuggestion`, with auth | `permission-denied` ✗ | passes the gate, reaches `admin.auth().getUser` ✓ |
| `submitContactForm`, empty payload | destructured `undefined` | `invalid-argument` ✓ |

The sort behaviour that started all this also replays correctly against the deployed module — a `Medium` suggestion lands between the last `Medium` and the first `Hard`, not at index 0.

For `submitContactForm`, the only remaining difference from the long-running deployed version is a type annotation, so that deploy was behaviourally a no-op that just brought it onto nodejs22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld15PL5jeYxRrY5zLnErXK