### PR TITLE
Rehome Bronze ad hoc problems to the modules they belong to

### DIFF
--- a/content/2_Bronze/Ad_Hoc.mdx
+++ b/content/2_Bronze/Ad_Hoc.mdx
@@ -6,7 +6,7 @@ contributors: Ryan Chou, Rameez Parwez
 description:
   'Problems that do not fall into standard categories with well-studied
   solutions.'
-frequency: 4
+frequency: 2
 ---
 
 ## Introduction
@@ -37,93 +37,6 @@ appear to be ad hoc.
 
 In the end, the best way to get better at ad hoc problems (or any type of
 problem) is to do a lot of them.
-
-## Example - Photoshoot 2
-
-<FocusProblem problem = "photoshoot2"/>
-
-<Spoiler title = "Solution">
-
-## Explanation
-
-If the element is at the target position, we simply move forward to the next one.
-Otherwise, if it's not currently available at the target position, we handle it by
-marking the element as moved and incrementing our answer.
-
-## Implementation
-
-**Time Complexity:** $\mathcal{O}(N)$
-
-<LanguageSection>
-<CPPSection>
-
-```cpp
-#include <cstring>
-#include <iostream>
-
-int main() {
-	int n;
-	std::cin >> n;
-	int moved[n] = {0};
-	int a[n], b[n];
-
-	for (int i = 0; i < n; i++) {
-		std::cin >> a[i];
-		a[i]--;
-	}
-
-	for (int i = 0; i < n; i++) {
-		std::cin >> b[i];
-		b[i]--;
-	}
-
-	int res = 0;
-	int j = 0;
-
-	for (int i = 0; i < n; i++) {
-		while (j < n && moved[a[j]]) { j++; }
-
-		if (a[j] == b[i]) {
-			j++;
-		} else {
-			res++;
-			moved[b[i]] = 1;
-		}
-	}
-
-	std::cout << res << '\n';
-}
-```
-
-</CPPSection>
-<PySection>
-
-```py
-n = int(input())
-a = [int(x) - 1 for x in input().split()]
-b = [int(x) - 1 for x in input().split()]
-
-moved = [0] * n
-j = res = 0
-
-
-for i in range(n):
-	while j < n and moved[a[j]]:
-		j += 1
-
-	if a[j] == b[i]:
-		j += 1
-	else:
-		res += 1
-		moved[b[i]] = 1
-
-
-print(res)
-```
-
-</PySection>
-</LanguageSection>
-</Spoiler>
 
 ## Problems
 

--- a/content/2_Bronze/Ad_Hoc.problems.json
+++ b/content/2_Bronze/Ad_Hoc.problems.json
@@ -1,33 +1,6 @@
 {
   "MODULE_ID": "ad-hoc",
-  "photoshoot2": [
-    {
-      "uniqueId": "usaco-1204",
-      "name": "Photoshoot 2",
-      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1204",
-      "source": "Bronze",
-      "difficulty": "Medium",
-      "isStarred": false,
-      "tags": ["Ad Hoc"],
-      "solutionMetadata": {
-        "kind": "in-module",
-        "moduleId": "ad-hoc"
-      }
-    }
-  ],
   "general": [
-    {
-      "uniqueId": "usaco-591",
-      "name": "Promotion Counting",
-      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=591",
-      "source": "Bronze",
-      "difficulty": "Easy",
-      "isStarred": false,
-      "tags": [],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
     {
       "uniqueId": "usaco-892",
       "name": "Sleepy Cow Sorting",
@@ -52,32 +25,6 @@
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
-      }
-    },
-    {
-      "uniqueId": "usaco-737",
-      "name": "Modern Art",
-      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=737",
-      "source": "Bronze",
-      "difficulty": "Hard",
-      "isStarred": false,
-      "tags": [],
-      "solutionMetadata": {
-        "kind": "internal",
-        "hasHints": true
-      }
-    },
-    {
-      "uniqueId": "usaco-1088",
-      "name": "Spaced Out",
-      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1088",
-      "source": "Silver",
-      "difficulty": "Very Hard",
-      "isStarred": false,
-      "tags": ["Greedy"],
-      "solutionMetadata": {
-        "kind": "internal",
-        "hasHints": false
       }
     }
   ]

--- a/content/2_Bronze/Casework.problems.json
+++ b/content/2_Bronze/Casework.problems.json
@@ -75,6 +75,19 @@
       "solutionMetadata": {
         "kind": "internal"
       }
+    },
+    {
+      "uniqueId": "usaco-1088",
+      "name": "Spaced Out",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1088",
+      "source": "Silver",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Casework"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": false
+      }
     }
   ]
 }

--- a/content/2_Bronze/Intro_Greedy.problems.json
+++ b/content/2_Bronze/Intro_Greedy.problems.json
@@ -90,6 +90,18 @@
       }
     },
     {
+      "uniqueId": "usaco-1204",
+      "name": "Photoshoot 2",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1204",
+      "source": "Bronze",
+      "difficulty": "Medium",
+      "isStarred": false,
+      "tags": ["Greedy"],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
       "uniqueId": "usaco-832",
       "name": "Milking Order",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=832",

--- a/content/2_Bronze/Rect_Geo.problems.json
+++ b/content/2_Bronze/Rect_Geo.problems.json
@@ -55,6 +55,19 @@
       }
     },
     {
+      "uniqueId": "usaco-737",
+      "name": "Modern Art",
+      "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=737",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Rectangle"],
+      "solutionMetadata": {
+        "kind": "internal",
+        "hasHints": true
+      }
+    },
+    {
       "uniqueId": "cf-1216C",
       "name": "D3C - White Sheet",
       "url": "https://codeforces.com/contest/1216/problem/C",

--- a/solutions/bronze/usaco-1204.mdx
+++ b/solutions/bronze/usaco-1204.mdx
@@ -1,0 +1,88 @@
+---
+id: usaco-1204
+source: USACO Bronze 2022 February
+title: Photoshoot 2
+author: Rameez Parwez
+---
+
+[Official Editorial (C++, Java, Python)](https://usaco.org/current/data/sol_prob2_bronze_feb22.html)
+
+## Explanation
+
+If the element is at the target position, we simply move forward to the next one.
+Otherwise, if it's not currently available at the target position, we handle it by
+marking the element as moved and incrementing our answer.
+
+## Implementation
+
+**Time Complexity:** $\mathcal{O}(N)$
+
+<LanguageSection>
+<CPPSection>
+
+```cpp
+#include <cstring>
+#include <iostream>
+
+int main() {
+	int n;
+	std::cin >> n;
+	int moved[n] = {0};
+	int a[n], b[n];
+
+	for (int i = 0; i < n; i++) {
+		std::cin >> a[i];
+		a[i]--;
+	}
+
+	for (int i = 0; i < n; i++) {
+		std::cin >> b[i];
+		b[i]--;
+	}
+
+	int res = 0;
+	int j = 0;
+
+	for (int i = 0; i < n; i++) {
+		while (j < n && moved[a[j]]) { j++; }
+
+		if (a[j] == b[i]) {
+			j++;
+		} else {
+			res++;
+			moved[b[i]] = 1;
+		}
+	}
+
+	std::cout << res << '\n';
+}
+```
+
+</CPPSection>
+<PySection>
+
+```py
+n = int(input())
+a = [int(x) - 1 for x in input().split()]
+b = [int(x) - 1 for x in input().split()]
+
+moved = [0] * n
+j = res = 0
+
+
+for i in range(n):
+	while j < n and moved[a[j]]:
+		j += 1
+
+	if a[j] == b[i]:
+		j += 1
+	else:
+		res += 1
+		moved[b[i]] = 1
+
+
+print(res)
+```
+
+</PySection>
+</LanguageSection>


### PR DESCRIPTION
The Bronze ad hoc module had become a bucket for problems that already had a home. Reading the six solutions, only two turn on an observation with no named technique behind it; the rest are solved by something the guide teaches in another Bronze module.

## Moves

| Problem | Was | Now | Why |
|---|---|---|---|
| Modern Art | `ad-hoc` | `rect-geo` | takes each color's bounding rectangle and rules out any color whose box contains another |
| Spaced Out | `ad-hoc` | `casework` | splits on whether every row alternates or every column alternates; retagged `Casework`, since the `Greedy` tag described neither case |
| Photoshoot 2 | `ad-hoc` | `intro-greedy` | one left-to-right pass, moving an element whenever it is out of place |
| Promotion Counting | `ad-hoc` | dropped | already listed in `expected-knowledge` and `usaco-faq` |

Photoshoot 2 was the module's worked example, so its explanation and both code samples move to `solutions/bronze/usaco-1204.mdx` as an internal solution (author credited to the contributor who wrote them), and the module's `## Example - Photoshoot 2` section goes away.

## What the module keeps

Sleepy Cow Sorting ("the answer is the position of the last unsorted cow") and Taming the Herd ("reconstruct backwards, then min = number of streaks, max = streaks + missing"). Both are genuinely ad hoc.

The module's value was never the problem list — it is the advice at the top about how to approach a problem with no standard technique, which nothing else in Bronze covers. Frequency drops from `4` ("Very Frequent" — at least once per contest) to `2` ("Not Frequent"), which is where Casework sits.

## Verification

`yarn tsx scripts/index-content.ts` indexes cleanly, and the resulting `module_problem_lists` rows show each problem in its new module and gone from `ad-hoc`.

Best merged after #6597, which touches the `usaco-1204` entry this PR moves out of `Ad_Hoc.problems.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCkkbphihYq2YmFyBGuBRA
