### PR TITLE
Sort "Appears In" modules by section on solution pages

### DIFF
--- a/content/ordering.ts
+++ b/content/ordering.ts
@@ -323,7 +323,7 @@ SECTIONS.forEach(section => {
   });
 });
 
-export { moduleIDToSectionMap, moduleIDToURLMap };
+export { moduleIDToRankMap, moduleIDToSectionMap, moduleIDToURLMap };
 
 const moduleIDToURLMap: { [key: string]: string } = {};
 
@@ -331,6 +331,20 @@ SECTIONS.forEach(section => {
   MODULE_ORDERING[section].forEach(category => {
     category.items.forEach(moduleID => {
       moduleIDToURLMap[moduleID] = `/${section}/${moduleID}`;
+    });
+  });
+});
+
+// The position of each module in the guide: sections in order from General to
+// Advanced, and within a section, chapters and modules in the order they are
+// listed above.
+const moduleIDToRankMap: { [key: string]: number } = {};
+
+let moduleRank = 0;
+SECTIONS.forEach(section => {
+  MODULE_ORDERING[section].forEach(category => {
+    category.items.forEach(moduleID => {
+      moduleIDToRankMap[moduleID] = moduleRank++;
     });
   });
 });

--- a/src/pages/problems/[slug]/solution/index.tsx
+++ b/src/pages/problems/[slug]/solution/index.tsx
@@ -1,5 +1,9 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
 import * as React from 'react';
+import {
+  moduleIDToSectionMap,
+  SECTIONS,
+} from '../../../../../content/ordering';
 import MarkdownLayout from '../../../../components/MarkdownLayout/MarkdownLayout';
 import Layout from '../../../../components/layout';
 import Markdown from '../../../../components/markdown/Markdown';
@@ -128,6 +132,15 @@ export const getStaticProps: GetStaticProps = async context => {
         notFound: true,
       };
     }
+    // Order the "Appears In" modules by section, from General to Advanced.
+    // Modules within the same section keep their existing relative order.
+    const sectionOrder = (moduleID: string) => {
+      const index = SECTIONS.indexOf(moduleIDToSectionMap[moduleID]);
+      return index === -1 ? SECTIONS.length : index;
+    };
+    modulesThatHaveProblem.sort(
+      (a, b) => sectionOrder(a.id) - sectionOrder(b.id)
+    );
 
     const problemInfo = await queryProblem(solutionForSlug.frontmatter.id);
     if (!problemInfo) {

--- a/src/pages/problems/[slug]/solution/index.tsx
+++ b/src/pages/problems/[slug]/solution/index.tsx
@@ -1,9 +1,6 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
 import * as React from 'react';
-import {
-  moduleIDToSectionMap,
-  SECTIONS,
-} from '../../../../../content/ordering';
+import { moduleIDToRankMap } from '../../../../../content/ordering';
 import MarkdownLayout from '../../../../components/MarkdownLayout/MarkdownLayout';
 import Layout from '../../../../components/layout';
 import Markdown from '../../../../components/markdown/Markdown';
@@ -132,15 +129,11 @@ export const getStaticProps: GetStaticProps = async context => {
         notFound: true,
       };
     }
-    // Order the "Appears In" modules by section, from General to Advanced.
-    // Modules within the same section keep their existing relative order.
-    const sectionOrder = (moduleID: string) => {
-      const index = SECTIONS.indexOf(moduleIDToSectionMap[moduleID]);
-      return index === -1 ? SECTIONS.length : index;
-    };
-    modulesThatHaveProblem.sort(
-      (a, b) => sectionOrder(a.id) - sectionOrder(b.id)
-    );
+    // Order the "Appears In" modules by where they sit in the guide: General
+    // through Advanced, then by module order within a section.
+    const rank = (moduleID: string) =>
+      moduleIDToRankMap[moduleID] ?? Number.MAX_SAFE_INTEGER;
+    modulesThatHaveProblem.sort((a, b) => rank(a.id) - rank(b.id));
 
     const problemInfo = await queryProblem(solutionForSlug.frontmatter.id);
     if (!problemInfo) {


### PR DESCRIPTION
On problem solution pages (e.g. [cses-1688-company-queries-ii](https://usaco.guide/problems/cses-1688-company-queries-ii/solution)), the "Appears In" module list was rendered in whatever order `queryModuleIdAndTitleFromProblemBySolutionId` returned — a `WHERE module_id IN (...)` lookup with no `ORDER BY`, so the order was effectively arbitrary. For that problem, Platinum modules showed before Gold.

Sort the list by where each module sits in the guide. `content/ordering` gains `moduleIDToRankMap`, which numbers every module in the order the guide lists it — sections from General to Advanced, and within a section, chapters and modules in their listed order. Sorting on that one key gives both levels of ordering; modules missing from the map sort last.

The sort happens in `getStaticProps`, so both "Appears In" lists on the page (the module header and the one in the user-solutions box) get the same order.

For cses-1688 this puts Gold – Euler Tour Technique first, then Platinum – Binary Jumping, then Platinum – Heavy-Light Decomposition, matching the order those modules appear in the guide.

`tsc --noEmit` passes; not verified visually in a running dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCkkbphihYq2YmFyBGuBRA
