### PR TITLE
Flag problem tags that do not already exist

### DIFF
--- a/.github/workflows/problem-tags.yml
+++ b/.github/workflows/problem-tags.yml
@@ -1,0 +1,35 @@
+name: Problem Tags
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'content/**/*.problems.json'
+      - 'content/extraProblems.json'
+      - 'py/check_problem_tags.py'
+      - '.github/workflows/problem-tags.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-problem-tags:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # the base branch is the tag vocabulary
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # Skipping the step passes the check, which is the point: a maintainer who
+      # has looked and decided the tag is genuinely new labels the pull request
+      # and moves on. Reading a label needs no write permission, so this stays a
+      # plain `pull_request` workflow.
+      - name: Check problem tags
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'new-tag') }}
+        run: python py/check_problem_tags.py --all --base-ref "origin/${{ github.base_ref }}"

--- a/.github/workflows/problem-tags.yml
+++ b/.github/workflows/problem-tags.yml
@@ -2,6 +2,9 @@ name: Problem Tags
 
 on:
   pull_request:
+    # labeled/unlabeled so that applying `new-tag` re-runs and clears the check,
+    # rather than leaving a red tick until the next push.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - master
     paths:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,9 @@
+# pre-commit.ci clones without the base branch, and check-problem-tags compares
+# against it -- the Problem Tags workflow runs that one instead, checking out with
+# fetch-depth: 0 so the comparison is possible at all.
+ci:
+  skip: [check-problem-tags]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,8 @@ repos:
         entry: python py/check_solutions.py
         language: python
         files: ^solutions/.*\.mdx$
+      - id: check-problem-tags
+        name: Check problem tags
+        entry: python py/check_problem_tags.py
+        language: python
+        files: (\.problems\.json|^content/extraProblems\.json)$

--- a/py/check_problem_tags.py
+++ b/py/check_problem_tags.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Flags problem tags that do not already exist on the base branch.
+
+A new tag is usually a typo -- "Bitmasking" for "Bitmasks", "Persistent Segtree"
+for "Persistent SegTree" -- and nothing else catches one. Tags feed the /problems
+filters and the autocomplete in ProblemTagsInput, which is built from whichever
+tags happen to exist, so a misspelling immediately suggests itself to the next
+contributor while the group it splits in two stays invisible from either side.
+
+Genuinely new tags are fine and expected; this only asks that someone look. In
+CI, label the pull request to say the tag is deliberate and the check passes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DISMISS_LABEL = "new-tag"
+
+
+def tags_in(node: object, found: dict[str, str], where: str) -> None:
+	"""Collect tag -> the uniqueId carrying it, over a problems file's tree."""
+	if isinstance(node, dict):
+		here = node.get("uniqueId", where)
+		for tag in node.get("tags") or []:
+			found.setdefault(tag, here)
+		for value in node.values():
+			tags_in(value, found, here)
+	elif isinstance(node, list):
+		for value in node:
+			tags_in(value, found, where)
+
+
+def problems_files_at(ref: str) -> list[str]:
+	out = subprocess.run(
+		["git", "ls-tree", "-r", "--name-only", ref, "content/"],
+		capture_output=True,
+		text=True,
+		cwd=ROOT,
+		check=True,
+	).stdout
+	return [
+		f
+		for f in out.split("\n")
+		if f.endswith(".problems.json") or f.endswith("extraProblems.json")
+	]
+
+
+def vocabulary_at(ref: str) -> set[str]:
+	"""Every tag in use on `ref` -- the base branch is the vocabulary."""
+	known: set[str] = set()
+	for path in problems_files_at(ref):
+		blob = subprocess.run(
+			["git", "show", f"{ref}:{path}"], capture_output=True, text=True, cwd=ROOT
+		).stdout
+		if not blob.strip():
+			continue
+		try:
+			found: dict[str, str] = {}
+			tags_in(json.loads(blob), found, path)
+			known |= set(found)
+		except json.JSONDecodeError:
+			continue  # a broken file on the base branch is not this check's problem
+	return known
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("paths", nargs="*", type=Path)
+	parser.add_argument("--base-ref", default="origin/master")
+	parser.add_argument("--all", action="store_true", help="check every problems file")
+	args = parser.parse_args()
+
+	if args.all or not args.paths:
+		paths = [ROOT / p for p in problems_files_at("HEAD")]
+	else:
+		paths = [p for p in args.paths if p.name.endswith(".json")]
+
+	known = vocabulary_at(args.base_ref)
+	if not known:
+		print(
+			f"Found no tags on {args.base_ref}; is the base branch fetched?",
+			file=sys.stderr,
+		)
+		return 1
+
+	ordered = sorted(known)
+	failed = 0
+	for path in paths:
+		if not path.exists():
+			continue
+		try:
+			data = json.loads(path.read_text())
+		except json.JSONDecodeError as err:
+			print(f"{path}: not valid JSON: {err}")
+			failed += 1
+			continue
+		found: dict[str, str] = {}
+		tags_in(data, found, path.name)
+		rel = path.relative_to(ROOT) if path.is_absolute() else path
+		for tag in sorted(set(found) - known):
+			failed += 1
+			near = difflib.get_close_matches(tag, ordered, n=3, cutoff=0.7)
+			hint = f" Did you mean {', '.join(repr(n) for n in near)}?" if near else ""
+			print(
+				f"{rel}: new tag {tag!r} on {found[tag]}, not used anywhere on {args.base_ref}.{hint}"
+			)
+
+	if failed:
+		print(
+			f"\n{failed} new tag(s). Fix the spelling, or label the pull request "
+			f"`{DISMISS_LABEL}` if the tag really is new.",
+			file=sys.stderr,
+		)
+	return 1 if failed else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/py/check_problem_tags.py
+++ b/py/check_problem_tags.py
@@ -16,12 +16,18 @@ from __future__ import annotations
 import argparse
 import difflib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 DISMISS_LABEL = "new-tag"
+# On Actions an ::error carrying a file and line is rendered on that line of the
+# diff. That is what lets this stay a plain pull_request workflow: the reader
+# gets the message where the tag is, and nothing needed permission to write a
+# comment to put it there.
+ANNOTATE = bool(os.environ.get("GITHUB_ACTIONS"))
 
 
 def tags_in(node: object, found: dict[str, str], where: str) -> None:
@@ -35,6 +41,36 @@ def tags_in(node: object, found: dict[str, str], where: str) -> None:
 	elif isinstance(node, list):
 		for value in node:
 			tags_in(value, found, where)
+
+
+def line_of(text: str, tag: str) -> int | None:
+	"""Which line of a problems file carries this tag, for the annotation."""
+	needle = f'"{tag}"'
+	for number, line in enumerate(text.split("\n"), start=1):
+		if needle in line and '"tags"' in line:
+			return number
+	return None
+
+
+def annotate(path: str, line: int | None, message: str) -> None:
+	where = f"file={path}" + (f",line={line}" if line else "")
+	# A newline would end the workflow command, so keep the message on one line.
+	print(f"::error {where},title=Unknown problem tag::{message}")
+
+
+def resolve_ref(preferred: str) -> str | None:
+	"""The base branch under whichever name this checkout knows it by."""
+	for ref in (preferred, preferred.removeprefix("origin/"), "origin/HEAD"):
+		if (
+			subprocess.run(
+				["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+				capture_output=True,
+				cwd=ROOT,
+			).returncode
+			== 0
+		):
+			return ref
+	return None
 
 
 def problems_files_at(ref: str) -> list[str]:
@@ -82,10 +118,19 @@ def main() -> int:
 	else:
 		paths = [p for p in args.paths if p.name.endswith(".json")]
 
-	known = vocabulary_at(args.base_ref)
+	base = resolve_ref(args.base_ref)
+	if base is None:
+		print(
+			f"Cannot find {args.base_ref}, so there is nothing to compare tags against. "
+			"Fetch the base branch, or pass --base-ref.",
+			file=sys.stderr,
+		)
+		return 1
+
+	known = vocabulary_at(base)
 	if not known:
 		print(
-			f"Found no tags on {args.base_ref}; is the base branch fetched?",
+			f"Found no tags on {base}; is the base branch fetched?",
 			file=sys.stderr,
 		)
 		return 1
@@ -104,13 +149,18 @@ def main() -> int:
 		found: dict[str, str] = {}
 		tags_in(data, found, path.name)
 		rel = path.relative_to(ROOT) if path.is_absolute() else path
+		raw = path.read_text()
 		for tag in sorted(set(found) - known):
 			failed += 1
 			near = difflib.get_close_matches(tag, ordered, n=3, cutoff=0.7)
 			hint = f" Did you mean {', '.join(repr(n) for n in near)}?" if near else ""
-			print(
-				f"{rel}: new tag {tag!r} on {found[tag]}, not used anywhere on {args.base_ref}.{hint}"
+			message = (
+				f"new tag {tag!r} on {found[tag]}, not used anywhere on {base}.{hint}"
+				f" If it really is new, label the pull request `{DISMISS_LABEL}`."
 			)
+			print(f"{rel}: {message}")
+			if ANNOTATE:
+				annotate(str(rel), line_of(raw, tag), message)
 
 	if failed:
 		print(

--- a/py/check_solutions.py
+++ b/py/check_solutions.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -37,6 +38,12 @@ DIVISION_LIST = ROOT / "src/components/markdown/ProblemsList/DivisionList"
 SKIP_DIRS = {"orphaned"}
 
 REQUIRED_FRONTMATTER = ("id", "source", "title", "author")
+
+# Actions renders an ::error with a file and line on that line of the diff. Only
+# findings that quote text which exists get one -- for "must link the official
+# editorial" there is, by definition, no line to point at, and guessing where the
+# link ought to go would put the message somewhere the reader did not expect.
+ANNOTATE = bool(os.environ.get("GITHUB_ACTIONS"))
 
 # Per-source wording for the link to the official editorial. USACO says "Official
 # Analysis"; Codeforces and AtCoder both call it an editorial, so they say
@@ -93,6 +100,17 @@ def parse_frontmatter(text: str) -> dict | None:
 	return fields
 
 
+def line_of(text: str, pattern: str) -> int | None:
+	"""1-indexed line where `pattern` first matches, for an annotation."""
+	match = re.search(pattern, text, re.M)
+	return text.count("\n", 0, match.start()) + 1 if match else None
+
+
+def annotate(path: str, line: int, message: str) -> None:
+	# A newline would end the workflow command, so keep the message on one line.
+	print(f"::error file={path},line={line},title=Solution check::{message}")
+
+
 def source_prefix(stem: str) -> str:
 	return stem.split("-")[0] if "-" in stem else stem
 
@@ -104,21 +122,24 @@ def cf_is_gym(stem: str) -> bool:
 
 def check_file(
 	path: Path, id_to_sol: dict, cpid_to_contest: dict, complexity_backlog: set[str]
-) -> list[str]:
-	errors: list[str] = []
+) -> list[tuple[str, int | None]]:
+	errors: list[tuple[str, int | None]] = []
 	text = path.read_text()
 	stem = path.stem
 	prefix = source_prefix(stem)
 
 	fields = parse_frontmatter(text)
 	if fields is None:
-		return ["missing frontmatter"]
+		return [("missing frontmatter", None)]
 	for key in REQUIRED_FRONTMATTER:
 		if not fields.get(key):
-			errors.append(f"frontmatter is missing `{key}`")
+			errors.append((f"frontmatter is missing `{key}`", None))
 	if fields.get("id") and fields["id"] != stem:
 		errors.append(
-			f"frontmatter `id: {fields['id']}` does not match the filename `{stem}`"
+			(
+				f"frontmatter `id: {fields['id']}` does not match the filename `{stem}`",
+				line_of(text, r"^id:"),
+			)
 		)
 
 	links = MD_LINK.findall(text)
@@ -130,7 +151,10 @@ def check_file(
 			match = OFFICIAL_LABEL.match(label)
 			if match and f"{match.group(1)} {match.group(2)}" != canonical:
 				errors.append(
-					f'link labeled "{label}" should say "{canonical}{(" " + match.group(3)) if match.group(3) else ""}"'
+					(
+						f'link labeled "{label}" should say "{canonical}{(" " + match.group(3)) if match.group(3) else ""}"',
+						line_of(text, re.escape(f"[{label}]")),
+					)
 				)
 
 	exempt = fields.get("noOfficialEditorial", "").lower() == "true"
@@ -140,14 +164,17 @@ def check_file(
 		expected_sol = id_to_sol.get(cpid)
 		if expected_sol is None:
 			errors.append(
-				f"cpid {cpid} is not in id_to_sol.json; is the filename right?"
+				(f"cpid {cpid} is not in id_to_sol.json; is the filename right?", None)
 			)
 		elif not any(
 			(m := USACO_SOL_URL.match(url)) and m.group(1) == expected_sol
 			for _label, url in links
 		):
 			errors.append(
-				f"must link the official analysis https://usaco.org/current/data/{expected_sol}"
+				(
+					f"must link the official analysis https://usaco.org/current/data/{expected_sol}",
+					None,
+				)
 			)
 		if (
 			cpid in cpid_to_contest
@@ -156,7 +183,10 @@ def check_file(
 			expected_source = f"USACO {division} {contest}"
 			if fields.get("source") and fields["source"] != expected_source:
 				errors.append(
-					f"frontmatter `source: {fields['source']}` should be `{expected_source}`"
+					(
+						f"frontmatter `source: {fields['source']}` should be `{expected_source}`",
+						line_of(text, r"^source:"),
+					)
 				)
 	elif prefix in REQUIRE_EDITORIAL and not exempt:
 		if prefix == "cf" and cf_is_gym(stem):
@@ -166,7 +196,10 @@ def check_file(
 			for label, url in links
 		):
 			errors.append(
-				f'must link the official editorial as "[{canonical} (C++)](...)", or set `noOfficialEditorial: true` if none exists'
+				(
+					f'must link the official editorial as "[{canonical} (C++)](...)", or set `noOfficialEditorial: true` if none exists',
+					None,
+				)
 			)
 
 	rel = path.relative_to(ROOT).as_posix() if path.is_absolute() else path.as_posix()
@@ -174,11 +207,17 @@ def check_file(
 	if rel in complexity_backlog:
 		if has_complexity:
 			errors.append(
-				f"now states its complexity; remove it from {MISSING_COMPLEXITY_LIST.name}"
+				(
+					f"now states its complexity; remove it from {MISSING_COMPLEXITY_LIST.name}",
+					line_of(text, re.escape("**Time Complexity:**")),
+				)
 			)
 	elif not has_complexity:
 		errors.append(
-			"must state its complexity as `**Time Complexity:** $\\mathcal{O}(...)$`"
+			(
+				"must state its complexity as `**Time Complexity:** $\\mathcal{O}(...)$`",
+				None,
+			)
 		)
 
 	return errors
@@ -218,8 +257,10 @@ def main() -> int:
 		if errors:
 			failed += 1
 			rel = path.relative_to(ROOT) if path.is_absolute() else path
-			for error in errors:
-				print(f"{rel}: {error}")
+			for message, line in errors:
+				print(f"{rel}: {message}")
+				if ANNOTATE and line is not None:
+					annotate(str(rel), line, message)
 	if failed:
 		print(f"\n{failed} solution(s) need fixing.", file=sys.stderr)
 	return 1 if failed else 0

--- a/py/check_solutions.py
+++ b/py/check_solutions.py
@@ -39,10 +39,12 @@ SKIP_DIRS = {"orphaned"}
 
 REQUIRED_FRONTMATTER = ("id", "source", "title", "author")
 
-# Actions renders an ::error with a file and line on that line of the diff. Only
-# findings that quote text which exists get one -- for "must link the official
-# editorial" there is, by definition, no line to point at, and guessing where the
-# link ought to go would put the message somewhere the reader did not expect.
+# Actions renders an ::error on the line it names, or against the file when it
+# names none. Findings that quote existing text get the line; a missing
+# frontmatter key gets the line it would be inserted on, since that is genuinely
+# where it goes. The rest -- no editorial link, no complexity -- have no place to
+# point at, and inventing one would put the message where nobody is looking, so
+# they are reported against the file.
 ANNOTATE = bool(os.environ.get("GITHUB_ACTIONS"))
 
 # Per-source wording for the link to the official editorial. USACO says "Official
@@ -106,9 +108,10 @@ def line_of(text: str, pattern: str) -> int | None:
 	return text.count("\n", 0, match.start()) + 1 if match else None
 
 
-def annotate(path: str, line: int, message: str) -> None:
+def annotate(path: str, line: int | None, message: str) -> None:
+	where = f"file={path}" + (f",line={line}" if line is not None else "")
 	# A newline would end the workflow command, so keep the message on one line.
-	print(f"::error file={path},line={line},title=Solution check::{message}")
+	print(f"::error {where},title=Solution check::{message}")
 
 
 def source_prefix(stem: str) -> str:
@@ -131,9 +134,11 @@ def check_file(
 	fields = parse_frontmatter(text)
 	if fields is None:
 		return [("missing frontmatter", None)]
+	# A missing key belongs in the frontmatter, so point at its closing ---.
+	frontmatter_end = text.count("\n", 0, text.index("\n---\n", 3)) + 2
 	for key in REQUIRED_FRONTMATTER:
 		if not fields.get(key):
-			errors.append((f"frontmatter is missing `{key}`", None))
+			errors.append((f"frontmatter is missing `{key}`", frontmatter_end))
 	if fields.get("id") and fields["id"] != stem:
 		errors.append(
 			(
@@ -259,7 +264,7 @@ def main() -> int:
 			rel = path.relative_to(ROOT) if path.is_absolute() else path
 			for message, line in errors:
 				print(f"{rel}: {message}")
-				if ANNOTATE and line is not None:
+				if ANNOTATE:
 					annotate(str(rel), line, message)
 	if failed:
 		print(f"\n{failed} solution(s) need fixing.", file=sys.stderr)


### PR DESCRIPTION
Two open PRs add `"Bitmasking"` and `"Persistent Segtree"` alongside the existing `"Bitmasks"` (44 problems) and `"Persistent SegTree"` (13 problems). Nothing catches that today.

It matters because the vocabulary is **self-reinforcing**: the /problems filters and the autocomplete in `ProblemTagsInput` are both built from whichever tags happen to exist, so a misspelling immediately suggests itself to the next contributor — while the group it splits in two is invisible from either side.

## How it works

**The base branch is the vocabulary.** A tag is "new" exactly when it appears nowhere on master. Nothing to check in, nothing to keep in sync, and the vocabulary keeps growing on its own as it does today. Close matches are suggested:

```
content/3_Silver/Conclusion.problems.json: new tag 'Bitmasking' on cf-2064D,
  not used anywhere on origin/master. Did you mean 'Bitmasks'?
```

**Dismissable.** New tags are expected and fine — the check only asks that someone look. Labelling the PR `new-tag` skips the step, and a skipped step passes. Reading a label needs no write permission, so this stays a plain `pull_request` workflow rather than `pull_request_target`, which would run untrusted code with write access.

## Verified against the real open PRs

| PR | result |
|---|---|
| #6305 | flags `'Persistent Segtree'`, suggests `'Persistent SegTree'` |
| #6318 | flags `'Bitmasking'`, suggests `'Bitmasks'` |
| #6579, #6580 | silent — they touch `problems.json` with no new tags |
| master vs itself | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cq1UarvezBkpsiMGxtXDp2
