### PR TITLE
Difficulty and ordering fixes for Very Easy problems

### DIFF
--- a/content/1_General/Expected_Knowledge.problems.json
+++ b/content/1_General/Expected_Knowledge.problems.json
@@ -6,7 +6,7 @@
       "name": "Teleportation",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=807",
       "source": "Bronze",
-      "difficulty": "Very Easy",
+      "difficulty": "Easy",
       "isStarred": false,
       "tags": ["Complete Search"],
       "solutionMetadata": {
@@ -18,7 +18,7 @@
       "name": "Watermelon",
       "url": "https://codeforces.com/problemset/problem/4/A",
       "source": "CF",
-      "difficulty": "Very Easy",
+      "difficulty": "Easy",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -30,7 +30,7 @@
       "name": "Team",
       "url": "https://codeforces.com/problemset/problem/231/A",
       "source": "CF",
-      "difficulty": "Very Easy",
+      "difficulty": "Easy",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -42,7 +42,7 @@
       "name": "Soldier and Bananas",
       "url": "https://codeforces.com/problemset/problem/546/A",
       "source": "CF",
-      "difficulty": "Very Easy",
+      "difficulty": "Easy",
       "isStarred": false,
       "tags": ["Math"],
       "solutionMetadata": {
@@ -54,7 +54,7 @@
       "name": "Promotion Counting",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=591",
       "source": "Bronze",
-      "difficulty": "Easy",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -66,7 +66,7 @@
       "name": "Do You Know Your ABCs?",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1059",
       "source": "Bronze",
-      "difficulty": "Easy",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": ["Sorting"],
       "solutionMetadata": {
@@ -78,7 +78,7 @@
       "name": "Word Processor",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=987",
       "source": "Bronze",
-      "difficulty": "Easy",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {
@@ -90,7 +90,7 @@
       "name": "Bucket Brigade",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=939",
       "source": "Bronze",
-      "difficulty": "Easy",
+      "difficulty": "Medium",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/1_General/Intro_CP.problems.json
+++ b/content/1_General/Intro_CP.problems.json
@@ -6,7 +6,7 @@
       "name": "Basketball One on One",
       "url": "https://open.kattis.com/problems/basketballoneonone",
       "source": "Kattis",
-      "difficulty": "Very Easy",
+      "difficulty": "Easy",
       "isStarred": false,
       "tags": [],
       "solutionMetadata": {

--- a/content/2_Bronze/Conclusion.problems.json
+++ b/content/2_Bronze/Conclusion.problems.json
@@ -30,7 +30,7 @@
       "name": "Reading Books",
       "url": "https://cses.fi/problemset/task/1631/",
       "source": "CSES",
-      "difficulty": "Very Easy",
+      "difficulty": "Easy",
       "isStarred": false,
       "tags": ["Math"],
       "solutionMetadata": {

--- a/content/2_Bronze/Conclusion.problems.json
+++ b/content/2_Bronze/Conclusion.problems.json
@@ -2,9 +2,9 @@
   "MODULE_ID": "bronze-conclusion",
   "problems": [
     {
-      "uniqueId": "cf-1560B",
-      "name": "Who's Opposite?",
-      "url": "https://codeforces.com/problemset/problem/1560/B",
+      "uniqueId": "cf-1593A",
+      "name": "Election",
+      "url": "https://codeforces.com/problemset/problem/1593/A",
       "source": "CF",
       "difficulty": "Very Easy",
       "isStarred": false,
@@ -14,9 +14,9 @@
       }
     },
     {
-      "uniqueId": "cf-1593A",
-      "name": "Election",
-      "url": "https://codeforces.com/problemset/problem/1593/A",
+      "uniqueId": "cf-1560B",
+      "name": "Who's Opposite?",
+      "url": "https://codeforces.com/problemset/problem/1560/B",
       "source": "CF",
       "difficulty": "Very Easy",
       "isStarred": false,

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -6,7 +6,7 @@
       "name": "Spying On The Beaver",
       "url": "https://codeforces.com/contest/2257/problem/C",
       "source": "CF",
-      "difficulty": "Very Easy",
+      "difficulty": "Easy",
       "isStarred": false,
       "tags": ["Greedy", "Tree"],
       "solutionMetadata": {


### PR DESCRIPTION
Adjustments coming out of a pass over every `Very Easy` problem in the guide.

## Difficulty

**Expected Knowledge** — every problem in [General → Expected Knowledge](https://usaco.guide/general/expected-knowledge) moves up one level: the four `Very Easy` problems become `Easy`, and the four `Easy` ones become `Medium`. Relative order is unchanged.

**Intro to CP** — Basketball One on One, the module's focus problem, goes from `Very Easy` to `Easy`.

**Bronze Conclusion** — Reading Books goes from `Very Easy` to `Easy`.

**Silver Conclusion** — Spying On The Beaver goes from `Very Easy` to `Easy`.

That clears every `Very Easy` rating out of the General section and out of the Silver conclusion list.

## Ordering

**Bronze Conclusion** — Election moves ahead of Who's Opposite?. Both are `Very Easy`, so list order is the only ordering signal, and it had the harder one first. Election is one formula applied three times; Who's Opposite? needs three chained observations — deduce the circle size from the given pair, reject inputs that exceed it, then wrap the answer back around the circle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCkkbphihYq2YmFyBGuBRA