### PR TITLE
Small tag fixes: rehome Monocarp, mark Cow Poetry's exponentiation, drop LCM

### DIFF
--- a/content/4_Gold/Conclusion.problems.json
+++ b/content/4_Gold/Conclusion.problems.json
@@ -156,6 +156,19 @@
       }
     },
     {
+      "uniqueId": "cf-1886D",
+      "name": "Monocarp and the Set",
+      "url": "https://codeforces.com/contest/1886/problem/D",
+      "source": "CF",
+      "difficulty": "Easy",
+      "isStarred": false,
+      "tags": ["Modular Arithmetic"],
+      "solutionMetadata": {
+        "kind": "autogen-label-from-site",
+        "site": "CF"
+      }
+    },
+    {
       "uniqueId": "cf-2244G",
       "name": "Yura and Deadlines",
       "url": "https://codeforces.com/contest/2244/problem/G",

--- a/content/4_Gold/Divisibility.problems.json
+++ b/content/4_Gold/Divisibility.problems.json
@@ -175,7 +175,7 @@
       "source": "SPOJ",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Divisibility", "Euler Totient", "LCM"],
+      "tags": ["Divisibility", "Euler Totient"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/4_Gold/Knapsack_DP.problems.json
+++ b/content/4_Gold/Knapsack_DP.problems.json
@@ -222,7 +222,7 @@
       "source": "Gold",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Exponentiation", "Knapsack"],
+      "tags": ["Exponentiation", "Knapsack", "Modular Arithmetic"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/DP_More.problems.json
+++ b/content/6_Advanced/DP_More.problems.json
@@ -66,19 +66,6 @@
       }
     },
     {
-      "uniqueId": "cf-1886D",
-      "name": "Monocarp and the Set",
-      "url": "https://codeforces.com/contest/1886/problem/D",
-      "source": "CF",
-      "difficulty": "Easy",
-      "isStarred": false,
-      "tags": ["DP"],
-      "solutionMetadata": {
-        "kind": "autogen-label-from-site",
-        "site": "CF"
-      }
-    },
-    {
       "uniqueId": "ceoi-16-kangaroo",
       "name": "2016 - Kangaroo",
       "url": "https://qoj.ac/contest/1107/problem/5532",


### PR DESCRIPTION
Three one-line tag fixes noticed while checking the loose ends from #6606.

**Monocarp and the Set** was in the connected component section of Additional DP Optimizations and Techniques; it now sits at the end of the Easy block in the Gold conclusion, retagged **Modular Arithmetic** rather than DP. That `DP` came from #6606 tagging every entry in the module it is leaving, and there is no solution in the repo to check it against — the problem's only link is autogenerated from Codeforces.

**Cow Poetry** gains **Modular Arithmetic** alongside its existing Exponentiation and Knapsack. It is the one use of `Exponentiation` in the guide that is not matrix exponentiation: the other ten all sit in the Matrix Expo module paired with `Matrix`, while this one raises a scalar to a power mod p — its code carries the module's modular exponentiation snippet and calls `pow(total[j], groups[i], MOD)`. The tag now says which kind it means.

**LCM Sum** loses **LCM**. That was the tag's only use, on a problem that already carries `Divisibility` — which is also the module it sits in. What remains is `Divisibility, Euler Totient`, the same pair as GCDEX beside it, which is the same shape of problem: a sum over pairs evaluated through the totient. The tag leaves the vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rq8Gabr1f1YSh8qBXZpBi