### PR TITLE
Fix undefined variable in the Election solution

### DIFF
--- a/solutions/bronze/cf-1593A.mdx
+++ b/solutions/bronze/cf-1593A.mdx
@@ -16,7 +16,7 @@ In other words, letting $a,b,c$ be the values of the $3$ given numbers and $n$ b
 
 $$a+n=\max(b,c)+1$$
 
-Solving this, we get $n=\max(b,x)+1-a$. With this, we can calculate $n$ for each of $a$, $b$, and $c$. However, it is important to note that if $n<0$, then we should output $0$, since the value to add can't be negative.
+Solving this, we get $n=\max(b,c)+1-a$. With this, we can calculate $n$ for each of $a$, $b$, and $c$. However, it is important to note that if $n<0$, then we should output $0$, since the value to add can't be negative.
 
 ## Implementation
 


### PR DESCRIPTION
On [cf-election](https://usaco.guide/problems/cf-election/solution), the explanation sets up

> $a+n=\max(b,c)+1$

and then says "Solving this, we get $n=\max(b,x)+1-a$". There is no $x$ in the problem — it should be $c$. The code below it already uses `max(b, c)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCkkbphihYq2YmFyBGuBRA