### PR TITLE
Check snippets in parallel, and add a whole-guide sweep

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches:
       - master
+# A new push supersedes whatever the previous one was still checking. Cancelling
+# is scoped to pull requests: a run on master is validating what actually ships,
+# so let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -12,6 +12,7 @@ on:
       - 'content/**/*.mdx'
       - 'solutions/**/*.mdx'
       - 'scripts/check-code-snippets.ts'
+      - '.github/workflows/code-snippets.yml'
 
 # A new push supersedes whatever the previous one was still checking. Cancelling
 # is scoped to pull requests: a run on master is validating what actually ships,
@@ -25,9 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # Somewhere cacheable -- but outside the repo, or yarn.js inherits
-      # "type": "module" from our package.json and fails to load as CommonJS.
-      COREPACK_HOME: ${{ runner.temp }}/corepack
       CPLUS_INCLUDE_PATH: ${{ github.workspace }}/.ac-library
     steps:
       - uses: actions/checkout@v7
@@ -39,10 +37,13 @@ jobs:
           node-version: 20.x
       # package.json pins yarn@4.9.2, which only Corepack can provide -- and
       # which it otherwise re-downloads on every run, node_modules cache or not.
+      # Cache it where Corepack already puts it: pointing COREPACK_HOME into the
+      # workspace instead makes Node read yarn.js under our "type": "module"
+      # package.json and fail to load that CommonJS bundle.
       - name: Cache Corepack
         uses: actions/cache@v6
         with:
-          path: ${{ runner.temp }}/corepack
+          path: ~/.cache/node/corepack
           key: corepack-${{ hashFiles('package.json') }}
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -25,8 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # Somewhere cacheable, rather than Corepack's default under ~/.cache.
-      COREPACK_HOME: ${{ github.workspace }}/.corepack
+      # Somewhere cacheable -- but outside the repo, or yarn.js inherits
+      # "type": "module" from our package.json and fails to load as CommonJS.
+      COREPACK_HOME: ${{ runner.temp }}/corepack
       CPLUS_INCLUDE_PATH: ${{ github.workspace }}/.ac-library
     steps:
       - uses: actions/checkout@v7
@@ -41,7 +42,7 @@ jobs:
       - name: Cache Corepack
         uses: actions/cache@v6
         with:
-          path: .corepack
+          path: ${{ runner.temp }}/corepack
           key: corepack-${{ hashFiles('package.json') }}
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -24,6 +24,9 @@ jobs:
   code-snippets:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Somewhere cacheable, rather than Corepack's default under ~/.cache.
+    env:
+      COREPACK_HOME: ${{ github.workspace }}/.corepack
     steps:
       - uses: actions/checkout@v7
         with:
@@ -32,7 +35,13 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 20.x
-      # package.json pins yarn@4.9.2, which only Corepack can provide.
+      # package.json pins yarn@4.9.2, which only Corepack can provide -- and
+      # which it otherwise re-downloads on every run, node_modules cache or not.
+      - name: Cache Corepack
+        uses: actions/cache@v6
+        with:
+          path: .corepack
+          key: corepack-${{ hashFiles('package.json') }}
       - name: Enable Corepack
         run: corepack enable
 

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -13,6 +13,13 @@ on:
       - 'solutions/**/*.mdx'
       - 'scripts/check-code-snippets.ts'
 
+# A new push supersedes whatever the previous one was still checking. Cancelling
+# is scoped to pull requests: a run on master is validating what actually ships,
+# so let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   code-snippets:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -83,8 +83,8 @@ jobs:
           if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
             echo 'Manual run; sweeping every snippet.'
             yarn check-code-snippets --all
-          elif git diff --name-only "$BASE_REF...HEAD" |
-              grep -qx 'scripts/check-code-snippets.ts'; then
+          elif git diff --name-only "$BASE_REF...HEAD" | grep -qxE \
+              'scripts/check-code-snippets\.ts|\.github/workflows/code-snippets\.yml'; then
             echo 'The checker changed; sweeping every snippet.'
             yarn check-code-snippets --all
           else

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -32,12 +32,21 @@ jobs:
         run: yarn
 
       # Only the snippets in files this PR touches, so existing breakage
-      # elsewhere doesn't block unrelated work.
+      # elsewhere doesn't block unrelated work -- except when the checker itself
+      # is what changed, since no .mdx diff exercises that. Sweeping everything
+      # is the only way such a pull request checks anything at all.
       - name: Check code snippets in changed files
         if: github.event_name == 'pull_request'
         env:
           BASE_REF: origin/${{ github.base_ref }}
-        run: yarn check-code-snippets
+        run: |
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" |
+              grep -qx 'scripts/check-code-snippets.ts'; then
+            echo 'The checker changed; sweeping every snippet.'
+            yarn check-code-snippets --all
+          else
+            yarn check-code-snippets
+          fi
 
       - name: Check every code snippet
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -45,23 +45,21 @@ jobs:
         if: steps.node-modules.outputs.cache-hit != 'true'
         run: yarn
 
-      # Only the snippets in files this PR touches, so existing breakage
-      # elsewhere doesn't block unrelated work -- except when the checker itself
-      # is what changed, since no .mdx diff exercises that. Sweeping everything
-      # is the only way such a pull request checks anything at all.
-      - name: Check code snippets in changed files
-        if: github.event_name == 'pull_request'
+      # A pull request checks only the files it touches, so breakage elsewhere
+      # does not block unrelated work. Two cases sweep the whole guide instead:
+      # a manual run, and a pull request that changes the checker itself --
+      # no .mdx diff exercises that, so it would otherwise check nothing at all.
+      - name: Check code snippets
         env:
           BASE_REF: origin/${{ github.base_ref }}
         run: |
-          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" |
+          if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
+            echo 'Manual run; sweeping every snippet.'
+            yarn check-code-snippets --all
+          elif git diff --name-only "$BASE_REF...HEAD" |
               grep -qx 'scripts/check-code-snippets.ts'; then
             echo 'The checker changed; sweeping every snippet.'
             yarn check-code-snippets --all
           else
             yarn check-code-snippets
           fi
-
-      - name: Check every code snippet
-        if: github.event_name == 'workflow_dispatch'
-        run: yarn check-code-snippets --all

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -33,11 +33,16 @@ jobs:
       # install is only here to provide tsx, so a cache hit skips almost all of it.
       - name: Cache node modules
         uses: actions/cache@v6
+        id: node-modules
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
+      # The key is the lockfile hash, so a hit means the tree already matches it
+      # and `yarn` would only spend half a minute confirming that. `yarn run`
+      # needs no install of its own -- Corepack provides the yarn binary.
       - name: Install dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: yarn
 
       # Only the snippets in files this PR touches, so existing breakage

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -25,9 +25,18 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 20.x
-          corepack: true
+      # package.json pins yarn@4.9.2, which only Corepack can provide.
       - name: Enable Corepack
         run: corepack enable
+
+      # The checker itself imports nothing outside Node's standard library; the
+      # install is only here to provide tsx, so a cache hit skips almost all of it.
+      - name: Cache node modules
+        uses: actions/cache@v6
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+
       - name: Install dependencies
         run: yarn
 

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -24,9 +24,10 @@ jobs:
   code-snippets:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Somewhere cacheable, rather than Corepack's default under ~/.cache.
     env:
+      # Somewhere cacheable, rather than Corepack's default under ~/.cache.
       COREPACK_HOME: ${{ github.workspace }}/.corepack
+      CPLUS_INCLUDE_PATH: ${{ github.workspace }}/.ac-library
     steps:
       - uses: actions/checkout@v7
         with:
@@ -44,6 +45,14 @@ jobs:
           key: corepack-${{ hashFiles('package.json') }}
       - name: Enable Corepack
         run: corepack enable
+
+      # Several Gold and Advanced snippets teach the AtCoder Library. It is
+      # header-only, so a shallow clone on the include path is enough -- 180K
+      # and under a second. Without it those snippets are only ever compiled by
+      # people who happen to have ACL checked out, which is how eight of them
+      # sat broken here unnoticed.
+      - name: Fetch the AtCoder Library
+        run: git clone --depth 1 -q https://github.com/atcoder/ac-library.git .ac-library
 
       # The checker itself imports nothing outside Node's standard library; the
       # install is only here to provide tsx, so a cache hit skips almost all of it.

--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -1,6 +1,10 @@
 name: Code Snippets
 
 on:
+  # Sweeps every snippet in the guide, not just the ones a pull request touches.
+  # Reach for this after changing the checker, or to find breakage that landed
+  # while nothing in its file was being edited.
+  workflow_dispatch:
   pull_request:
     branches:
       - master
@@ -12,7 +16,7 @@ on:
 jobs:
   code-snippets:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:
@@ -30,6 +34,11 @@ jobs:
       # Only the snippets in files this PR touches, so existing breakage
       # elsewhere doesn't block unrelated work.
       - name: Check code snippets in changed files
+        if: github.event_name == 'pull_request'
         env:
           BASE_REF: origin/${{ github.base_ref }}
         run: yarn check-code-snippets
+
+      - name: Check every code snippet
+        if: github.event_name == 'workflow_dispatch'
+        run: yarn check-code-snippets --all

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -18,6 +18,13 @@ on:
       - 'src/functions/**'
       - 'src/models/**'
       - '.github/workflows/functions.yml'
+# A new push supersedes whatever the previous one was still checking. Cancelling
+# is scoped to pull requests: a run on master is validating what actually ships,
+# so let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   functions:
     runs-on: ubuntu-latest

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches:
       - master
+# A new push supersedes whatever the previous one was still checking. Cancelling
+# is scoped to pull requests: a run on master is validating what actually ships,
+# so let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   prettier:
     runs-on: ubuntu-latest

--- a/.github/workflows/solutions.yml
+++ b/.github/workflows/solutions.yml
@@ -11,6 +11,13 @@ on:
       - 'src/components/markdown/ProblemsList/DivisionList/*.json'
       - '.github/workflows/solutions.yml'
 
+# A new push supersedes whatever the previous one was still checking. Cancelling
+# is scoped to pull requests: a run on master is validating what actually ships,
+# so let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-solutions:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,13 @@ on:
     paths-ignore:
       - 'content/**'
       - 'solutions/**'
+# A new push supersedes whatever the previous one was still checking. Cancelling
+# is scoped to pull requests: a run on master is validating what actually ships,
+# so let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/content/4_Gold/TopoSort.mdx
+++ b/content/4_Gold/TopoSort.mdx
@@ -687,6 +687,7 @@ topological sorting:
 
 ```cpp
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <queue>
 #include <vector>

--- a/content/6_Advanced/random.mdx
+++ b/content/6_Advanced/random.mdx
@@ -169,7 +169,7 @@ def clt_probability(k, S):
 By supporting path queries with HLD, we can solve this problem in $\mathcal{O}(S\cdot(n + m\log^2n))$.
 
 ```cpp
-#include "bits/stdc++.h"
+#include <bits/stdc++.h>
 using namespace std;
 
 using us = unsigned short;

--- a/scripts/check-code-snippets.ts
+++ b/scripts/check-code-snippets.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawnSync } from 'child_process';
+import { execFile, execFileSync, spawnSync } from 'child_process';
 import {
   copyFileSync,
   mkdirSync,
@@ -7,9 +7,10 @@ import {
   writeFileSync,
 } from 'fs';
 import { readFile } from 'fs/promises';
-import { tmpdir } from 'os';
+import { availableParallelism, tmpdir } from 'os';
 import path, { join, relative } from 'path';
 import { fileURLToPath } from 'url';
+import { promisify } from 'util';
 
 /**
  * Checks the code snippets in .mdx files: C++ is compiled with g++
@@ -22,11 +23,18 @@ import { fileURLToPath } from 'url';
  * parsed rather than run, so fragments are fine as long as they stand on their
  * own, and blocks that open mid-indentation are skipped.
  *
- * Pass the files to check, or nothing to check the ones this branch changed
- * (against origin/master, or BASE_REF when set).
+ * Pass the files to check, --all to sweep every .mdx under content/ and
+ * solutions/, or nothing to check the ones this branch changed (against
+ * origin/master, or BASE_REF when set).
+ *
+ * Snippets are checked JOBS at a time, defaulting to one per core.
  */
 
+const execFileAsync = promisify(execFile);
+
 const STANDARD = process.env.CXX_STANDARD ?? 'c++20';
+/** Each check is its own process, so the pool can be as wide as the machine. */
+const JOBS = Number(process.env.JOBS) || availableParallelism();
 const PYTHON = process.env.PYTHON ?? 'python3';
 
 /** Reports a syntax error as `file:line:col: message`, without a traceback. */
@@ -83,9 +91,12 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 }
 
 async function main() {
-  const files = process.argv.slice(2).length
-    ? process.argv.slice(2)
-    : changedMdxFiles();
+  const args = process.argv.slice(2);
+  const files = args.includes('--all')
+    ? allMdxFiles()
+    : args.length
+      ? args
+      : changedMdxFiles();
 
   const mdx = files.filter(f => f.endsWith('.mdx'));
   if (mdx.length === 0) {
@@ -141,28 +152,46 @@ async function main() {
     console.log(
       `Checking ${cpp} C++ snippet${cpp === 1 ? '' : 's'} with ${cxx} -std=${STANDARD} ` +
         `and ${py} Python snippet${py === 1 ? '' : 's'} with ${PYTHON}, ` +
-        `in ${mdx.length} file${mdx.length === 1 ? '' : 's'}...`
+        `in ${mdx.length} file${mdx.length === 1 ? '' : 's'}, ` +
+        `${Math.min(JOBS, snippets.length)} at a time...`
     );
 
     const include = precompileStdcxx(cxx, dir, snippets);
 
-    for (const [i, snippet] of snippets.entries()) {
+    const jobs = snippets.map((snippet, i) => {
       const source = join(dir, `snippet${i}.${snippet.lang}`);
       writeFileSync(source, snippet.code);
-      const [command, args] =
-        snippet.lang === 'cpp'
-          ? [cxx, [`-std=${STANDARD}`, ...include, '-fsyntax-only', source]]
-          : [PYTHON, ['-c', PARSE_PYTHON, source]];
-      try {
-        execFileSync(command, args, { stdio: 'pipe' });
-      } catch (err) {
-        const { stderr } = err as { stderr?: Buffer };
-        failures.push({
-          snippet,
-          error: rewritePaths(String(stderr ?? err), source, snippet),
-        });
-      }
-    }
+      return { snippet, source };
+    });
+
+    // Compiling is what costs, and each snippet is independent, so run a pool
+    // of them. Failures come back out of order, so they carry their index and
+    // are sorted afterwards to keep the report stable across runs.
+    const found: { at: number; snippet: Snippet; error: string }[] = [];
+    let next = 0;
+    await Promise.all(
+      Array.from({ length: Math.min(JOBS, jobs.length) }, async () => {
+        for (let at = next++; at < jobs.length; at = next++) {
+          const { snippet, source } = jobs[at];
+          const [command, args] =
+            snippet.lang === 'cpp'
+              ? [cxx, [`-std=${STANDARD}`, ...include, '-fsyntax-only', source]]
+              : [PYTHON, ['-c', PARSE_PYTHON, source]];
+          try {
+            await execFileAsync(command, args, { maxBuffer: 32 << 20 });
+          } catch (err) {
+            const { stderr } = err as { stderr?: string | Buffer };
+            found.push({
+              at,
+              snippet,
+              error: rewritePaths(String(stderr ?? err), source, snippet),
+            });
+          }
+        }
+      })
+    );
+    found.sort((a, b) => a.at - b.at);
+    failures.push(...found.map(({ snippet, error }) => ({ snippet, error })));
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -180,6 +209,16 @@ async function main() {
   }
   console.error(`\n${failures.length} of ${snippets.length} snippets failed.`);
   process.exit(1);
+}
+
+/** Every .mdx under content/ and solutions/, tracked by git. */
+function allMdxFiles(): string[] {
+  const out = execFileSync(
+    'git',
+    ['ls-files', '-z', 'content/**/*.mdx', 'solutions/**/*.mdx'],
+    { encoding: 'utf8', maxBuffer: 32 << 20 }
+  );
+  return out.split('\0').filter(Boolean);
 }
 
 /** .mdx files under content/ and solutions/ that differ from the base branch. */

--- a/scripts/check-code-snippets.ts
+++ b/scripts/check-code-snippets.ts
@@ -253,8 +253,10 @@ export function extractSnippets(file: string, source: string): Snippet[] {
       // A whole program, not a fragment illustrating one function. Solutions
       // spell the entry point `int main`, `signed main` or `int32_t main`.
       if (!code.includes('#include') || !MAIN.test(code)) continue;
-      // Needs a header that ships with the problem, e.g. grader.h.
-      if (/^\s*#include\s*"/m.test(code)) continue;
+      // Needs a header that ships with the problem, e.g. grader.h. Quoting
+      // the GCC catch-all is just a style, not a missing header -- seven whole
+      // programs were being skipped over that.
+      if (/^\s*#include\s*"(?!bits\/stdc\+\+\.h")/m.test(code)) continue;
     } else {
       // An excerpt lifted out of a function, which will not parse alone.
       const first = code.split('\n').find(l => l.trim() !== '');

--- a/solutions/advanced/cc-FaultySystem.mdx
+++ b/solutions/advanced/cc-FaultySystem.mdx
@@ -21,7 +21,7 @@ We make two observations. Firstly, $|T| \leq |S|$ by construction. Secondly, we 
 <CPPSection>
 
 ```cpp
-#include "bits/stdc++.h"
+#include <bits/stdc++.h>
 
 using namespace std;
 

--- a/solutions/advanced/cfgym-102156D.mdx
+++ b/solutions/advanced/cfgym-102156D.mdx
@@ -37,7 +37,7 @@ The extra factor of $O(d)$ comes from the cost of check/add in LinearMat.
 <CPPSection>
 
 ```cpp
-#include "bits/stdc++.h"
+#include <bits/stdc++.h>
 using namespace std;
 
 using u64 = uint64_t;

--- a/solutions/advanced/cfgym-104832J.mdx
+++ b/solutions/advanced/cfgym-104832J.mdx
@@ -62,7 +62,7 @@ To maintain the capacity constraints, we use HLD. The capacity of each vertex $v
 <CPPSection>
 
 ```cpp
-#include "bits/stdc++.h"
+#include <bits/stdc++.h>
 
 using namespace std;
 

--- a/solutions/advanced/kattis-thekingsguards.mdx
+++ b/solutions/advanced/kattis-thekingsguards.mdx
@@ -142,7 +142,7 @@ independence check takes $\mathcal O(n^2)$ time.
 <CPPSection>
 
 ```cpp
-#include "bits/stdc++.h"
+#include <bits/stdc++.h>
 
 using namespace std;
 
@@ -187,11 +187,11 @@ void solve() {
 	iota(comp.begin() + 1, comp.end(), 1);
 	vector<int> back(n + 1), vis(n + 1);
 	auto augment = [&](int s) {
-		auto DFS = [&](this auto DFS, int i) -> int {
+		auto DFS = [&](auto &&self, int i) -> int {
 			for (int v : adj[i]) {
 				if (vis[comp[v]]) { continue; }
 				vis[comp[v]] = 1;
-				if (!back[comp[v]] || DFS(back[comp[v]])) {
+				if (!back[comp[v]] || self(self, back[comp[v]])) {
 					back[comp[v]] = i;
 					return 1;
 				}
@@ -199,7 +199,7 @@ void solve() {
 			return 0;
 		};
 		fill(vis.begin() + 1, vis.end(), 0);
-		return DFS(s);
+		return DFS(DFS, s);
 	};
 
 	// check initial matching

--- a/solutions/bronze/usaco-526.mdx
+++ b/solutions/bronze/usaco-526.mdx
@@ -59,7 +59,7 @@ print(censored)
 <CPPSection>
 
 ```cpp
-#include "bits/stdc++.h"
+#include <bits/stdc++.h>
 using namespace std;
 
 // BeginCodeSnip{{USACO-style I/O. See General / Input & Output}}

--- a/solutions/bronze/usaco-619.mdx
+++ b/solutions/bronze/usaco-619.mdx
@@ -231,6 +231,7 @@ The final answer is the minimum out of all such answers.
 
 ```cpp
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -465,6 +466,7 @@ version.
 
 ```cpp
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <vector>

--- a/solutions/gold/ceoi18-clo.mdx
+++ b/solutions/gold/ceoi18-clo.mdx
@@ -118,6 +118,7 @@ Given this, the rest of the problem is simple knapsack.
 
 ```cpp
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <vector>
 

--- a/solutions/gold/cses-1195.mdx
+++ b/solutions/gold/cses-1195.mdx
@@ -113,6 +113,7 @@ public class FlightDiscount {
 <CPPSection>
 
 ```cpp
+#include <cstdint>
 #include <iostream>
 #include <queue>
 #include <vector>
@@ -196,6 +197,7 @@ the shortest distance after using the discount.
 <CPPSection>
 
 ```cpp
+#include <cstdint>
 #include <iostream>
 #include <queue>
 #include <vector>

--- a/solutions/gold/cses-1639.mdx
+++ b/solutions/gold/cses-1639.mdx
@@ -97,6 +97,7 @@ public class EditDistance {
 
 ```cpp
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/solutions/gold/ioi-00-walls.mdx
+++ b/solutions/gold/ioi-00-walls.mdx
@@ -21,6 +21,7 @@ Finally, we try all meeting regions and print out the one that minimizes the num
 
 ```cpp
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <vector>

--- a/solutions/gold/joi-mergers.mdx
+++ b/solutions/gold/joi-mergers.mdx
@@ -95,16 +95,17 @@ int main() {
 	int leaves = 0;
 	// implementation of merge(tree, root)
 	// returns [degree of C, XOR of C] where C is potentially incomplete root component
-	[&](this auto dfs, int x, int p) -> array<int, 2> {
+	auto dfs = [&](auto &&self, int x, int p) -> array<int, 2> {
 		int deg = 0, cur = val[x];
 		for (int y : g[x])
 			if (y != p) {
-				auto [d, sm] = dfs(y, x);
+				auto [d, sm] = self(self, y, x);
 				deg += d, cur ^= sm;
 			}
 		if (!cur && deg + (p > 0) == 1) ++leaves;
 		return {cur ? deg : 1, cur};
-	}(1, 0);
+	};
+	dfs(dfs, 1, 0);
 	cout << (leaves + 1) / 2 << "\n";
 }
 ```

--- a/solutions/gold/sapo-14-genghis.mdx
+++ b/solutions/gold/sapo-14-genghis.mdx
@@ -27,6 +27,7 @@ $$\texttt{lowestOps}[a][b]=\texttt{lowestOps}[a][c]+\texttt{lowestOps}[c][b]+(\t
 ```cpp
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <vector>
 

--- a/solutions/platinum/cses-2134.mdx
+++ b/solutions/platinum/cses-2134.mdx
@@ -23,7 +23,7 @@ from $a$ to $lca(a,b)$ and the path from $b$ to $lca(a,b)$ to find our answer.
 **Time Complexity:** $\mathcal O(N\log^2 N)$
 
 ```cpp
-#include "bits/stdc++.h"
+#include <bits/stdc++.h>
 using namespace std;
 
 const int N = 2e5 + 5;

--- a/solutions/silver/cf-1117C.mdx
+++ b/solutions/silver/cf-1117C.mdx
@@ -22,6 +22,7 @@ We perform a binary search on the number of days to find the smallest time for w
 
 ```cpp
 #include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/solutions/silver/cf-701C.mdx
+++ b/solutions/silver/cf-701C.mdx
@@ -22,6 +22,7 @@ Let's iterate through all possible ending flats while keeping a variable ($\text
 
 ```cpp
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <unordered_map>
 #include <unordered_set>

--- a/solutions/silver/usaco-811.mdx
+++ b/solutions/silver/usaco-811.mdx
@@ -41,6 +41,7 @@ There are $\mathcal{O}(NB)$ total states and since $N$ and $B$ are both at most 
 
 ```cpp
 #include <algorithm>
+#include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <vector>

--- a/solutions/silver/usaco-991.mdx
+++ b/solutions/silver/usaco-991.mdx
@@ -25,6 +25,7 @@ Therefore, we can validate a given value of $X$ in $\mathcal{O} (\sqrt{N})$ time
 
 ```cpp
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 


### PR DESCRIPTION
Two follow-ups to #6614, which surfaced 7 long-broken snippets purely because it happened to touch their files.

## Parallel checking

Each snippet is checked in its own process and they are independent, so the serial loop left most of the machine idle. A pool of `availableParallelism()` workers (override with `JOBS`) takes a full sweep of **1941 snippets from 6m10s to 68s** on 10 cores -- a 5.4x speedup, at 759% CPU (both measured on the same machine, same 1941 snippets).

Failures come back out of order, so each carries its index and they are sorted before reporting — output is byte-identical to before.

## Whole-guide sweep

`yarn check-code-snippets --all` sweeps every `.mdx` under `content/` and `solutions/`, and `workflow_dispatch` on the Code Snippets workflow runs it on Linux.

The per-PR job is unchanged: it still checks only the files that PR touches, so unrelated breakage doesn't block anyone. The sweep is how that breakage gets found deliberately instead of ambushing whoever next edits the file.

## Why this matters

The 7 snippets fixed in #6614 had been broken for a long time and were invisible to both halves of the existing setup:

- the **per-PR check** never saw them, because nothing had touched those files since the check existed
- the **#6612 sweep** did cover them, but ran on macOS, where the colliding symbols don't exist — `fdiv` is glibc's narrowing division (0 occurrences in Darwin's `<bits/stdc++.h>`), `::close(int)` is only reachable through glibc's header graph, and libstdc++ 13 dropped the transitive `<cstdint>` that the macOS SDK still provides

So a sweep is only as good as the platform it runs on. Running it via `workflow_dispatch` puts it on Ubuntu with glibc and GCC 13, which is the environment that actually gates merges.

Worth running the sweep once after this merges, to confirm master is genuinely clean on Linux rather than clean-on-macOS.

## CI plumbing found along the way

Reviewing this PR's own runs turned up four separate problems, all fixed here:

- **The job was checking nothing.** A PR that only touches `scripts/check-code-snippets.ts` changes no `.mdx`, so the diff-based job logged `No .mdx files to check.` and passed green having compiled zero snippets — the one kind of PR where the checker most needs exercising was the one where it ran on an empty set. A change to the checker now sweeps the whole guide, so this PR validates itself against all 1943 snippets on Linux.
- **No `node_modules` cache.** The checker imports only Node builtins, so the 42s cold install of Next.js/Firebase/Storybook existed purely to provide `tsx`. `build-tests`, `test` and `functions` all cache already; this workflow did not. Caching alone only got 42s → 32s because yarn still re-resolved the restored tree, so the install is now skipped outright on a cache hit — the key *is* the lockfile hash, which is exactly what the install would have confirmed.
- **A permanently greyed-out step.** The manual sweep was a second step gated on `workflow_dispatch`, so on every PR it sat there never running, while the step that did run was labelled "in changed files" whilst sweeping all of them. Now one step, named for what it does.
- **No `concurrency` anywhere.** Nothing grouped runs, so each push left the previous one's checks running against a commit nobody cares about; iterating on this PR had ten runs in flight across three superseded commits. Added to every workflow except `update-usaco` (manual, pushes a branch partway through). Cancelling is scoped to pull requests — a run on master validates what actually ships.

Also drops `corepack: true` from `setup-node`, which is not one of its inputs and logged `Unexpected input(s) 'corepack'` on every run.

Not addressed: `fetch-depth: 0` still fetches the full 269 MB history on every run, including manual sweeps that never need it. Making it conditional means either two checkout steps or careful merge-base handling, and getting it subtly wrong breaks the diff path silently — the same failure mode as the vacuous pass above. Worth doing deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cq1UarvezBkpsiMGxtXDp2


