### PR TITLE
Tag recent problems, adjust module frequencies, clean up solution metadata

### DIFF
--- a/content/2_Bronze/Ad_Hoc.mdx
+++ b/content/2_Bronze/Ad_Hoc.mdx
@@ -6,7 +6,7 @@ contributors: Ryan Chou, Rameez Parwez
 description:
   'Problems that do not fall into standard categories with well-studied
   solutions.'
-frequency: 2
+frequency: 4
 ---
 
 ## Introduction

--- a/content/2_Bronze/Ad_Hoc.problems.json
+++ b/content/2_Bronze/Ad_Hoc.problems.json
@@ -2,6 +2,31 @@
   "MODULE_ID": "ad-hoc",
   "general": [
     {
+      "uniqueId": "usaco-1539",
+      "name": "Chip Exchange",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1539",
+      "source": "Bronze",
+      "difficulty": "Medium",
+      "isStarred": false,
+      "tags": [],
+      "solutionMetadata": {
+        "kind": "USACO",
+        "usacoId": "1539"
+      }
+    },
+    {
+      "uniqueId": "usaco-1541",
+      "name": "Photoshoot",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1541",
+      "source": "Bronze",
+      "difficulty": "Medium",
+      "isStarred": false,
+      "tags": [],
+      "solutionMetadata": {
+        "kind": "internal"
+      }
+    },
+    {
       "uniqueId": "usaco-892",
       "name": "Sleepy Cow Sorting",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=892",
@@ -25,6 +50,18 @@
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
+      }
+    },
+    {
+      "uniqueId": "usaco-1540",
+      "name": "COW Splits",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1540",
+      "source": "Bronze",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Constructive", "Strings"],
+      "solutionMetadata": {
+        "kind": "internal"
       }
     }
   ]

--- a/content/2_Bronze/Complete_Rec.mdx
+++ b/content/2_Bronze/Complete_Rec.mdx
@@ -7,7 +7,7 @@ contributors:
   Liu, Dustin Miao
 description: 'Harder problems involving iterating through the entire solution space,
 including those that require generating subsets and permutations.'
-frequency: 1
+frequency: 2
 prerequisites:
   - intro-complete
 ---

--- a/content/2_Bronze/Intro_Graphs.mdx
+++ b/content/2_Bronze/Intro_Graphs.mdx
@@ -4,7 +4,7 @@ title: Introduction to Graphs
 author: Darren Yao, Benjamin Qi
 contributors: Nathan Gong, Ryan Chou, Kevin Sheng, Nikhil Chatterjee
 description: 'What graphs are.'
-frequency: 2
+frequency: 1
 prerequisites:
   - intro-ds
 ---

--- a/content/2_Bronze/Intro_Greedy.mdx
+++ b/content/2_Bronze/Intro_Greedy.mdx
@@ -5,7 +5,7 @@ author: Darren Yao, Benjamin Qi
 contributors: Ryan Chou
 description:
   'Problems that can be solved by selecting the choice that seems to be the best at the moment at every step.'
-frequency: 3
+frequency: 4
 ---
 
 <Warning>

--- a/content/2_Bronze/Intro_Sets.mdx
+++ b/content/2_Bronze/Intro_Sets.mdx
@@ -4,7 +4,7 @@ title: Introduction to Sets & Maps
 author: Darren Yao, Benjamin Qi, Allen Li, Jesse Choe, Nathan Gong
 contributors: Elliott Harper
 description: 'Maintaining collections of distinct elements/keys with sets and maps.'
-frequency: 2
+frequency: 3
 prerequisites:
   - intro-sorting
 ---

--- a/content/2_Bronze/Simulation.mdx
+++ b/content/2_Bronze/Simulation.mdx
@@ -5,7 +5,7 @@ author: Darren Yao
 contributors: Allen Li, Siyong Huang, Juheon Rhee
 description:
   'Directly simulating the problem statement.'
-frequency: 4
+frequency: 3
 ---
 
 <Resources>

--- a/content/3_Silver/Binary_Search.mdx
+++ b/content/3_Silver/Binary_Search.mdx
@@ -9,7 +9,7 @@ prerequisites:
   - binary-search-sorted-array
 description:
   'Binary searching on arbitrary monotonic functions.'
-frequency: 3
+frequency: 4
 ---
 
 ## Resources

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -675,19 +675,6 @@
       }
     },
     {
-      "uniqueId": "usaco-1523",
-      "name": "OohMoo Milk",
-      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1523",
-      "source": "Gold",
-      "difficulty": "Hard",
-      "isStarred": false,
-      "tags": ["Binary Search", "Sorting"],
-      "solutionMetadata": {
-        "kind": "USACO",
-        "usacoId": "1523"
-      }
-    },
-    {
       "uniqueId": "cf-2118D2",
       "name": "Red Light, Green Light (Hard Version)",
       "url": "https://codeforces.com/contest/2118/problem/D2",
@@ -761,19 +748,6 @@
       "tags": ["Bipartite"],
       "solutionMetadata": {
         "kind": "internal"
-      }
-    },
-    {
-      "uniqueId": "usaco-1449",
-      "name": "Cowdependence",
-      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1449",
-      "source": "Gold",
-      "difficulty": "Very Hard",
-      "isStarred": false,
-      "tags": ["Binary Search", "Prefix Sums", "Sqrt", "Two Pointers"],
-      "solutionMetadata": {
-        "kind": "USACO",
-        "usacoId": "1449"
       }
     },
     {

--- a/content/3_Silver/Flood_Fill.mdx
+++ b/content/3_Silver/Flood_Fill.mdx
@@ -8,7 +8,7 @@ contributors: Kevin Sheng, George Pong
 prerequisites:
   - graph-traversal
 description: 'Finding connected components in a graph represented by a grid.'
-frequency: 3
+frequency: 2
 ---
 
 ## Resources

--- a/content/3_Silver/Func_Graphs.mdx
+++ b/content/3_Silver/Func_Graphs.mdx
@@ -7,7 +7,7 @@ prerequisites:
   - intro-tree
 description:
   'Directed graphs in which every vertex has exactly one outgoing edge.'
-frequency: 2
+frequency: 1
 ---
 
 ## Introduction

--- a/content/3_Silver/Greedy_Sorting.mdx
+++ b/content/3_Silver/Greedy_Sorting.mdx
@@ -8,7 +8,7 @@ prerequisites:
   - intro-greedy
   - two-pointers
 description: 'Solving greedy problems by sorting the input.'
-frequency: 3
+frequency: 4
 ---
 
 ## Resources

--- a/content/3_Silver/Intro_Tree.mdx
+++ b/content/3_Silver/Intro_Tree.mdx
@@ -5,7 +5,7 @@ author: Nathan Chen, Siyong Huang, Albert Ye
 prerequisites:
   - graph-traversal
 description: 'Introducing a special type of graph: trees.'
-frequency: 2
+frequency: 3
 ---
 
 ## Resources

--- a/content/3_Silver/More_Prefix_Sums.mdx
+++ b/content/3_Silver/More_Prefix_Sums.mdx
@@ -10,7 +10,7 @@ description:
   example.'
 prerequisites:
   - prefix-sums
-frequency: 2
+frequency: 1
 ---
 
 <YouTube id="h8UdQM40Vlk" />

--- a/content/3_Silver/Prefix_Sums.mdx
+++ b/content/3_Silver/Prefix_Sums.mdx
@@ -5,7 +5,7 @@ author: Darren Yao, Dustin Miao
 description:
   'Computing range sum queries in constant time over a fixed 1D array.'
 prerequisites:
-frequency: 3
+frequency: 4
 ---
 
 ## Resources

--- a/content/3_Silver/Priority_Queues.mdx
+++ b/content/3_Silver/Priority_Queues.mdx
@@ -6,7 +6,7 @@ prerequisites:
   - greedy-sorting
   - sorting-custom
 description: 'A data structure that supports insert, query max, and pop max.'
-frequency: 2
+frequency: 3
 ---
 
 ## Introduction

--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -662,6 +662,19 @@
       }
     },
     {
+      "uniqueId": "usaco-1523",
+      "name": "OohMoo Milk",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1523",
+      "source": "Gold",
+      "difficulty": "Hard",
+      "isStarred": false,
+      "tags": ["Binary Search", "Sorting"],
+      "solutionMetadata": {
+        "kind": "USACO",
+        "usacoId": "1523"
+      }
+    },
+    {
       "uniqueId": "cf-906D",
       "name": "Power Tower",
       "url": "https://codeforces.com/problemset/problem/906/D",
@@ -684,6 +697,19 @@
       "tags": ["Shortest Path"],
       "solutionMetadata": {
         "kind": "internal"
+      }
+    },
+    {
+      "uniqueId": "usaco-1449",
+      "name": "Cowdependence",
+      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1449",
+      "source": "Gold",
+      "difficulty": "Very Hard",
+      "isStarred": false,
+      "tags": ["Binary Search", "Prefix Sums", "Sqrt", "Two Pointers"],
+      "solutionMetadata": {
+        "kind": "USACO",
+        "usacoId": "1449"
       }
     }
   ]

--- a/content/4_Gold/Knapsack_DP.mdx
+++ b/content/4_Gold/Knapsack_DP.mdx
@@ -7,7 +7,7 @@ prerequisites:
   - intro-dp
 description:
   'Problems that can be modeled as filling a limited-size container with items.'
-frequency: 2
+frequency: 1
 ---
 
 <FocusProblem problem="sam" />

--- a/content/4_Gold/LIS.mdx
+++ b/content/4_Gold/LIS.mdx
@@ -1,6 +1,6 @@
 ---
 id: lis
-title: 'Longest Increasing Subsequence'
+title: '(Optional) Longest Increasing Subsequence'
 author: Michael Cao, Benjamin Qi, Andi Qu, Andrew Wang
 contributors: Dong Liu, Siyong Huang, Aryansh Shrivastava, Kevin Sheng, Katja Frantzen
 prerequisites:
@@ -219,16 +219,16 @@ def find_lis(arr: List[int]) -> int:
 </PySection>
 </LanguageSection>
 
-### Fast Solution (RMQ Data Structures)
+<Optional title="Fast Solution with RMQ Data Structures">
 
 **Time Complexity**: $\mathcal O(N \log N)$, but perhaps a constant factor
 slower than the previous solution.
 
 Note that the following solution assumes knowledge of a basic PURQ data
 structure for RMQ (range max query). Suitable implementations include a segment
-tree or a modified Fenwick tree, but both of these are generally considered
-Platinum level topics. However, this solution has the advantage of being more
-intuitive if you're deriving LIS on the spot.
+tree or a modified Fenwick tree, both of which are covered in the later Gold
+module [Point Update Range Sum](/gold/PURS). However, this solution has the
+advantage of being more intuitive if you're deriving LIS on the spot.
 
 Let $\texttt{dp}[k]$ be the length of the LIS of $a$ that ends with the element
 $k \in a$. Our base case is obviously $\texttt{dp}[a[0]] = 1$ (we have an LIS
@@ -256,6 +256,8 @@ technique: it suffices to collect the array elements and sort them to coordinate
 compress, creating $\texttt{dp}$ with those compressed IDs instead.
 
 The implementation follows:
+
+<Spoiler title="Implementation">
 
 <LanguageSection>
 <CPPSection>
@@ -448,6 +450,10 @@ def find_lis(a: List[int]) -> int:
 
 </PySection>
 </LanguageSection>
+
+</Spoiler>
+
+</Optional>
 
 ## Example - PCB
 

--- a/content/4_Gold/LIS.mdx
+++ b/content/4_Gold/LIS.mdx
@@ -1,6 +1,6 @@
 ---
 id: lis
-title: '(Optional) Longest Increasing Subsequence'
+title: 'Longest Increasing Subsequence'
 author: Michael Cao, Benjamin Qi, Andi Qu, Andrew Wang
 contributors: Dong Liu, Siyong Huang, Aryansh Shrivastava, Kevin Sheng, Katja Frantzen
 prerequisites:

--- a/content/4_Gold/MST.mdx
+++ b/content/4_Gold/MST.mdx
@@ -9,7 +9,7 @@ prerequisites:
 description:
   'Finding a subset of the edges of a connected, undirected, edge-weighted graph that
   connects all the vertices to each other of minimum total weight.'
-frequency: 2
+frequency: 1
 ---
 
 To review a couple of terms:

--- a/content/4_Gold/Meet_In_The_Middle.mdx
+++ b/content/4_Gold/Meet_In_The_Middle.mdx
@@ -1,6 +1,6 @@
 ---
 id: meet-in-the-middle
-title: 'Meet In The Middle'
+title: '(Optional) Meet In The Middle'
 author: Chongtian Ma
 description:
   'Problems involving dividing the search space into two.'

--- a/content/4_Gold/Shortest_Paths.mdx
+++ b/content/4_Gold/Shortest_Paths.mdx
@@ -6,7 +6,6 @@ title: 'Shortest Paths with Non-Negative Edge Weights'
 author: Benjamin Qi, Andi Qu, Qi Wang, Neo Wang
 prerequisites:
   - unweighted-shortest-paths
-  - custom-cpp-stl
 description: 'Bellman-Ford, Floyd-Warshall, and Dijkstra.'
 frequency: 2
 ---

--- a/content/4_Gold/Sliding_Window.mdx
+++ b/content/4_Gold/Sliding_Window.mdx
@@ -9,7 +9,7 @@ prerequisites:
   - intro-sorted-sets
   - two-pointers
 description: 'Maintaining data over consecutive subarrays.'
-frequency: 2
+frequency: 3
 ---
 
 ## Sliding Window

--- a/content/4_Gold/Stacks.mdx
+++ b/content/4_Gold/Stacks.mdx
@@ -7,7 +7,7 @@ description:
   'A data structure that only allows insertion and deletion at one end.'
 prerequisites:
   - intro-ds
-frequency: 1
+frequency: 2
 ---
 
 <Resources>

--- a/content/4_Gold/Tree_Euler.mdx
+++ b/content/4_Gold/Tree_Euler.mdx
@@ -1,6 +1,6 @@
 ---
 id: tree-euler
-title: 'Euler Tour Technique'
+title: '(Optional) Euler Tour Technique'
 author: Benjamin Qi, Andrew Wang, Neo Wang
 prerequisites:
   - intro-tree

--- a/content/4_Gold/Unweighted_Shortest_Paths.mdx
+++ b/content/4_Gold/Unweighted_Shortest_Paths.mdx
@@ -10,7 +10,7 @@ description:
   'Introduces how BFS can be used to find shortest paths in unweighted graphs.'
 redirects:
   - /gold/bfs
-frequency: 2
+frequency: 3
 ---
 
 ## Unweighted Shortest Path

--- a/content/extraProblems.json
+++ b/content/extraProblems.json
@@ -2193,7 +2193,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["0/1 Principle", "DP", "Sorting"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1473"
@@ -2384,7 +2384,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Combinatorics", "Modular Arithmetic"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1521"
@@ -2397,7 +2397,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Sqrt"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1522"
@@ -2449,7 +2449,7 @@
       "source": "Gold",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Connected Components"],
+      "tags": ["DSU"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2494,26 +2494,13 @@
       }
     },
     {
-      "uniqueId": "usaco-1545",
-      "name": "COW Traversals",
-      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1545",
-      "source": "Gold",
-      "difficulty": "N/A",
-      "isStarred": false,
-      "tags": [],
-      "solutionMetadata": {
-        "kind": "USACO",
-        "usacoId": "1545"
-      }
-    },
-    {
       "uniqueId": "usaco-1546",
       "name": "Milk Buckets",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1546",
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["PURS"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1546"
@@ -2526,7 +2513,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["DP", "Prefix Sums", "Two Pointers"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1547"
@@ -2639,7 +2626,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Binary Search", "Sorting"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1569"
@@ -2652,7 +2639,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["BFS"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1570"
@@ -2665,7 +2652,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Functional Graph"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1571"
@@ -2780,7 +2767,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["PURS", "Stack"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1593"
@@ -2793,7 +2780,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["BFS"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1594"
@@ -2806,7 +2793,7 @@
       "source": "Gold",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Modular Arithmetic", "Probability", "Rerooting", "Tree"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1595"

--- a/content/extraProblems.json
+++ b/content/extraProblems.json
@@ -1818,7 +1818,7 @@
       "source": "Bronze",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Sorting"],
       "solutionMetadata": {
         "kind": "internal",
         "usacoId": "1397"
@@ -2104,7 +2104,7 @@
       "source": "Bronze",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Math"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2116,7 +2116,7 @@
       "source": "Bronze",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Simulation"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2245,7 +2245,7 @@
       "source": "Bronze",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Greedy", "Map"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2282,7 +2282,7 @@
       "source": "Silver",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Number Theory"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2346,7 +2346,7 @@
       "source": "Bronze",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Greedy", "Map"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2526,7 +2526,7 @@
       "source": "Silver",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Simulation"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2538,7 +2538,7 @@
       "source": "Silver",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Connected Components", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2563,7 +2563,7 @@
       "source": "Bronze",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Constructive", "Strings"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2678,7 +2678,7 @@
       "source": "Silver",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Queue", "Simulation"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1567"
@@ -2716,7 +2716,7 @@
       "source": "Bronze",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Bitmasks", "Complete Search"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2806,7 +2806,7 @@
       "source": "Silver",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Binary Search", "Priority Queue"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1590"
@@ -2819,7 +2819,7 @@
       "source": "Silver",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Sorted Set"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1591"
@@ -2845,7 +2845,7 @@
       "source": "Bronze",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Greedy", "Sorting"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -2857,7 +2857,7 @@
       "source": "Bronze",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Bitwise", "Math"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/extraProblems.json
+++ b/content/extraProblems.json
@@ -2544,43 +2544,6 @@
       }
     },
     {
-      "uniqueId": "usaco-1539",
-      "name": "Chip Exchange",
-      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1539",
-      "source": "Bronze",
-      "difficulty": "N/A",
-      "isStarred": false,
-      "tags": [],
-      "solutionMetadata": {
-        "kind": "USACO",
-        "usacoId": "1539"
-      }
-    },
-    {
-      "uniqueId": "usaco-1540",
-      "name": "COW Splits",
-      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1540",
-      "source": "Bronze",
-      "difficulty": "N/A",
-      "isStarred": false,
-      "tags": ["Constructive", "Strings"],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
-      "uniqueId": "usaco-1541",
-      "name": "Photoshoot",
-      "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1541",
-      "source": "Bronze",
-      "difficulty": "N/A",
-      "isStarred": false,
-      "tags": [],
-      "solutionMetadata": {
-        "kind": "internal"
-      }
-    },
-    {
       "uniqueId": "usaco-1572",
       "name": "Circle of Cows",
       "url": "https://usaco.org/index.php?page=viewproblem2&cpid=1572",
@@ -2869,7 +2832,7 @@
       "source": "Bronze",
       "difficulty": "N/A",
       "isStarred": false,
-      "tags": [],
+      "tags": ["Constructive"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1589"

--- a/content/ordering.ts
+++ b/content/ordering.ts
@@ -171,7 +171,7 @@ const MODULE_ORDERING: { [key in SectionID]: Chapter[] } = {
     {
       name: 'Additional Topics',
       description: 'Rarely required.',
-      items: ['hashing', 'hashmaps', 'meet-in-the-middle', 'ternary-search'],
+      items: ['ternary-search', 'hashing', 'hashmaps', 'meet-in-the-middle'],
     },
     {
       name: 'Conclusion',

--- a/solutions/advanced/usaco-949.mdx
+++ b/solutions/advanced/usaco-949.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-949
-source: USACO Open 2019 Open
+source: USACO Platinum 2019 US Open
 title: Compound Escape
 author: Benjamin Qi
 ---

--- a/solutions/bronze/usaco-1228.mdx
+++ b/solutions/bronze/usaco-1228.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1228
-source: USACO Bronze 2022 Open
+source: USACO Bronze 2022 US Open
 title: Counting Liars
 author: Chongtian Ma, Juheon Rhee
 ---

--- a/solutions/bronze/usaco-1323.mdx
+++ b/solutions/bronze/usaco-1323.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1323
-source: USACO Bronze 2023 Open
+source: USACO Bronze 2023 US Open
 title: FEB
 author: Nathan Wang
 ---

--- a/solutions/bronze/usaco-1444.mdx
+++ b/solutions/bronze/usaco-1444.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1444
-source: USCAO Bronze December 2024
+source: USACO Bronze 2024 December
 title: Farmer John's Cheese Block
 author: Arnav Gokhale
 ---

--- a/solutions/bronze/usaco-1515.mdx
+++ b/solutions/bronze/usaco-1515.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1515
-source: 2025 US Open Bronze
+source: USACO Bronze 2025 US Open
 title: Hoof Paper Scissors Minus One
 author: Aarav Sethi, James Li
 ---

--- a/solutions/bronze/usaco-1541.mdx
+++ b/solutions/bronze/usaco-1541.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1541
-source: USACO 2026 First Contest
+source: USACO Bronze 2026 First Contest
 title: Photoshoot
 author: Arnav Gokhale
 ---

--- a/solutions/bronze/usaco-509.mdx
+++ b/solutions/bronze/usaco-509.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-509
-source: Old Bronze
+source: USACO Old Bronze 2015 January
 title: It's All About the Base
 author: Justin Ji
 ---

--- a/solutions/bronze/usaco-639.mdx
+++ b/solutions/bronze/usaco-639.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-639
-source: USACO Bronze 2016 Open
+source: USACO Bronze 2016 US Open
 title: Diamond Collector
 author: Danh Ta Chi Thanh, Ryan Chou, Rameez Parwez
 ---

--- a/solutions/bronze/usaco-640.mdx
+++ b/solutions/bronze/usaco-640.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-640
-source: USACO Bronze 2016 Open
+source: USACO Bronze 2016 US Open
 title: Bull in a China Shop
 author: Maggie Liu, David Zhang
 ---

--- a/solutions/bronze/usaco-735.mdx
+++ b/solutions/bronze/usaco-735.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-735
-source: USACO Bronze 2017 Open
+source: USACO Bronze 2017 US Open
 title: The Lost Cow
 author: Jesse Choe, Ananth Kashyap, Brad Ma, Rameez Parwez
 ---

--- a/solutions/bronze/usaco-831.mdx
+++ b/solutions/bronze/usaco-831.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-831
-source: USACO Bronze 2018 Open
+source: USACO Bronze 2018 US Open
 title: Team Tic Tac Toe
 author: Jesse Choe, Kevin Sheng, Benjamin Qi, Brad Ma, Qian Qian, Jay Fu
 ---

--- a/solutions/bronze/usaco-833.mdx
+++ b/solutions/bronze/usaco-833.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-833
-source: USACO Bronze 2018 Open
+source: USACO Bronze 2018 US Open
 title: Family Tree
 author: Danh Ta Chi Thanh, Ryan Chou, Chuyang Wang, Kevin Sheng, Amogha Pokkulandra
 ---

--- a/solutions/bronze/usaco-917.mdx
+++ b/solutions/bronze/usaco-917.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-917
-source: USACO Bronze February 2019
+source: USACO Bronze 2019 February
 title: Measuring Traffic
 author: Brad Ma, Kevin Sheng, Jay Fu
 ---

--- a/solutions/bronze/usaco-940.mdx
+++ b/solutions/bronze/usaco-940.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-940
-source: USACO Bronze 2019 Open
+source: USACO Bronze 2019 US Open
 title: Milk Factory
 author: Mrinall Umasudhan, Jesse Choe, Ryan Chou, Chuyang Wang, David Eidenas, Neo Wang, David Guo
 ---

--- a/solutions/bronze/usaco-941.mdx
+++ b/solutions/bronze/usaco-941.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-941
-source: USACO Bronze 2019 Open
+source: USACO Bronze 2019 US Open
 title: Cow Evolution
 author: Jesse Choe, Ryan Chou, Chuyang Wang, Vivian Han
 ---

--- a/solutions/general/usaco-939.mdx
+++ b/solutions/general/usaco-939.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-939
-source: USACO Bronze 2019 Open
+source: USACO Bronze 2019 US Open
 title: Bucket Brigade
 author: Maggie Liu
 ---

--- a/solutions/gold/usaco-1045.mdx
+++ b/solutions/gold/usaco-1045.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1045
-source: USACO Open 2020
+source: USACO Platinum 2020 US Open
 title: Exercise (Platinum)
 author: Benjamin Qi
 ---

--- a/solutions/gold/usaco-1138.mdx
+++ b/solutions/gold/usaco-1138.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1138
-source: USACO Gold 2021 Open
+source: USACO Gold 2021 US Open
 title: Portals
 author: Maggie Liu, David Guo
 ---

--- a/solutions/gold/usaco-1234.mdx
+++ b/solutions/gold/usaco-1234.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1234
-source: USACO Gold 2022 Open
+source: USACO Gold 2022 US Open
 title: Pair Programming
 author: Daniel Zhu
 ---

--- a/solutions/gold/usaco-1235.mdx
+++ b/solutions/gold/usaco-1235.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1235
-source: USACO Gold 2022 Open
+source: USACO Gold 2022 US Open
 title: Balancing a Tree
 author: Daniel Zhu
 ---

--- a/solutions/gold/usaco-1498.mdx
+++ b/solutions/gold/usaco-1498.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1498
-source: Gold
+source: USACO Gold 2025 February
 title: The Best Subsequence
 author: Justin Ji
 ---

--- a/solutions/gold/usaco-265.mdx
+++ b/solutions/gold/usaco-265.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-265
-source: Old Gold
+source: USACO Old Gold 2013 March
 title: The Cow Run
 author: Ryan Chou
 ---

--- a/solutions/gold/usaco-282.mdx
+++ b/solutions/gold/usaco-282.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-282
-source: USACO Silver 2013 Open
+source: USACO Old Silver 2013 US Open
 title: What's Up With Gravity
 author: Chuyang Wang
 ---

--- a/solutions/gold/usaco-494.mdx
+++ b/solutions/gold/usaco-494.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-494
-source: Old Gold
+source: USACO Old Gold 2014 December
 title: Guard Mark
 author: Ryan Chou, Sofia Yang
 ---

--- a/solutions/gold/usaco-553.mdx
+++ b/solutions/gold/usaco-553.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-553
-source: USACO Gold 2015 Open
+source: USACO Gold 2015 US Open
 title: Palindromic Paths
 author: Maggie Liu
 ---

--- a/solutions/gold/usaco-646.mdx
+++ b/solutions/gold/usaco-646.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-646
-source: USACO Gold 2016 Open
+source: USACO Gold 2016 US Open
 title: Closing the Farm
 author: Nathan Gong, Melody Yu, George Pong
 ---

--- a/solutions/gold/usaco-647.mdx
+++ b/solutions/gold/usaco-647.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-647
-source: USACO Gold 2016 Open
+source: USACO Gold 2016 US Open
 title: '248'
 author: Melody Yu, Qi Wang, Rohak Debnath
 ---

--- a/solutions/gold/usaco-673.mdx
+++ b/solutions/gold/usaco-673.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-673
-source: USACO Plat 2016 December
+source: USACO Platinum 2016 December
 title: Team Building
 author: Ryan Chou
 ---

--- a/solutions/gold/usaco-741.mdx
+++ b/solutions/gold/usaco-741.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-741
-source: USACO Gold 2017 Open
+source: USACO Gold 2017 US Open
 title: Bovine Genomics
 author: Benjamin Qi
 ---

--- a/solutions/gold/usaco-743.mdx
+++ b/solutions/gold/usaco-743.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-743
-source: USACO Silver 2017 Open
+source: USACO Gold 2017 US Open
 title: Modern Art 2
 author: Sofia Yang, William Yuan
 ---

--- a/solutions/gold/usaco-838.mdx
+++ b/solutions/gold/usaco-838.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-838
-source: USACO Gold 2018 Open
+source: USACO Gold 2018 US Open
 title: Milking Order
 author: Timothy Gao, Qi Wang, Melody Yu, Neo Wang
 ---

--- a/solutions/gold/usaco-839.mdx
+++ b/solutions/gold/usaco-839.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-839
-source: USACO Gold 2018 Open
+source: USACO Gold 2018 US Open
 title: Talent Show
 author: Arpan Banerjee
 ---

--- a/solutions/gold/usaco-946.mdx
+++ b/solutions/gold/usaco-946.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-946
-source: USACO Gold 2019 Open
+source: USACO Gold 2019 US Open
 title: I Would Walk 500 Miles
 author: Benjamin Qi, Aryansh Shrivastava, Chuyang Wang
 ---

--- a/solutions/gold/usaco-950.mdx
+++ b/solutions/gold/usaco-950.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-950
-source: USACO Platinum 2019 Open
+source: USACO Platinum 2019 US Open
 title: Valleys
 author: Benjamin Qi
 ---

--- a/solutions/platinum/usaco-1044.mdx
+++ b/solutions/platinum/usaco-1044.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1044
-source: USACO Open 2020
+source: USACO Platinum 2020 US Open
 title: Sprinklers 2
 author: Benjamin Qi
 ---

--- a/solutions/platinum/usaco-816.mdx
+++ b/solutions/platinum/usaco-816.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-816
-source: USACO Platinum February 2018
+source: USACO Platinum 2018 February
 title: Slingshot
 author: Justin Ji
 ---

--- a/solutions/platinum/usaco-842.mdx
+++ b/solutions/platinum/usaco-842.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-842
-source: USACO Platinum Open 2018
+source: USACO Platinum 2018 US Open
 title: Disruption
 author: Akshaj Arora
 ---

--- a/solutions/platinum/usaco-948.mdx
+++ b/solutions/platinum/usaco-948.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-948
-source: USACO Platinum 2019 Open
+source: USACO Platinum 2019 US Open
 title: Tree Boxes
 author: Justin Ji
 ---

--- a/solutions/silver/usaco-1110.mdx
+++ b/solutions/silver/usaco-1110.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1110
-source: USACO Silver 2021 Feburary
+source: USACO Silver 2021 February
 title: Comfortable Cows
 author: Arnav Gokhale
 ---

--- a/solutions/silver/usaco-1134.mdx
+++ b/solutions/silver/usaco-1134.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1134
-source: USACO Silver 2021 Open
+source: USACO Silver 2021 US Open
 title: Maze Tac Toe
 author: Ruben Jing
 ---

--- a/solutions/silver/usaco-1230.mdx
+++ b/solutions/silver/usaco-1230.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1230
-source: USACO Silver 2022 Open
+source: USACO Silver 2022 US Open
 title: Visits
 author: Aditya Gupta, Chuyang Wang
 ---

--- a/solutions/silver/usaco-1233.mdx
+++ b/solutions/silver/usaco-1233.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1233
-source: USACO Gold 2022 Open
+source: USACO Gold 2022 US Open
 title: Apple Catching
 author: Qi Wang
 ---

--- a/solutions/silver/usaco-1326.mdx
+++ b/solutions/silver/usaco-1326.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1326
-source: USACO Silver 2023 Open
+source: USACO Silver 2023 US Open
 title: Milk Sum
 author: Sachet Abeysinghe
 ---

--- a/solutions/silver/usaco-1327.mdx
+++ b/solutions/silver/usaco-1327.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-1327
-source: USACO Silver 2023 Open
+source: USACO Silver 2023 US Open
 title: Field Day
 author: Ryan Chou, David Guo
 ---

--- a/solutions/silver/usaco-284.mdx
+++ b/solutions/silver/usaco-284.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-284
-source: Old Silver 2013 Open
+source: USACO Old Silver 2013 US Open
 title: Luxury River Cruise
 author: Justin Ji
 ---

--- a/solutions/silver/usaco-643.mdx
+++ b/solutions/silver/usaco-643.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-643
-source: USACO Silver 2016 Open
+source: USACO Silver 2016 US Open
 title: Diamond Collector
 author: Nathan Wang, Albert Ye, David Guo
 ---

--- a/solutions/silver/usaco-644.mdx
+++ b/solutions/silver/usaco-644.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-644
-source: USACO Silver 2016 Open
+source: USACO Silver 2016 US Open
 title: Closing the Farm
 author: Jesse Choe, Maggie Liu, Nathan Gong, Ryan Chou
 ---

--- a/solutions/silver/usaco-645.mdx
+++ b/solutions/silver/usaco-645.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-645
-source: USACO Gold 2016 Open
+source: USACO Gold 2016 US Open
 title: Splitting the Field
 author: Óscar Garries, Benjamin Qi, Ryan Chou
 ---

--- a/solutions/silver/usaco-810.mdx
+++ b/solutions/silver/usaco-810.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-810
-source: USACO Silver 2018 Silver
+source: USACO Silver 2018 February
 title: Rest Stops
 author: Vivian Han, Kevin Sheng
 ---

--- a/solutions/silver/usaco-835.mdx
+++ b/solutions/silver/usaco-835.mdx
@@ -1,6 +1,6 @@
 ---
 id: usaco-835
-source: USACO Silver 2018 Open
+source: USACO Silver 2018 US Open
 title: Lemonade Line
 author: Mrinall Umasudhan, Ryan Chou
 ---

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,7 +6,7 @@ import 'katex/dist/katex.min.css';
 import type { AppProps } from 'next/app';
 import { Inter } from 'next/font/google';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import 'react-calendar-heatmap/dist/styles.css';
 import { Toaster } from 'react-hot-toast';
 import 'tippy.js/animations/scale-subtle.css';
@@ -33,11 +33,18 @@ const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? '';
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
+  // `useRouter()` returns a fresh object each render with `asPath` copied onto
+  // it, so capturing it in a mount-only effect freezes the path at first load
+  // and every hot reload would navigate back there. Read it at fire time
+  // instead. `router.replace` is proxied to the live router, so it is safe to
+  // close over.
+  const asPathRef = useRef(router.asPath);
+  asPathRef.current = router.asPath;
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_WATCH_RELOAD !== '1') return;
     const es = new EventSource('http://localhost:3001');
     es.onmessage = () =>
-      router.replace(router.asPath, undefined, { scroll: false });
+      router.replace(asPathRef.current, undefined, { scroll: false });
     es.onerror = () => {};
     return () => es.close();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Problem tagging, module frequency adjustments, a solution metadata cleanup, a readability fix in the LIS module, and one dev-server bug.

## Tagging

Tags every USACO Gold problem from 2024 through 2026 in `extraProblems.json`, plus a batch of Bronze and Silver. Nine of the Bronze/Silver tags are derived from reading the internal solutions; the rest are direct classifications.

| Division | Untagged since 2024, before | After |
|---|---|---|
| Gold | 9 / 30 | **0 / 30** |
| Bronze | 19 / 30 | 9 / 30 |
| Silver | 15 / 30 | 9 / 30 |

Most of what remains has no solution file to derive from. Three problems are deliberately left untagged — Majority Opinion (1371), Photoshoot (1541) and It's Mooin' Time IV (1563) are observation problems with no clean technique, matching the convention in the Bronze `ad-hoc` module, whose problems carry no tags.

Also removes a duplicate `usaco-1545` entry, the only duplicated `uniqueId` in the file, and introduces one new tag, `Queue`, for Declining Invitations — the repo had `Priority Queue` and `Deque` but nothing for a plain FIFO queue.

## Optional modules

Marks `meet-in-the-middle` and `tree-euler` optional:

| Module | Total appearances | Last |
|---|---|---|
| `meet-in-the-middle` | 1 | 2022 February (**Silver**; never in Gold) |
| `tree-euler` | 2 | 2019 February |


Drops the `custom-cpp-stl` prerequisite from `shortest-paths`. `custom-cpp-stl` was already optional while `shortest-paths` is required, so an optional module was a prerequisite of a required one in the same division. The module body never referenced custom comparators. After this change, no division has that pattern.

Moves `ternary-search` to the front of Gold's Additional Topics — it is now the only required module in that chapter, having appeared in 2023 December.

Moves OohMoo Milk and Cowdependence from `silver-conclusion` to `gold-conclusion`; both are Gold problems. Adds the three 2026 First Contest Bronze problems to the Ad Hoc module.

## Frequencies

Based on USACO appearances since 2023, counted by tag and by module membership, and including lower-division appearances.

**Bronze** — `intro-greedy` 3→4, `ad-hoc` 2→4, `intro-sets` 2→3, `complete-rec` 1→2, `simulation` 4→3, `intro-graphs` 2→1

**Silver** — `greedy-sorting` 3→4, `binary-search` 3→4, `prefix-sums` 3→4, `priority-queues` 2→3, `intro-tree` 2→3, `flood-fill` 3→2, `func-graphs` 2→1, `more-prefix-sums` 2→1

**Gold** — `sliding-window` 2→3, `stacks` 1→2, `unweighted-shortest-paths` 2→3, `knapsack` 2→1, `mst` 2→1

`ad-hoc` going to 4 deserves explanation: its old value measured how many problems had been *added to the module*, not how often ad hoc problems appear in contests. Of the 30 Bronze problems since 2024, 22 sit in no module at all and 9 are neither tagged nor placed — roughly one per contest, which is what frequency 4 denotes.

`sliding-window` counts `Two Pointers` alongside `Sliding Window`, since recent Gold problems using the technique are tagged with the former.

## LIS module

The second `### Fast Solution (RMQ Data Structures)` is moved out of the main flow. It is the same O(N log N) as the solution above it, explicitly "perhaps a constant factor slower," and needs a PURQ structure plus coordinate compression the reader has not met — `PURS` is a *later* Gold module, in the Data Structures chapter.

It is not deleted, because `ac-suitableeditforlis` in this module's own problem list opens with "We can solve this problem with the segment tree LIS technique." Instead it is wrapped in `<Optional>`, with the 191 lines of segment tree implementations behind a `<Spoiler>` — ~40 visible lines instead of 231.

Also corrects the claim that segment trees and Fenwick trees are "generally considered Platinum level topics." Both are covered in Gold's `PURS`, which the text now links.

## Dev server

Fixes a stale closure in the hot-reload handler in `src/pages/_app.tsx`. `useRouter()` returns a fresh object each render with `asPath` **copied** onto it (see `makePublicRouterInstance` in `next/dist/client/router.js`), so capturing it in a mount-only effect froze the path at first page load. Every rebuild then navigated back to wherever the browser first landed instead of staying on the current page. The path is now read at fire time via a ref; `router.replace` is proxied to the live router, so closing over it is safe.

## Solution metadata

Fixes 17 malformed `source:` lines, including a `USCAO` typo, a `Feburary` typo, a bare `Gold` with no contest, and two problems labeled with the wrong division (`usaco-743` is Gold, not Silver; `usaco-282` predates the modern divisions and is Old Silver). Divisions and contests were verified against `div_to_probs.json`; the four Old-division contests were verified against usaco.org.

Normalizes 31 sources from `<year> Open` to `<year> US Open`, the more common form (34 vs 31).

Moves `solutions/silver/usaco-1541.mdx` to `solutions/bronze/` — it is a Bronze problem and links the bronze official analysis. Solutions are indexed recursively by frontmatter `id`, so the directory is organizational only and no URLs change.

## Known limitations

Six Gold modules can't be measured by this method — `intro-dp`, `paths-grids`, `dp-trees`, `digit-dp`, `custom-cpp-stl`, `hashmaps` — along with `sorting-custom` and `binary-search-sorted-array` in Silver. Their only tags are generic (`DP`, `Tree`, `Sorting`, `Binary Search`) and belong to sibling modules, so tag matching cannot distinguish them. Their counts are floors, not estimates, and their frequencies are left unchanged. Notably `intro-dp` remains at 4 unverified.

Counts for modules that do own a distinctive tag are still floors wherever recent problems went untagged; `PURS` showing a five-year gap between 2020 and 2026 is an artifact of that, not a real absence, which is why it was left at 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQEdmRp21nuvwACTcDcALU
