### PR TITLE
Anchor a missing editorial link to the frontmatter it belongs under

### DIFF
--- a/py/check_solutions.py
+++ b/py/check_solutions.py
@@ -42,9 +42,12 @@ REQUIRED_FRONTMATTER = ("id", "source", "title", "author")
 # Actions renders an ::error on the line it names, or against the file when it
 # names none. Findings that quote existing text get the line; a missing
 # frontmatter key gets the line it would be inserted on, since that is genuinely
-# where it goes. The rest -- no editorial link, no complexity -- have no place to
-# point at, and inventing one would put the message where nobody is looking, so
-# they are reported against the file.
+# where it goes -- as does a missing editorial link, which by convention sits
+# immediately below the frontmatter. What is left has no conventional home: a
+# complexity line belongs beside whichever implementation it describes, and
+# inventing a line for it would put the message where nobody is looking, so those
+# are annotated against the file. GitHub stores those at line 0 and draws them
+# only in the check summary, never on the diff.
 ANNOTATE = bool(os.environ.get("GITHUB_ACTIONS"))
 
 # Per-source wording for the link to the official editorial. USACO says "Official
@@ -178,7 +181,7 @@ def check_file(
 			errors.append(
 				(
 					f"must link the official analysis https://usaco.org/current/data/{expected_sol}",
-					None,
+					frontmatter_end,
 				)
 			)
 		if (
@@ -203,7 +206,7 @@ def check_file(
 			errors.append(
 				(
 					f'must link the official editorial as "[{canonical} (C++)](...)", or set `noOfficialEditorial: true` if none exists',
-					None,
+					frontmatter_end,
 				)
 			)
 


### PR DESCRIPTION
Follow-up to #6618, from checking what GitHub actually recorded on #6585:

```
path=solutions/gold/cf-837D.mdx  lines=0-0  level=failure
msg:  must link the official editorial as "[Official Editorial (C++)](...)" …
```

A file-scoped annotation is stored at **line 0** and drawn only in the check summary — never on the diff. So the most common failure was also the least visible one, while #6318's tag annotation (`lines=682-682`) rendered inline fine.

A missing editorial link does have a conventional home: immediately below the frontmatter. It now names that closing `---`, so it renders inline:

```
::error file=solutions/gold/cf-837D.mdx,line=6,…::must link the official editorial as …
```

The USACO "official analysis" rule gets the same treatment, being the same rule for a different source.

**A missing complexity line stays file-scoped.** It belongs beside whichever implementation it describes, so any line chosen for it would be a guess — which is the distinction worth keeping rather than anchoring every absence somewhere.

All four PRs that currently fail this rule add new files, so every line is inside the diff and the annotation will render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cq1UarvezBkpsiMGxtXDp2
