### PR TITLE
Tag cleanup: fill in missing tags, drop "Ad Hoc", fix duplicate one-off tags

### DIFF
--- a/content/2_Bronze/Ad_Hoc.problems.json
+++ b/content/2_Bronze/Ad_Hoc.problems.json
@@ -8,7 +8,7 @@
       "source": "Bronze",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Greedy"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "ad-hoc"

--- a/content/2_Bronze/Ad_Hoc.problems.json
+++ b/content/2_Bronze/Ad_Hoc.problems.json
@@ -8,7 +8,7 @@
       "source": "Bronze",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Ad Hoc"],
+      "tags": [],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "ad-hoc"

--- a/content/2_Bronze/Casework.problems.json
+++ b/content/2_Bronze/Casework.problems.json
@@ -8,7 +8,7 @@
       "source": "Bronze",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Casework"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": false

--- a/content/2_Bronze/Conclusion.problems.json
+++ b/content/2_Bronze/Conclusion.problems.json
@@ -141,7 +141,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Ad Hoc"],
+      "tags": [],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -165,7 +165,7 @@
       "source": "CSES",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Ad Hoc", "Greedy"],
+      "tags": ["Greedy"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/2_Bronze/Conclusion.problems.json
+++ b/content/2_Bronze/Conclusion.problems.json
@@ -141,7 +141,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Greedy"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/2_Bronze/Intro_Complete.problems.json
+++ b/content/2_Bronze/Intro_Complete.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Complete Search"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "intro-complete"

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -300,7 +300,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Ad Hoc", "DFS", "Greedy"],
+      "tags": ["DFS", "Greedy"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Prefix_Sums.problems.json
+++ b/content/3_Silver/Prefix_Sums.problems.json
@@ -8,7 +8,7 @@
       "source": "YS",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Prefix Sums"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "prefix-sums"

--- a/content/3_Silver/Sorting_Custom.problems.json
+++ b/content/3_Silver/Sorting_Custom.problems.json
@@ -22,7 +22,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Coordinate Compression", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "sorting-custom"

--- a/content/4_Gold/Combinatorics.problems.json
+++ b/content/4_Gold/Combinatorics.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Combinatorics"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "combo"
@@ -23,7 +23,7 @@
       "source": "YS",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Combinatorics"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "combo"
@@ -53,7 +53,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Probability"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "combo"
@@ -68,7 +68,7 @@
       "source": "AC",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Probability"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "combo"

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -149,7 +149,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DP", "Graphs", "Sortings"],
+      "tags": ["DP", "Graphs", "Sorting"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/4_Gold/Divisibility.problems.json
+++ b/content/4_Gold/Divisibility.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Divisibility"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "divisibility"
@@ -23,7 +23,7 @@
       "source": "SPOJ",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": [],
+      "tags": ["Divisibility", "Euler Totient"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "divisibility"
@@ -38,7 +38,7 @@
       "source": "SPOJ",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": [],
+      "tags": ["Euler Totient"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "divisibility"

--- a/content/4_Gold/LIS.problems.json
+++ b/content/4_Gold/LIS.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["LIS"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "lis"
@@ -23,7 +23,7 @@
       "source": "Baltic OI",
       "difficulty": "Medium",
       "isStarred": true,
-      "tags": [],
+      "tags": ["LIS"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "lis"

--- a/content/4_Gold/TopoSort.problems.json
+++ b/content/4_Gold/TopoSort.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["TopoSort"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "toposort"
@@ -38,7 +38,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["TopoSort"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "toposort"

--- a/content/4_Gold/Tree_Euler.problems.json
+++ b/content/4_Gold/Tree_Euler.problems.json
@@ -51,7 +51,7 @@
       "source": "YS",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["SRQ"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "tree-euler"

--- a/content/6_Advanced/Eulerian_Tours.problems.json
+++ b/content/6_Advanced/Eulerian_Tours.problems.json
@@ -8,7 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Hamiltonian Path"],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "eulerian-tours"


### PR DESCRIPTION
Two commits of tag cleanup on Bronze–Gold problems.

## Fill in missing tags

Sixteen problems across nine Bronze/Silver/Gold modules had an empty `tags` array. All of them are in-text focus/example problems rather than entries in a rendered `<Problems />` list, so they were invisible in the module pages but still feed the problem database behind `/problems`. Every tag used already exists elsewhere in the repo — none are new.

**Tag the module already uses on every other problem**

| Problem | Module | Tags |
|---|---|---|
| Maximum Distance | `intro-complete` | `Complete Search` |
| Sleepy Cow Herding | `casework` | `Casework` |
| Static Range Sum | `prefix-sums` | `Prefix Sums` |
| Counting Divisors | `divisibility` | `Divisibility` |
| Binomial Coefficients, Montmort Numbers | `combo` | `Combinatorics` |
| Increasing Subsequence, Baltic OI 2010 – PCB | `lis` | `LIS` |
| Course Schedule, Longest Flight Route | `toposort` | `TopoSort` |

**Tag drawn from the section the problem illustrates**, matching the nearest sibling problem

| Problem | Module | Tags | Basis |
|---|---|---|---|
| Static Range Queries | `sorting-custom` | `Coordinate Compression`, `Prefix Sums` | module text says it "will require prefix sums and coordinate compression"; CF 1000C in the same module has the same pair |
| ETF – Euler Totient Function | `divisibility` | `Euler Totient` | focus problem for "Euler's Totient Function" |
| GCDEX – GCD Extreme | `divisibility` | `Divisibility`, `Euler Totient` | phi-based solution; mirrors LCM Sum's `Divisibility, Euler Totient, LCM` |
| Candy Lottery, Erasing Vertices | `combo` | `Probability` | both sit under "Expected Value" / "Linearity of Expectation", not the combinatorics sections |
| Static RMQ | `tree-euler` | `SRQ` | focus problem for the Sparse Tables section |

## Drop the "Ad Hoc" tag

It carried no information beyond the module it came from, and was on only four problems. Raab Game I keeps `Greedy` and Big Brush keeps `DFS, Greedy`; Photoshoot 2 (in `ad-hoc`) and ABBC or BACB (in `bronze-conclusion`) are retagged `Greedy` in a follow-up commit — each is solved by a single greedy pass.

## Fold two one-off tags into the tags they duplicate

- **Sortings → Sorting** on Fibonacci Paths. `Sortings` is Codeforces' spelling; the guide uses `Sorting` on 83 other problems. Normalizing the whole vocabulary for case, punctuation, and plurals turns up no other spelling duplicate — every remaining one-off tag (`0/1 BFS`, `Manhattan MST`, `Suffix Tree`, `3DRQ`, …) names a technique distinct from its lookalike.
- **Hamiltonian Path → Euler Tour** on De Bruijn Sequence. The tag described the framing, not the solution: the module builds the De Bruijn graph and states "an Eulerian path in the above graph represents a valid solution". Every other tagged problem in `eulerian-tours` already uses `Euler Tour`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCkkbphihYq2YmFyBGuBRA
