### PR TITLE
Add deterministic checks for problem data and C++ snippets

### DIFF
--- a/.github/workflows/mdx.yml
+++ b/.github/workflows/mdx.yml
@@ -1,0 +1,38 @@
+# Two rules over the prose and snippets that neither the compiler nor Prettier
+# can express: links into the guide stay relative, and cout.tie(...) -- banned
+# by Adding_Solution.mdx as a call that does nothing -- stays out of C++
+# snippets. Both are scoped by fenced code block; see py/check_mdx.py for why
+# each rule is noise without that.
+name: MDX
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'content/**/*.mdx'
+      - 'solutions/**/*.mdx'
+      - 'py/check_mdx.py'
+      - '.github/workflows/mdx.yml'
+
+# A new push supersedes whatever the previous one was still checking. Cancelling
+# is scoped to pull requests: a run on master is validating what actually ships,
+# so let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-mdx:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # Both rules hold repo-wide today, so this sweeps everything rather than
+      # only the changed files.
+      - name: Check MDX
+        run: python py/check_mdx.py --all

--- a/.github/workflows/problem-data.yml
+++ b/.github/workflows/problem-data.yml
@@ -1,0 +1,39 @@
+# The problem lists carry three things a reviewer cannot check by reading a
+# diff: whether a USACO name matches usaco.org, whether a url points at the
+# problem its uniqueId names, and whether copies of one problem in different
+# modules still agree. See py/check_problems_json.py for what each rule covers
+# and, just as importantly, which fields are deliberately left alone.
+name: Problem Data
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'content/**/*.problems.json'
+      - 'content/extraProblems.json'
+      - 'src/components/markdown/ProblemsList/DivisionList/div_to_probs.json'
+      - 'py/check_problems_json.py'
+      - '.github/workflows/problem-data.yml'
+
+# A new push supersedes whatever the previous one was still checking. Cancelling
+# is scoped to pull requests: a run on master is validating what actually ships,
+# so let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-problem-data:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # The third rule compares a problem against its copies in other modules,
+      # so this always sweeps every list rather than only the changed ones.
+      - name: Check problem data
+        run: python py/check_problems_json.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,9 @@ repos:
         entry: python py/check_problem_tags.py
         language: python
         files: (\.problems\.json|^content/extraProblems\.json)$
+      - id: check-problems-json
+        name: Check problem data
+        entry: python py/check_problems_json.py
+        language: python
+        files: (\.problems\.json|^content/extraProblems\.json|^src/components/markdown/ProblemsList/DivisionList/div_to_probs\.json)$
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,11 @@ repos:
       #
       # .prettierignore excludes *.mdx; the format-mdx hook above covers the code
       # blocks inside those.
+      - id: check-mdx
+        name: Check MDX
+        entry: python py/check_mdx.py
+        language: python
+        files: ^(content|solutions)/.*\.mdx$
       - id: prettier
         name: Format with Prettier
         entry: yarn prettier --write --ignore-unknown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,11 @@
 # against it -- the Problem Tags workflow runs that one instead, checking out with
 # fetch-depth: 0 so the comparison is possible at all.
 ci:
-  skip: [check-problem-tags]
+  # Prettier runs from the repo's own node_modules, which pre-commit.ci has no
+  # way to install. It is also already covered there by the autofix.ci workflow,
+  # and two bots pushing format commits to the same branch would race, so this
+  # hook is for local commits only.
+  skip: [check-problem-tags, prettier]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -41,6 +45,20 @@ repos:
         entry: python py/check_problem_tags.py
         language: python
         files: (\.problems\.json|^content/extraProblems\.json)$
+      # Prettier otherwise runs only in CI, via autofix.ci, so a formatting slip
+      # is invisible locally until the pull request goes red. Uses the version
+      # and plugins pinned in package.json rather than a copy pre-commit
+      # installs, since prettier-plugin-organize-imports needs the project's own
+      # TypeScript to resolve imports.
+      #
+      # .prettierignore excludes *.mdx; the format-mdx hook above covers the code
+      # blocks inside those.
+      - id: prettier
+        name: Format with Prettier
+        entry: yarn prettier --write --ignore-unknown
+        language: system
+        files: \.(json|ya?ml|[jt]sx?|css|scss|html|md)$
+        require_serial: true
       - id: check-problems-json
         name: Check problem data
         entry: python py/check_problems_json.py

--- a/content/2_Bronze/Intro_Sets.problems.json
+++ b/content/2_Bronze/Intro_Sets.problems.json
@@ -104,7 +104,7 @@
     },
     {
       "uniqueId": "usaco-667",
-      "name": "Cities & States",
+      "name": "Cities and States",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=667",
       "source": "Silver",
       "difficulty": "Medium",
@@ -135,8 +135,7 @@
       "isStarred": false,
       "tags": ["Map", "Set"],
       "solutionMetadata": {
-        "kind": "USACO",
-        "usacoId": "1445"
+        "kind": "internal"
       }
     },
     {

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -222,7 +222,7 @@
     },
     {
       "uniqueId": "usaco-1255",
-      "name": "Circular Barn - The Game",
+      "name": "Circular Barn",
       "url": "http://usaco.org/index.php?page=viewproblem2&cpid=1255",
       "source": "Silver",
       "difficulty": "Medium",

--- a/content/3_Silver/Intro_Bitwise.problems.json
+++ b/content/3_Silver/Intro_Bitwise.problems.json
@@ -1,6 +1,5 @@
 {
   "MODULE_ID": "intro-bitwise",
-
   "sample": [
     {
       "uniqueId": "cf-1556D",
@@ -16,7 +15,6 @@
       }
     }
   ],
-
   "sample2": [
     {
       "uniqueId": "ac-XorSigmaProblem",
@@ -32,7 +30,6 @@
       }
     }
   ],
-
   "probs": [
     {
       "uniqueId": "cf-1338A",
@@ -78,7 +75,9 @@
       "difficulty": "Easy",
       "isStarred": true,
       "tags": ["Bitwise"],
-      "solutionMetadata": { "kind": "internal" }
+      "solutionMetadata": {
+        "kind": "internal"
+      }
     },
     {
       "uniqueId": "cf-1851F",
@@ -94,7 +93,7 @@
     },
     {
       "uniqueId": "usaco-1182",
-      "name": "Searching For Soulmates",
+      "name": "Searching for Soulmates",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1182",
       "source": "Silver",
       "difficulty": "Easy",

--- a/content/3_Silver/Intro_Tree.problems.json
+++ b/content/3_Silver/Intro_Tree.problems.json
@@ -30,7 +30,7 @@
     },
     {
       "uniqueId": "usaco-788",
-      "name": "Mootube",
+      "name": "MooTube",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=788",
       "source": "Silver",
       "difficulty": "Easy",

--- a/content/3_Silver/More_Prefix_Sums.problems.json
+++ b/content/3_Silver/More_Prefix_Sums.problems.json
@@ -45,7 +45,6 @@
       }
     }
   ],
-
   "difference-arrays-problemset": [
     {
       "uniqueId": "cf-816B",
@@ -117,11 +116,11 @@
       "isStarred": true,
       "tags": ["2D Prefix Sums", "Max Subarray Sum"],
       "solutionMetadata": {
-        "kind": "internal"
+        "kind": "internal",
+        "hasHints": true
       }
     }
   ],
-
   "cum2": [
     {
       "uniqueId": "cf-104114N",

--- a/content/3_Silver/Prefix_Sums.mdx
+++ b/content/3_Silver/Prefix_Sums.mdx
@@ -31,7 +31,7 @@ frequency: 4
 Prefix sums are a technique used to quickly calculate the sum of any subarray.
 By precomputing cumulative sums in $\mathcal{O}(N)$ time, subsequent queries can be computed in $\mathcal{O}(1)$ time.
 This technique can be generalized to invertible operations,
-such as [bitwise XOR](https://usaco.guide/silver/intro-bitwise#xor-operation).
+such as [bitwise XOR](/silver/intro-bitwise#xor-operation).
 
 ## Example - Static Range Sum
 

--- a/content/3_Silver/Prefix_Sums.problems.json
+++ b/content/3_Silver/Prefix_Sums.problems.json
@@ -30,7 +30,7 @@
     },
     {
       "uniqueId": "usaco-691",
-      "name": "Hoof Paper Scissors",
+      "name": "Hoof, Paper, Scissors",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=691",
       "source": "Silver",
       "difficulty": "Very Easy",

--- a/content/3_Silver/Sorting_Custom.problems.json
+++ b/content/3_Silver/Sorting_Custom.problems.json
@@ -166,7 +166,7 @@
     },
     {
       "uniqueId": "usaco-834",
-      "name": "Out Of Sorts",
+      "name": "Out of Sorts",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=834",
       "source": "Silver",
       "difficulty": "Hard",

--- a/content/4_Gold/All_Roots.problems.json
+++ b/content/4_Gold/All_Roots.problems.json
@@ -116,7 +116,7 @@
     },
     {
       "uniqueId": "usaco-793",
-      "name": "Cow At Large",
+      "name": "Cow at Large",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=793",
       "source": "Platinum",
       "difficulty": "Very Hard",

--- a/content/4_Gold/Combinatorics.problems.json
+++ b/content/4_Gold/Combinatorics.problems.json
@@ -40,8 +40,8 @@
       "isStarred": false,
       "tags": ["Combinatorics"],
       "solutionMetadata": {
-        "kind": "in-module",
-        "moduleId": "combo"
+        "kind": "internal",
+        "hasHints": true
       }
     }
   ],

--- a/content/4_Gold/DSU.problems.json
+++ b/content/4_Gold/DSU.problems.json
@@ -42,7 +42,7 @@
     },
     {
       "uniqueId": "usaco-789",
-      "name": "Mootube",
+      "name": "MooTube",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=789",
       "source": "Gold",
       "difficulty": "Easy",

--- a/content/4_Gold/Hashmaps.problems.json
+++ b/content/4_Gold/Hashmaps.problems.json
@@ -3,7 +3,7 @@
   "three": [
     {
       "uniqueId": "usaco-994",
-      "name": "3SUM",
+      "name": "Farmer John Solves 3SUM",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=994",
       "source": "Gold",
       "difficulty": "Medium",

--- a/content/4_Gold/Intro_DP.problems.json
+++ b/content/4_Gold/Intro_DP.problems.json
@@ -42,7 +42,7 @@
     },
     {
       "uniqueId": "usaco-694",
-      "name": "Hoof Paper Scissors",
+      "name": "Hoof, Paper, Scissors",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=694",
       "source": "Gold",
       "difficulty": "Easy",

--- a/content/4_Gold/Knapsack_DP.problems.json
+++ b/content/4_Gold/Knapsack_DP.problems.json
@@ -189,7 +189,7 @@
     },
     {
       "uniqueId": "usaco-925",
-      "name": "Mooriokart",
+      "name": "Moorio Kart",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=925",
       "source": "Platinum",
       "difficulty": "Very Hard",

--- a/content/4_Gold/PURS.problems.json
+++ b/content/4_Gold/PURS.problems.json
@@ -172,7 +172,7 @@
     },
     {
       "uniqueId": "usaco-719",
-      "name": "Circle Cross",
+      "name": "Why Did the Cow Cross the Road III",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=719",
       "source": "Gold",
       "difficulty": "Easy",
@@ -197,7 +197,7 @@
     },
     {
       "uniqueId": "usaco-720",
-      "name": "Mincross",
+      "name": "Why Did the Cow Cross the Road",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=720",
       "source": "Platinum",
       "difficulty": "Easy",

--- a/content/4_Gold/Shortest_Paths.problems.json
+++ b/content/4_Gold/Shortest_Paths.problems.json
@@ -86,8 +86,7 @@
       "isStarred": false,
       "tags": ["Shortest Path"],
       "solutionMetadata": {
-        "kind": "USACO",
-        "usacoId": "1090"
+        "kind": "internal"
       }
     },
     {

--- a/content/4_Gold/Sliding_Window.mdx
+++ b/content/4_Gold/Sliding_Window.mdx
@@ -327,7 +327,7 @@ maintain monotonicity. In this case, a decreasing monotonic queue works well
 as any elements smaller than our current element will serve no use to us finding
 a sliding window maximum.
 
-A monotonic queue is similar to a [monotonic stack](https://usaco.guide/gold/stacks#application---nearest-smaller-element),
+A monotonic queue is similar to a [monotonic stack](/gold/stacks#application---nearest-smaller-element),
 but due to its deque implementation, a monotonic queue has access to both the front and end,
 making it efficient for sliding window problems. A monotonic stack is useful for nearest greater/smaller element.
 

--- a/content/4_Gold/Unweighted_Shortest_Paths.problems.json
+++ b/content/4_Gold/Unweighted_Shortest_Paths.problems.json
@@ -117,7 +117,7 @@
     },
     {
       "uniqueId": "usaco-790",
-      "name": "Cow At Large",
+      "name": "Cow at Large",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=790",
       "source": "Gold",
       "difficulty": "Medium",
@@ -185,7 +185,9 @@
       "difficulty": "Hard",
       "isStarred": true,
       "tags": ["BFS"],
-      "solutionMetadata": { "kind": "internal" }
+      "solutionMetadata": {
+        "kind": "internal"
+      }
     },
     {
       "uniqueId": "usaco-1065",

--- a/content/5_Plat/2DRQ.problems.json
+++ b/content/5_Plat/2DRQ.problems.json
@@ -61,7 +61,7 @@
   "off": [
     {
       "uniqueId": "usaco-722",
-      "name": "Friendcross",
+      "name": "Why Did the Cow Cross the Road III",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=722",
       "source": "Platinum",
       "difficulty": "Medium",

--- a/content/5_Plat/Binary_Jump.problems.json
+++ b/content/5_Plat/Binary_Jump.problems.json
@@ -223,7 +223,7 @@
     },
     {
       "uniqueId": "usaco-866",
-      "name": "Gathering",
+      "name": "The Cow Gathering",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=866",
       "source": "Platinum",
       "difficulty": "Hard",

--- a/content/5_Plat/Bitsets.problems.json
+++ b/content/5_Plat/Bitsets.problems.json
@@ -25,7 +25,8 @@
       "isStarred": false,
       "tags": ["Bitset", "PIE"],
       "solutionMetadata": {
-        "kind": "internal"
+        "kind": "internal",
+        "hasHints": true
       }
     }
   ],

--- a/content/5_Plat/Centroid.problems.json
+++ b/content/5_Plat/Centroid.problems.json
@@ -221,7 +221,7 @@
     },
     {
       "uniqueId": "usaco-793",
-      "name": "Cow At Large",
+      "name": "Cow at Large",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=793",
       "source": "Platinum",
       "difficulty": "Very Hard",

--- a/content/5_Plat/Conclusion.problems.json
+++ b/content/5_Plat/Conclusion.problems.json
@@ -193,7 +193,7 @@
     },
     {
       "uniqueId": "usaco-602",
-      "name": "Lightsout",
+      "name": "Lights Out",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=602",
       "source": "Platinum",
       "difficulty": "Very Hard",

--- a/content/5_Plat/DP_SOS.problems.json
+++ b/content/5_Plat/DP_SOS.problems.json
@@ -105,7 +105,7 @@
       }
     },
     {
-      "uniqueId": "cf-880D",
+      "uniqueId": "cf-800D",
       "name": "Varying Kibibits",
       "url": "https://codeforces.com/contest/800/problem/D",
       "source": "CF",

--- a/content/5_Plat/DP_SOS.problems.json
+++ b/content/5_Plat/DP_SOS.problems.json
@@ -8,7 +8,10 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Bitmasks", "SOS DP"],
+      "tags": [
+        "Bitmasks",
+        "SOS DP"
+      ],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "dp-sos"
@@ -23,7 +26,9 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SOS DP"],
+      "tags": [
+        "SOS DP"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -35,7 +40,10 @@
       "source": "Platinum",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Combinatorics", "DP"],
+      "tags": [
+        "Combinatorics",
+        "DP"
+      ],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1309"
@@ -48,7 +56,10 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Bitmasks", "SOS DP"],
+      "tags": [
+        "Bitmasks",
+        "SOS DP"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -60,7 +71,10 @@
       "source": "Platinum",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Number Theory", "Prefix Sums"],
+      "tags": [
+        "Number Theory",
+        "Prefix Sums"
+      ],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1213"
@@ -73,7 +87,10 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Bitmasks", "SOS DP"],
+      "tags": [
+        "Bitmasks",
+        "SOS DP"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -86,7 +103,10 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Bitmasks", "SOS DP"],
+      "tags": [
+        "Bitmasks",
+        "SOS DP"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -99,19 +119,26 @@
       "source": "kilonova",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Bitmasks", "Number Theory", "SOS DP"],
+      "tags": [
+        "Bitmasks",
+        "Number Theory",
+        "SOS DP"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
     },
     {
-      "uniqueId": "cf-800D",
+      "uniqueId": "cf-880D",
       "name": "Varying Kibibits",
       "url": "https://codeforces.com/contest/800/problem/D",
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Bitmasks", "DP"],
+      "tags": [
+        "Bitmasks",
+        "DP"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -124,7 +151,9 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["SOS DP"],
+      "tags": [
+        "SOS DP"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -136,7 +165,11 @@
       "source": "CF",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": ["Bitmasks", "DP", "SOS DP"],
+      "tags": [
+        "Bitmasks",
+        "DP",
+        "SOS DP"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/5_Plat/DP_SOS.problems.json
+++ b/content/5_Plat/DP_SOS.problems.json
@@ -8,10 +8,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Bitmasks",
-        "SOS DP"
-      ],
+      "tags": ["Bitmasks", "SOS DP"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "dp-sos"
@@ -26,9 +23,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "SOS DP"
-      ],
+      "tags": ["SOS DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -40,10 +35,7 @@
       "source": "Platinum",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Combinatorics",
-        "DP"
-      ],
+      "tags": ["Combinatorics", "DP"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1309"
@@ -56,10 +48,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Bitmasks",
-        "SOS DP"
-      ],
+      "tags": ["Bitmasks", "SOS DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -71,10 +60,7 @@
       "source": "Platinum",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Number Theory",
-        "Prefix Sums"
-      ],
+      "tags": ["Number Theory", "Prefix Sums"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "1213"
@@ -87,10 +73,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Bitmasks",
-        "SOS DP"
-      ],
+      "tags": ["Bitmasks", "SOS DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -103,10 +86,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Bitmasks",
-        "SOS DP"
-      ],
+      "tags": ["Bitmasks", "SOS DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -119,11 +99,7 @@
       "source": "kilonova",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": [
-        "Bitmasks",
-        "Number Theory",
-        "SOS DP"
-      ],
+      "tags": ["Bitmasks", "Number Theory", "SOS DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -135,10 +111,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "Bitmasks",
-        "DP"
-      ],
+      "tags": ["Bitmasks", "DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -151,9 +124,7 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "SOS DP"
-      ],
+      "tags": ["SOS DP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -165,11 +136,7 @@
       "source": "CF",
       "difficulty": "Insane",
       "isStarred": false,
-      "tags": [
-        "Bitmasks",
-        "DP",
-        "SOS DP"
-      ],
+      "tags": ["Bitmasks", "DP", "SOS DP"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/5_Plat/HLD.problems.json
+++ b/content/5_Plat/HLD.problems.json
@@ -10,8 +10,7 @@
       "isStarred": false,
       "tags": ["HLD"],
       "solutionMetadata": {
-        "kind": "in-module",
-        "moduleId": "hld"
+        "kind": "internal"
       }
     }
   ],

--- a/content/5_Plat/PIE.problems.json
+++ b/content/5_Plat/PIE.problems.json
@@ -25,7 +25,8 @@
       "isStarred": false,
       "tags": ["Bitset", "PIE"],
       "solutionMetadata": {
-        "kind": "internal"
+        "kind": "internal",
+        "hasHints": true
       }
     }
   ],

--- a/content/5_Plat/Sqrt.problems.json
+++ b/content/5_Plat/Sqrt.problems.json
@@ -368,7 +368,7 @@
     },
     {
       "uniqueId": "usaco-793",
-      "name": "Cow At Large",
+      "name": "Cow at Large",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=793",
       "source": "Platinum",
       "difficulty": "Very Hard",

--- a/content/5_Plat/VTree.mdx
+++ b/content/5_Plat/VTree.mdx
@@ -335,8 +335,8 @@ int main() {
 Note that
 [Bridges: The Final Battle](https://codeforces.com/problemset/gymProblem/100551/D)
 requires concepts from
-[Offline Deletion](https://usaco.guide/adv/offline-del?lang=cpp) and
-[BCCs and 2CCs](https://usaco.guide/adv/BCC-2CC?lang=cpp) to solve.
+[Offline Deletion](/adv/offline-del?lang=cpp) and
+[BCCs and 2CCs](/adv/BCC-2CC?lang=cpp) to solve.
 
 </Warning>
 

--- a/content/6_Advanced/DP_More.mdx
+++ b/content/6_Advanced/DP_More.mdx
@@ -49,7 +49,7 @@ $$
 $$
 The proof of correctness for this claim is in the resources above.
 
-The structure of the code is identical to that of [Range DP](https://usaco.guide/gold/dp-ranges), with the exception of maintaining the $\texttt{opt}$ array. To calculate $\texttt{dp}[i][j]$ and $\texttt{opt}[i][j]$, it is only necessary to check values of $k$ between $\texttt{opt}[i][j-1]$ and $\texttt{opt}[i+1][j]$. Because of the monotonicity of $\texttt{opt}$, the time complexity of the final algorithm can be shown to be $\mathcal{O}(N^2)$.
+The structure of the code is identical to that of [Range DP](/gold/dp-ranges), with the exception of maintaining the $\texttt{opt}$ array. To calculate $\texttt{dp}[i][j]$ and $\texttt{opt}[i][j]$, it is only necessary to check values of $k$ between $\texttt{opt}[i][j-1]$ and $\texttt{opt}[i+1][j]$. Because of the monotonicity of $\texttt{opt}$, the time complexity of the final algorithm can be shown to be $\mathcal{O}(N^2)$.
 
 ### Knuth's Optimization Problems
 

--- a/content/6_Advanced/Eulerian_Tours.problems.json
+++ b/content/6_Advanced/Eulerian_Tours.problems.json
@@ -8,7 +8,9 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "eulerian-tours"
@@ -23,7 +25,9 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "eulerian-tours"
@@ -38,7 +42,9 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "eulerian-tours"
@@ -53,7 +59,9 @@
       "source": "Baltic OI",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/boi-2014/tasks/blob/master/solutions/analysis/postmen.tex"
@@ -66,7 +74,9 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -79,20 +89,24 @@
       "source": "CSA",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CSA"
       }
     },
     {
-      "uniqueId": "cf-1981D",
+      "uniqueId": "cf-949D",
       "name": "Turtle and Multiplication",
       "url": "https://codeforces.com/contest/1981/problem/D",
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -105,7 +119,9 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -118,7 +134,9 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -131,7 +149,9 @@
       "source": "Balkan OI",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Euler Tour"],
+      "tags": [
+        "Euler Tour"
+      ],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://bytefreaks.net/cyprus-computer-society/tasks-balkan-olympiad-in-informatics-2016"

--- a/content/6_Advanced/Eulerian_Tours.problems.json
+++ b/content/6_Advanced/Eulerian_Tours.problems.json
@@ -86,7 +86,7 @@
       }
     },
     {
-      "uniqueId": "cf-949D",
+      "uniqueId": "cf-1981D",
       "name": "Turtle and Multiplication",
       "url": "https://codeforces.com/contest/1981/problem/D",
       "source": "CF",

--- a/content/6_Advanced/Eulerian_Tours.problems.json
+++ b/content/6_Advanced/Eulerian_Tours.problems.json
@@ -8,9 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "eulerian-tours"
@@ -25,9 +23,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "eulerian-tours"
@@ -42,9 +38,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "eulerian-tours"
@@ -59,9 +53,7 @@
       "source": "Baltic OI",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/boi-2014/tasks/blob/master/solutions/analysis/postmen.tex"
@@ -74,9 +66,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -89,9 +79,7 @@
       "source": "CSA",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CSA"
@@ -104,9 +92,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -119,9 +105,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -134,9 +118,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -149,9 +131,7 @@
       "source": "Balkan OI",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Euler Tour"
-      ],
+      "tags": ["Euler Tour"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://bytefreaks.net/cyprus-computer-society/tasks-balkan-olympiad-in-informatics-2016"

--- a/content/6_Advanced/Lagrange.mdx
+++ b/content/6_Advanced/Lagrange.mdx
@@ -124,7 +124,7 @@ int main() {
 	int n, k;
 	cin >> n >> k;
 
-	int a[n];
+	vector<int> a(n);
 	for (int &i : a) { cin >> i; }
 
 	/**
@@ -133,7 +133,7 @@ int main() {
 	 * there is no limit to the number of subarrays you can create
 	 */
 	auto solve_lambda = [&](ll lmb) {
-		pair<ll, ll> dp[n][2];
+		vector<array<pair<ll, ll>, 2>> dp(n);
 
 		dp[0][0] = {0, 0};
 		dp[0][1] = {a[0] - lmb, 1};

--- a/content/6_Advanced/Lagrange.problems.json
+++ b/content/6_Advanced/Lagrange.problems.json
@@ -17,7 +17,7 @@
   "probs": [
     {
       "uniqueId": "usaco-697",
-      "name": "Tall Barn",
+      "name": "Building a Tall Barn",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=697",
       "source": "Platinum",
       "difficulty": "Easy",

--- a/content/6_Advanced/Matroid.problems.json
+++ b/content/6_Advanced/Matroid.problems.json
@@ -4,7 +4,7 @@
     {
       "uniqueId": "cf-2085D",
       "name": "Serval and Kaitenzushi Buffet",
-      "url": "https://codeforces.com/problemset/problem/2085/D",
+      "url": "https://codeforces.com/contest/2085/problem/D",
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": true,

--- a/content/6_Advanced/SCC.problems.json
+++ b/content/6_Advanced/SCC.problems.json
@@ -79,7 +79,7 @@
       }
     },
     {
-      "uniqueId": "cf-1534F1",
+      "uniqueId": "cf-1534F2",
       "name": "Falling Sand",
       "url": "https://codeforces.com/contest/1534/problem/F2",
       "source": "CF",

--- a/content/6_Advanced/SCC.problems.json
+++ b/content/6_Advanced/SCC.problems.json
@@ -8,9 +8,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "SCC"
-      ],
+      "tags": ["SCC"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -24,10 +22,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "DP",
-        "SCC"
-      ],
+      "tags": ["DP", "SCC"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -39,10 +34,7 @@
       "source": "POI",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "DP",
-        "SCC"
-      ],
+      "tags": ["DP", "SCC"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -54,10 +46,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "DP",
-        "SCC"
-      ],
+      "tags": ["DP", "SCC"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -70,9 +59,7 @@
       "source": "Old Gold",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "SCC"
-      ],
+      "tags": ["SCC"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "516"
@@ -85,9 +72,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "SCC"
-      ],
+      "tags": ["SCC"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -100,9 +85,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "SCC"
-      ],
+      "tags": ["SCC"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -115,9 +98,7 @@
       "source": "POI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "SCC"
-      ],
+      "tags": ["SCC"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/mostafa-saad/MyCompetitiveProgramming/blob/master/Olympiad/POI/official/2012/editorial/fes.pdf"
@@ -130,9 +111,7 @@
       "source": "Kattis",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "SCC"
-      ],
+      "tags": ["SCC"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -144,9 +123,7 @@
       "source": "CSES",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": [
-        "SCC"
-      ],
+      "tags": ["SCC"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -160,9 +137,7 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "2SAT"
-      ],
+      "tags": ["2SAT"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "SCC"
@@ -177,9 +152,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "2SAT"
-      ],
+      "tags": ["2SAT"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -192,11 +165,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "2SAT",
-        "DFS",
-        "DSU"
-      ],
+      "tags": ["2SAT", "DFS", "DSU"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -209,12 +178,7 @@
       "source": "CC",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "2SAT",
-        "DSU",
-        "Greedy",
-        "Sliding Window"
-      ],
+      "tags": ["2SAT", "DSU", "Greedy", "Sliding Window"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -226,9 +190,7 @@
       "source": "Kattis",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "2SAT"
-      ],
+      "tags": ["2SAT"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -240,9 +202,7 @@
       "source": "AC",
       "difficulty": "Medium",
       "isStarred": true,
-      "tags": [
-        "2SAT"
-      ],
+      "tags": ["2SAT"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"
@@ -255,11 +215,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": [
-        "2SAT",
-        "Binary Search",
-        "Tree"
-      ],
+      "tags": ["2SAT", "Binary Search", "Tree"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -272,10 +228,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": [
-        "2SAT",
-        "DFS"
-      ],
+      "tags": ["2SAT", "DFS"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/SCC.problems.json
+++ b/content/6_Advanced/SCC.problems.json
@@ -8,7 +8,9 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["SCC"],
+      "tags": [
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -22,7 +24,10 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DP", "SCC"],
+      "tags": [
+        "DP",
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -34,7 +39,10 @@
       "source": "POI",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DP", "SCC"],
+      "tags": [
+        "DP",
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -46,7 +54,10 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["DP", "SCC"],
+      "tags": [
+        "DP",
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -59,7 +70,9 @@
       "source": "Old Gold",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["SCC"],
+      "tags": [
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "516"
@@ -72,20 +85,24 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["SCC"],
+      "tags": [
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
       }
     },
     {
-      "uniqueId": "cf-1534F2",
+      "uniqueId": "cf-1534F1",
       "name": "Falling Sand",
       "url": "https://codeforces.com/contest/1534/problem/F2",
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["SCC"],
+      "tags": [
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -98,7 +115,9 @@
       "source": "POI",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["SCC"],
+      "tags": [
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/mostafa-saad/MyCompetitiveProgramming/blob/master/Olympiad/POI/official/2012/editorial/fes.pdf"
@@ -111,7 +130,9 @@
       "source": "Kattis",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["SCC"],
+      "tags": [
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -123,7 +144,9 @@
       "source": "CSES",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["SCC"],
+      "tags": [
+        "SCC"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -137,7 +160,9 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["2SAT"],
+      "tags": [
+        "2SAT"
+      ],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "SCC"
@@ -152,7 +177,9 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2SAT"],
+      "tags": [
+        "2SAT"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -165,7 +192,11 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2SAT", "DFS", "DSU"],
+      "tags": [
+        "2SAT",
+        "DFS",
+        "DSU"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -178,7 +209,12 @@
       "source": "CC",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2SAT", "DSU", "Greedy", "Sliding Window"],
+      "tags": [
+        "2SAT",
+        "DSU",
+        "Greedy",
+        "Sliding Window"
+      ],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -190,7 +226,9 @@
       "source": "Kattis",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["2SAT"],
+      "tags": [
+        "2SAT"
+      ],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -202,7 +240,9 @@
       "source": "AC",
       "difficulty": "Medium",
       "isStarred": true,
-      "tags": ["2SAT"],
+      "tags": [
+        "2SAT"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "AC"
@@ -215,7 +255,11 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["2SAT", "Binary Search", "Tree"],
+      "tags": [
+        "2SAT",
+        "Binary Search",
+        "Tree"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -228,7 +272,10 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["2SAT", "DFS"],
+      "tags": [
+        "2SAT",
+        "DFS"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/6_Advanced/Springboards.problems.json
+++ b/content/6_Advanced/Springboards.problems.json
@@ -31,7 +31,7 @@
     },
     {
       "uniqueId": "usaco-721",
-      "name": "Nocross",
+      "name": "Why Did the Cow Cross the Road II",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=721",
       "source": "Platinum",
       "difficulty": "Hard",

--- a/content/6_Advanced/String_Search.problems.json
+++ b/content/6_Advanced/String_Search.problems.json
@@ -8,7 +8,10 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["KMP", "Z Algorithm"],
+      "tags": [
+        "KMP",
+        "Z Algorithm"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -20,7 +23,10 @@
       "source": "POI",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["KMP", "Strings"],
+      "tags": [
+        "KMP",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/thecodingwizard/competitive-programming/blob/master/POI/POI%2006-Periods.cpp"
@@ -33,7 +39,10 @@
       "source": "Baltic OI",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["KMP", "Strings"],
+      "tags": [
+        "KMP",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -45,7 +54,10 @@
       "source": "Old Gold",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["KMP", "Strings"],
+      "tags": [
+        "KMP",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "sketch",
         "sketch": "Run KMP, except each state needs to be considered as not only a length, but also mapping of pattern to # of spots"
@@ -58,7 +70,10 @@
       "source": "POI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["KMP", "Strings"],
+      "tags": [
+        "KMP",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -70,7 +85,9 @@
       "source": "CEOI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["KMP"],
+      "tags": [
+        "KMP"
+      ],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://oi.edu.pl/static/attachment/20110713/ceoi-2011.pdf#page=16"
@@ -83,7 +100,9 @@
       "source": "POI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["KMP"],
+      "tags": [
+        "KMP"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -95,7 +114,9 @@
       "source": "POI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["KMP"],
+      "tags": [
+        "KMP"
+      ],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -109,7 +130,9 @@
       "source": "YS",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["Z Algorithm"],
+      "tags": [
+        "Z Algorithm"
+      ],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -121,7 +144,10 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": ["KMP", "Z Algorithm"],
+      "tags": [
+        "KMP",
+        "Z Algorithm"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -133,7 +159,10 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["DP", "Strings"],
+      "tags": [
+        "DP",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -146,7 +175,9 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Z Algorithm"],
+      "tags": [
+        "Z Algorithm"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -174,7 +205,9 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Palindrome"],
+      "tags": [
+        "Palindrome"
+      ],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "string-search"
@@ -189,7 +222,10 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["DP", "Strings"],
+      "tags": [
+        "DP",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "string-search"
@@ -204,7 +240,9 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Strings"],
+      "tags": [
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -217,7 +255,9 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Strings"],
+      "tags": [
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -230,7 +270,10 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Prefix Sums", "Strings"],
+      "tags": [
+        "Prefix Sums",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -245,7 +288,11 @@
       "source": "COCI",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": ["DFS", "Strings", "Trie"],
+      "tags": [
+        "DFS",
+        "Strings",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://hsin.hr/coci/contest3_solutions.zip"
@@ -258,7 +305,11 @@
       "source": "IOI",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": ["DFS", "Strings", "Trie"],
+      "tags": [
+        "DFS",
+        "Strings",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "IOI",
         "year": 2008
@@ -271,7 +322,10 @@
       "source": "YS",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Greedy", "Trie"],
+      "tags": [
+        "Greedy",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -283,7 +337,10 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["MST", "Trie"],
+      "tags": [
+        "MST",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -295,19 +352,25 @@
       "source": "Gold",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Strings", "Trie"],
+      "tags": [
+        "Strings",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
     },
     {
-      "uniqueId": "cf-37C",
+      "uniqueId": "cf-1083B",
       "name": "Old Berland Language",
       "url": "https://codeforces.com/contest/37/problem/C",
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Strings", "Trie"],
+      "tags": [
+        "Strings",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -320,7 +383,9 @@
       "source": "COCI",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Trie"],
+      "tags": [
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://hsin.hr/coci/archive/2019_2020/contest4_solutions.zip"
@@ -346,7 +411,11 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Small to Large", "Tree", "Trie"],
+      "tags": [
+        "Small to Large",
+        "Tree",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -359,7 +428,9 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Trie"],
+      "tags": [
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -372,7 +443,10 @@
       "source": "IZhO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Greedy", "Trie"],
+      "tags": [
+        "Greedy",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -384,7 +458,10 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["BIT", "Trie"],
+      "tags": [
+        "BIT",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "link",
         "url": "http://s3-ap-northeast-1.amazonaws.com/data.cms.ioi-jp.org/open-2016/2016-open-selling_rna-sol-en.pdf"
@@ -397,7 +474,10 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Tree", "Trie"],
+      "tags": [
+        "Tree",
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -412,7 +492,9 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Strings"],
+      "tags": [
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -424,7 +506,9 @@
       "source": "Gold",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Strings"],
+      "tags": [
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "533"
@@ -437,7 +521,9 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Strings"],
+      "tags": [
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -452,7 +538,10 @@
       "source": "APIO",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Palindrome", "Palindromic Tree"],
+      "tags": [
+        "Palindrome",
+        "Palindromic Tree"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -464,7 +553,10 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Prefix Sums", "Strings"],
+      "tags": [
+        "Prefix Sums",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -492,7 +584,9 @@
       "source": "CSES",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": ["Strings"],
+      "tags": [
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "string-search"
@@ -507,7 +601,9 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": true,
-      "tags": ["Z Algorithm"],
+      "tags": [
+        "Z Algorithm"
+      ],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "string-search"
@@ -522,7 +618,10 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Hashing", "Strings"],
+      "tags": [
+        "Hashing",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -534,7 +633,11 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Binary Search", "Hashing", "Strings"],
+      "tags": [
+        "Binary Search",
+        "Hashing",
+        "Strings"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -546,7 +649,9 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Trie"],
+      "tags": [
+        "Trie"
+      ],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/6_Advanced/String_Search.problems.json
+++ b/content/6_Advanced/String_Search.problems.json
@@ -301,7 +301,7 @@
       }
     },
     {
-      "uniqueId": "cf-1083B",
+      "uniqueId": "cf-37C",
       "name": "Old Berland Language",
       "url": "https://codeforces.com/contest/37/problem/C",
       "source": "CF",

--- a/content/6_Advanced/String_Search.problems.json
+++ b/content/6_Advanced/String_Search.problems.json
@@ -8,10 +8,7 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": [
-        "KMP",
-        "Z Algorithm"
-      ],
+      "tags": ["KMP", "Z Algorithm"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -23,10 +20,7 @@
       "source": "POI",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "KMP",
-        "Strings"
-      ],
+      "tags": ["KMP", "Strings"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://github.com/thecodingwizard/competitive-programming/blob/master/POI/POI%2006-Periods.cpp"
@@ -39,10 +33,7 @@
       "source": "Baltic OI",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "KMP",
-        "Strings"
-      ],
+      "tags": ["KMP", "Strings"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -54,10 +45,7 @@
       "source": "Old Gold",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "KMP",
-        "Strings"
-      ],
+      "tags": ["KMP", "Strings"],
       "solutionMetadata": {
         "kind": "sketch",
         "sketch": "Run KMP, except each state needs to be considered as not only a length, but also mapping of pattern to # of spots"
@@ -70,10 +58,7 @@
       "source": "POI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": [
-        "KMP",
-        "Strings"
-      ],
+      "tags": ["KMP", "Strings"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -85,9 +70,7 @@
       "source": "CEOI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": [
-        "KMP"
-      ],
+      "tags": ["KMP"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://oi.edu.pl/static/attachment/20110713/ceoi-2011.pdf#page=16"
@@ -100,9 +83,7 @@
       "source": "POI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": [
-        "KMP"
-      ],
+      "tags": ["KMP"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -114,9 +95,7 @@
       "source": "POI",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": [
-        "KMP"
-      ],
+      "tags": ["KMP"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -130,9 +109,7 @@
       "source": "YS",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": [
-        "Z Algorithm"
-      ],
+      "tags": ["Z Algorithm"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -144,10 +121,7 @@
       "source": "CSES",
       "difficulty": "Very Easy",
       "isStarred": true,
-      "tags": [
-        "KMP",
-        "Z Algorithm"
-      ],
+      "tags": ["KMP", "Z Algorithm"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -159,10 +133,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "DP",
-        "Strings"
-      ],
+      "tags": ["DP", "Strings"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -175,9 +146,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Z Algorithm"
-      ],
+      "tags": ["Z Algorithm"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -205,9 +174,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Palindrome"
-      ],
+      "tags": ["Palindrome"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "string-search"
@@ -222,10 +189,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "DP",
-        "Strings"
-      ],
+      "tags": ["DP", "Strings"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "string-search"
@@ -240,9 +204,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Strings"
-      ],
+      "tags": ["Strings"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -255,9 +217,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Strings"
-      ],
+      "tags": ["Strings"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -270,10 +230,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "Prefix Sums",
-        "Strings"
-      ],
+      "tags": ["Prefix Sums", "Strings"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -288,11 +245,7 @@
       "source": "COCI",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": [
-        "DFS",
-        "Strings",
-        "Trie"
-      ],
+      "tags": ["DFS", "Strings", "Trie"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://hsin.hr/coci/contest3_solutions.zip"
@@ -305,11 +258,7 @@
       "source": "IOI",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": [
-        "DFS",
-        "Strings",
-        "Trie"
-      ],
+      "tags": ["DFS", "Strings", "Trie"],
       "solutionMetadata": {
         "kind": "IOI",
         "year": 2008
@@ -322,10 +271,7 @@
       "source": "YS",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Greedy",
-        "Trie"
-      ],
+      "tags": ["Greedy", "Trie"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -337,10 +283,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "MST",
-        "Trie"
-      ],
+      "tags": ["MST", "Trie"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -352,10 +295,7 @@
       "source": "Gold",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Strings",
-        "Trie"
-      ],
+      "tags": ["Strings", "Trie"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -367,10 +307,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Strings",
-        "Trie"
-      ],
+      "tags": ["Strings", "Trie"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -383,9 +320,7 @@
       "source": "COCI",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Trie"
-      ],
+      "tags": ["Trie"],
       "solutionMetadata": {
         "kind": "link",
         "url": "https://hsin.hr/coci/archive/2019_2020/contest4_solutions.zip"
@@ -411,11 +346,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Small to Large",
-        "Tree",
-        "Trie"
-      ],
+      "tags": ["Small to Large", "Tree", "Trie"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -428,9 +359,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Trie"
-      ],
+      "tags": ["Trie"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -443,10 +372,7 @@
       "source": "IZhO",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "Greedy",
-        "Trie"
-      ],
+      "tags": ["Greedy", "Trie"],
       "solutionMetadata": {
         "kind": "none"
       }
@@ -458,10 +384,7 @@
       "source": "JOI",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": [
-        "BIT",
-        "Trie"
-      ],
+      "tags": ["BIT", "Trie"],
       "solutionMetadata": {
         "kind": "link",
         "url": "http://s3-ap-northeast-1.amazonaws.com/data.cms.ioi-jp.org/open-2016/2016-open-selling_rna-sol-en.pdf"
@@ -474,10 +397,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "Tree",
-        "Trie"
-      ],
+      "tags": ["Tree", "Trie"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -492,9 +412,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Strings"
-      ],
+      "tags": ["Strings"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -506,9 +424,7 @@
       "source": "Gold",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Strings"
-      ],
+      "tags": ["Strings"],
       "solutionMetadata": {
         "kind": "USACO",
         "usacoId": "533"
@@ -521,9 +437,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Strings"
-      ],
+      "tags": ["Strings"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -538,10 +452,7 @@
       "source": "APIO",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": [
-        "Palindrome",
-        "Palindromic Tree"
-      ],
+      "tags": ["Palindrome", "Palindromic Tree"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -553,10 +464,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": [
-        "Prefix Sums",
-        "Strings"
-      ],
+      "tags": ["Prefix Sums", "Strings"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"
@@ -584,9 +492,7 @@
       "source": "CSES",
       "difficulty": "Hard",
       "isStarred": true,
-      "tags": [
-        "Strings"
-      ],
+      "tags": ["Strings"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "string-search"
@@ -601,9 +507,7 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": true,
-      "tags": [
-        "Z Algorithm"
-      ],
+      "tags": ["Z Algorithm"],
       "solutionMetadata": {
         "kind": "in-module",
         "moduleId": "string-search"
@@ -618,10 +522,7 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Hashing",
-        "Strings"
-      ],
+      "tags": ["Hashing", "Strings"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -633,11 +534,7 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Binary Search",
-        "Hashing",
-        "Strings"
-      ],
+      "tags": ["Binary Search", "Hashing", "Strings"],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -649,9 +546,7 @@
       "source": "CSES",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": [
-        "Trie"
-      ],
+      "tags": ["Trie"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/extraProblems.json
+++ b/content/extraProblems.json
@@ -232,7 +232,7 @@
     },
     {
       "uniqueId": "usaco-1087",
-      "name": "No Time To Paint",
+      "name": "No Time to Paint",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1087",
       "source": "Silver",
       "difficulty": "Medium",
@@ -395,7 +395,7 @@
     },
     {
       "uniqueId": "usaco-1137",
-      "name": "UCFJ",
+      "name": "United Cows of Farmer John",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1137",
       "source": "Gold",
       "difficulty": "Medium",
@@ -420,7 +420,7 @@
     },
     {
       "uniqueId": "usaco-1140",
-      "name": "UCFJ",
+      "name": "United Cows of Farmer John",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1140",
       "source": "Platinum",
       "difficulty": "Medium",
@@ -433,7 +433,7 @@
     },
     {
       "uniqueId": "usaco-1141",
-      "name": "Routing",
+      "name": "Routing Schemes",
       "url": "http://www.usaco.org/index.php?page=viewproblem2&cpid=1141",
       "source": "Platinum",
       "difficulty": "Medium",

--- a/py/check_mdx.py
+++ b/py/check_mdx.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Textual checks over the .mdx under ``content/`` and ``solutions/``.
+
+Rules the compiler cannot express and a reviewer keeps having to apply by eye.
+Both are scoped by fenced code block, because both are noise without it.
+
+1. Links into the guide are relative. ``Adding_Solution.mdx`` asks for
+   ``/silver/binary-search`` over ``https://usaco.guide/silver/binary-search``,
+   and an absolute one bounces the reader off a preview deployment back to the
+   live site mid-page -- exactly where a reviewer clicks.
+
+   Only markdown links outside code fences are flagged. Inside a fence the URL
+   is usually in a comment that someone may paste into an editor, where a
+   relative path means nothing, and the rule's own statement quotes the
+   absolute form as its bad example.
+
+2. ``cout.tie(...)`` does not appear in C++ snippets. ``Adding_Solution.mdx``
+   bans it as code that does nothing, since ``cout`` is not tied to anything.
+
+   Only inside a ```cpp fence: the ban's own wording and the Fast_IO warning
+   explaining it both name the call in prose, and neither is a violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+ANNOTATE = bool(os.environ.get("GITHUB_ACTIONS"))
+
+FENCE = re.compile(r"^\s*```(\w*)")
+# A markdown link whose target is the guide's own origin.
+ABSOLUTE_LINK = re.compile(r"\]\(\s*(https?://(?:www\.)?usaco\.guide(/[^)\s]*)?)\s*\)")
+# Any spelling: the one in the tree was cout.tie(0), not cout.tie(nullptr).
+COUT_TIE = re.compile(r"\bcout\s*\.\s*tie\s*\(")
+
+
+def mdx_files() -> list[Path]:
+	return sorted(
+		list((ROOT / "content").rglob("*.mdx"))
+		+ list((ROOT / "solutions").rglob("*.mdx"))
+	)
+
+
+def annotate(path: str, line: int, message: str) -> None:
+	# A newline would end the workflow command, so keep the message on one line.
+	print(f"::error file={path},line={line},title=MDX check::{message}")
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+	errors: list[tuple[int, str]] = []
+	language: str | None = None  # the open fence's language, None outside a fence
+
+	for number, line in enumerate(path.read_text().splitlines(), 1):
+		fence = FENCE.match(line)
+		if fence:
+			language = fence.group(1) if language is None else None
+			continue
+
+		if language is None:
+			for match in ABSOLUTE_LINK.finditer(line):
+				target = match.group(2) or "/"
+				errors.append(
+					(number, f"link to {match.group(1)} should be relative: {target}")
+				)
+		elif language == "cpp" and COUT_TIE.search(line):
+			errors.append(
+				(
+					number,
+					"cout.tie(...) does nothing, since cout is not tied to anything; "
+					"see /general/fast-io#cintienullptr",
+				)
+			)
+	return errors
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("paths", nargs="*", type=Path)
+	parser.add_argument("--all", action="store_true", help="check every .mdx")
+	args = parser.parse_args()
+
+	if args.all or not args.paths:
+		paths = mdx_files()
+	else:
+		paths = [p for p in args.paths if p.suffix == ".mdx"]
+
+	failed = 0
+	for path in paths:
+		for line, message in check_file(path):
+			rel = path.relative_to(ROOT) if path.is_absolute() else path
+			print(f"{rel}:{line}: {message}")
+			if ANNOTATE:
+				annotate(str(rel), line, message)
+			failed += 1
+
+	if failed:
+		print(f"\n{failed} finding(s) in .mdx files.", file=sys.stderr)
+	return 1 if failed else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/py/check_problems_json.py
+++ b/py/check_problems_json.py
@@ -20,6 +20,12 @@ reasonably verify by reading a diff:
    a mistyped id. Repointing the url at the id would send the reader to a
    different problem, so check the name against the judge before "fixing" either.
 
+   Those four are listed in ``problems_mismatched_id.txt`` rather than corrected,
+   because ``uniqueId`` is what Firebase keys user progress and
+   ``userProblemSolutions`` on: renaming one orphans progress people genuinely
+   earned. That list only shrinks -- a new mismatch fails, and an entry on it
+   that no longer mismatches must be removed.
+
 3. Copies of one problem in several modules agree on the fields that cannot
    legitimately differ. Only three qualify. ``difficulty`` is documented as
    "relative to the module it is in" and ``isStarred`` as "starred in the module
@@ -44,6 +50,9 @@ from collections import defaultdict
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+# Ids that disagree with their url and cannot be corrected until the Firebase
+# progress and userProblemSolutions keyed on them move too. Only shrinks.
+MISMATCHED_ID_LIST = Path(__file__).resolve().parent / "problems_mismatched_id.txt"
 DIV_TO_PROBS = (
 	ROOT / "src/components/markdown/ProblemsList/DivisionList/div_to_probs.json"
 )
@@ -181,9 +190,15 @@ def main() -> int:
 	parser.parse_args()
 
 	official = load_official_names()
+	id_backlog = {
+		line.strip()
+		for line in MISMATCHED_ID_LIST.read_text().splitlines()
+		if line.strip() and not line.startswith("#")
+	}
 	texts: dict[Path, str] = {}
 	copies: dict[str, list[tuple[Path, dict]]] = defaultdict(list)
 	findings: list[tuple[Path, str, str]] = []  # path, uniqueId, message
+	mismatched_ids: set[str] = set()
 
 	for path in problem_files():
 		texts[path] = path.read_text()
@@ -191,10 +206,27 @@ def main() -> int:
 			if not isinstance(entries, list):
 				continue
 			for problem in entries:
-				copies[problem["uniqueId"]].append((path, problem))
-				for message in (check_name(problem, official), check_url(problem)):
-					if message:
-						findings.append((path, problem["uniqueId"], message))
+				unique_id = problem["uniqueId"]
+				copies[unique_id].append((path, problem))
+
+				name_error = check_name(problem, official)
+				if name_error:
+					findings.append((path, unique_id, name_error))
+
+				url_error = check_url(problem)
+				if url_error:
+					mismatched_ids.add(unique_id)
+					# The backlog holds ids that are known-wrong but cannot be
+					# renamed until the Firebase progress keyed on them moves.
+					if unique_id not in id_backlog:
+						findings.append((path, unique_id, url_error))
+
+	stale_backlog = sorted(id_backlog - mismatched_ids)
+	for stale in stale_backlog:
+		print(
+			f"{MISMATCHED_ID_LIST.name}: `{stale}` no longer disagrees with its url; "
+			"remove it"
+		)
 
 	for unique_id, listed in sorted(copies.items()):
 		if len(listed) < 2:
@@ -212,7 +244,7 @@ def main() -> int:
 
 	if findings:
 		print(f"\n{len(findings)} problem entr(ies) need fixing.", file=sys.stderr)
-	return 1 if findings else 0
+	return 1 if findings or stale_backlog else 0
 
 
 if __name__ == "__main__":

--- a/py/check_problems_json.py
+++ b/py/check_problems_json.py
@@ -79,6 +79,12 @@ CF_URL = re.compile(
 SHARED_FIELDS = ("name", "url")
 
 
+def internal_solutions() -> set[str]:
+	"""uniqueIds with a solution file. `orphaned/` counts: no module links to
+	those, but the loader still indexes them, so `internal` resolves."""
+	return {path.stem for path in (ROOT / "solutions").rglob("*.mdx")}
+
+
 def problem_files() -> list[Path]:
 	return sorted((ROOT / "content").rglob("*.problems.json")) + [
 		ROOT / "content/extraProblems.json"
@@ -143,6 +149,19 @@ def check_url(problem: dict) -> str | None:
 	return None
 
 
+def check_internal(problem: dict, solutions: set[str]) -> str | None:
+	"""An entry promising an internal solution must have one to show."""
+	metadata = problem.get("solutionMetadata") or {}
+	if metadata.get("kind") != "internal":
+		return None
+	if problem["uniqueId"] in solutions:
+		return None
+	return (
+		'solutionMetadata says kind "internal", but there is no '
+		f'solutions/*/{problem["uniqueId"]}.mdx'
+	)
+
+
 def hints_flag(problem: dict) -> bool | None:
 	"""Whether an internally-solved problem declares hints. None if not internal."""
 	metadata = problem.get("solutionMetadata") or {}
@@ -190,6 +209,7 @@ def main() -> int:
 	parser.parse_args()
 
 	official = load_official_names()
+	solutions = internal_solutions()
 	id_backlog = {
 		line.strip()
 		for line in MISMATCHED_ID_LIST.read_text().splitlines()
@@ -209,9 +229,12 @@ def main() -> int:
 				unique_id = problem["uniqueId"]
 				copies[unique_id].append((path, problem))
 
-				name_error = check_name(problem, official)
-				if name_error:
-					findings.append((path, unique_id, name_error))
+				for message in (
+					check_name(problem, official),
+					check_internal(problem, solutions),
+				):
+					if message:
+						findings.append((path, unique_id, message))
 
 				url_error = check_url(problem)
 				if url_error:

--- a/py/check_problems_json.py
+++ b/py/check_problems_json.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Quality checks for the problem lists under ``content/``.
+
+Run by pre-commit and by CI. Three rules, all of them things a reviewer cannot
+reasonably verify by reading a diff:
+
+1. A USACO problem's ``name`` matches usaco.org. The authoritative names are
+   already vendored in ``div_to_probs.json``, which ``DivisionList/scripts/update.py``
+   scrapes, so this needs no network. usaco.org appends the division to a name
+   that would otherwise be ambiguous across divisions ("High Card Low Card
+   (Gold)"); ``source`` already carries that, so the suffix is stripped before
+   comparing rather than written into every entry.
+
+2. A problem's ``url`` points at the problem its ``uniqueId`` names. Only URL
+   shapes that encode the id are checked -- a gym, edu-course or group link
+   cannot be derived from the id, so those are left alone rather than guessed at.
+
+   When this rule fires, the ``uniqueId`` is usually the wrong side: every one
+   of the four it caught on introduction had a correct ``name`` and ``url`` and
+   a mistyped id. Repointing the url at the id would send the reader to a
+   different problem, so check the name against the judge before "fixing" either.
+
+3. Copies of one problem in several modules agree on the fields that cannot
+   legitimately differ. Only three qualify. ``difficulty`` is documented as
+   "relative to the module it is in" and ``isStarred`` as "starred in the module
+   problem table"; ``tags`` are unioned across modules when the site builds its
+   filters. ``solutionMetadata.kind`` is module-scoped too -- a focus problem is
+   ``in-module`` where it is taught and a plain link elsewhere -- but
+   ``hasHints`` describes the solution *file*, so it cannot depend on the route
+   the reader took to reach it.
+
+Rule 3 is global by nature, so this checks every list regardless of the paths
+it is given; the whole sweep is a few hundred milliseconds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DIV_TO_PROBS = (
+	ROOT / "src/components/markdown/ProblemsList/DivisionList/div_to_probs.json"
+)
+
+# Actions renders an ::error on the line it names. Every finding here quotes an
+# entry that exists, so all of them can be anchored to their "uniqueId" line.
+ANNOTATE = bool(os.environ.get("GITHUB_ACTIONS"))
+
+# usaco.org disambiguates a name reused across divisions by appending the
+# division. `source` already records that, so it is not part of the name.
+DIVISION_SUFFIX = re.compile(r"\s*\((Bronze|Silver|Gold|Platinum)\)$")
+
+USACO_ID = re.compile(r"usaco-(\d+)$")
+CF_ID = re.compile(r"cf-(\d+)([A-Z]\d?)$")
+# The two URL shapes that encode a Codeforces contest and index. Gym, edu and
+# group links do not, and are skipped rather than guessed at.
+CF_URL = re.compile(
+	r"^https?://(?:www\.)?codeforces\.com/"
+	r"(?:contest/(\d+)/problem/([A-Z]\d?)|problemset/problem/(\d+)/([A-Z]\d?))"
+	r"/?$"
+)
+
+# Fields that mean the same thing wherever a problem is listed. See rule 3.
+SHARED_FIELDS = ("name", "url")
+
+
+def problem_files() -> list[Path]:
+	return sorted((ROOT / "content").rglob("*.problems.json")) + [
+		ROOT / "content/extraProblems.json"
+	]
+
+
+def load_official_names() -> dict[str, str]:
+	"""cpid -> the name on usaco.org, with any division suffix stripped."""
+	div_to_probs = json.loads(DIV_TO_PROBS.read_text())
+	return {
+		cpid: DIVISION_SUFFIX.sub("", name)
+		for problems in div_to_probs.values()
+		for cpid, _contest, name in problems
+	}
+
+
+def line_of(text: str, unique_id: str) -> int | None:
+	"""1-indexed line of an entry's "uniqueId", for an annotation."""
+	match = re.search(rf'"uniqueId":\s*"{re.escape(unique_id)}"', text)
+	return text.count("\n", 0, match.start()) + 1 if match else None
+
+
+def annotate(path: str, line: int | None, message: str) -> None:
+	where = f"file={path}" + (f",line={line}" if line is not None else "")
+	# A newline would end the workflow command, so keep the message on one line.
+	print(f"::error {where},title=Problem data check::{message}")
+
+
+def check_name(problem: dict, official: dict[str, str]) -> str | None:
+	match = USACO_ID.fullmatch(problem["uniqueId"])
+	if match is None or match.group(1) not in official:
+		return None
+	want = official[match.group(1)]
+	if problem["name"] == want:
+		return None
+	return f"name is {problem['name']!r}; usaco.org calls it {want!r}"
+
+
+def check_url(problem: dict) -> str | None:
+	unique_id, url = problem["uniqueId"], problem.get("url", "")
+
+	usaco = USACO_ID.fullmatch(unique_id)
+	if usaco is not None:
+		cpid = usaco.group(1)
+		if f"cpid={cpid}" not in url:
+			return f"url does not point at cpid={cpid}: {url}"
+		return None
+
+	codeforces = CF_ID.fullmatch(unique_id)
+	if codeforces is not None:
+		parsed = CF_URL.match(url)
+		if parsed is None:
+			return None  # gym/edu/group link; the id cannot describe it
+		contest = parsed.group(1) or parsed.group(3)
+		index = parsed.group(2) or parsed.group(4)
+		if (contest, index) != codeforces.groups():
+			return (
+				f"url points at contest {contest} problem {index}, but the id says "
+				f"{codeforces.group(1)}{codeforces.group(2)}. Check the name against "
+				f"the judge -- the id is usually the wrong side"
+			)
+	return None
+
+
+def hints_flag(problem: dict) -> bool | None:
+	"""Whether an internally-solved problem declares hints. None if not internal."""
+	metadata = problem.get("solutionMetadata") or {}
+	if metadata.get("kind") != "internal":
+		return None
+	return bool(metadata.get("hasHints"))
+
+
+def check_shared(
+	copies: list[tuple[Path, dict]],
+) -> list[str]:
+	"""Fields that cannot legitimately differ between copies of one problem."""
+	errors = []
+	for field in SHARED_FIELDS:
+		values = {
+			json.dumps(problem.get(field), sort_keys=True) for _, problem in copies
+		}
+		if len(values) > 1:
+			listed = ", ".join(
+				f"{path.relative_to(ROOT)} has {problem.get(field)!r}"
+				for path, problem in copies
+			)
+			errors.append(f"copies disagree on {field}: {listed}")
+
+	flags = {hints_flag(problem) for _, problem in copies} - {None}
+	if len(flags) > 1:
+		listed = ", ".join(
+			f"{path.relative_to(ROOT)} says {hints_flag(problem)}"
+			for path, problem in copies
+			if hints_flag(problem) is not None
+		)
+		errors.append(
+			"copies disagree on solutionMetadata.hasHints, which describes the "
+			f"solution file and cannot vary by module: {listed}"
+		)
+	return errors
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__)
+	# Accepted for pre-commit, which passes the files it staged. Rule 3 compares
+	# a problem against its copies elsewhere, so the sweep is always global.
+	parser.add_argument("paths", nargs="*", type=Path)
+	parser.add_argument("--all", action="store_true", help="accepted; always implied")
+	parser.parse_args()
+
+	official = load_official_names()
+	texts: dict[Path, str] = {}
+	copies: dict[str, list[tuple[Path, dict]]] = defaultdict(list)
+	findings: list[tuple[Path, str, str]] = []  # path, uniqueId, message
+
+	for path in problem_files():
+		texts[path] = path.read_text()
+		for entries in json.loads(texts[path]).values():
+			if not isinstance(entries, list):
+				continue
+			for problem in entries:
+				copies[problem["uniqueId"]].append((path, problem))
+				for message in (check_name(problem, official), check_url(problem)):
+					if message:
+						findings.append((path, problem["uniqueId"], message))
+
+	for unique_id, listed in sorted(copies.items()):
+		if len(listed) < 2:
+			continue
+		for message in check_shared(listed):
+			findings.append((listed[0][0], unique_id, message))
+
+	for path, unique_id, message in findings:
+		rel = path.relative_to(ROOT)
+		print(f"{rel}: {unique_id}: {message}")
+		if ANNOTATE:
+			annotate(
+				str(rel), line_of(texts[path], unique_id), f"{unique_id}: {message}"
+			)
+
+	if findings:
+		print(f"\n{len(findings)} problem entr(ies) need fixing.", file=sys.stderr)
+	return 1 if findings else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/py/check_problems_json.py
+++ b/py/check_problems_json.py
@@ -75,6 +75,10 @@ CF_URL = re.compile(
 	r"/?$"
 )
 
+# solutions/orphaned holds solutions no module links to; a file there is
+# deliberately unreachable, which is the point of the directory.
+SKIP_DIRS = {"orphaned"}
+
 # Fields that mean the same thing wherever a problem is listed. See rule 3.
 SHARED_FIELDS = ("name", "url")
 
@@ -83,6 +87,16 @@ def internal_solutions() -> set[str]:
 	"""uniqueIds with a solution file. `orphaned/` counts: no module links to
 	those, but the loader still indexes them, so `internal` resolves."""
 	return {path.stem for path in (ROOT / "solutions").rglob("*.mdx")}
+
+
+def reachable_solutions() -> dict[str, Path]:
+	"""Solution files that something is expected to link to, so `orphaned/` is
+	excluded -- that directory is how a solution is declared dead."""
+	return {
+		path.stem: path
+		for path in (ROOT / "solutions").rglob("*.mdx")
+		if path.parent.name not in SKIP_DIRS
+	}
 
 
 def problem_files() -> list[Path]:
@@ -243,6 +257,31 @@ def main() -> int:
 					# renamed until the Firebase progress keyed on them moves.
 					if unique_id not in id_backlog:
 						findings.append((path, unique_id, url_error))
+
+	# A written solution that no entry points at is invisible: the reader is sent
+	# to the official link, or to the module, and never sees it. Moving the file
+	# to solutions/orphaned/ is how to say that is intended.
+	for unique_id, path in sorted(reachable_solutions().items()):
+		listed = copies.get(unique_id, [])
+		if listed and not any(
+			(problem.get("solutionMetadata") or {}).get("kind") == "internal"
+			for _, problem in listed
+		):
+			kinds = sorted(
+				{
+					str((problem.get("solutionMetadata") or {}).get("kind"))
+					for _, problem in listed
+				}
+			)
+			findings.append(
+				(
+					listed[0][0],
+					unique_id,
+					f"{path.relative_to(ROOT)} exists but no entry has kind "
+					f"\"internal\" (found {', '.join(kinds)}), so no reader can "
+					"reach it; mark it internal or move it to solutions/orphaned/",
+				)
+			)
 
 	stale_backlog = sorted(id_backlog - mismatched_ids)
 	for stale in stale_backlog:

--- a/py/problems_mismatched_id.txt
+++ b/py/problems_mismatched_id.txt
@@ -1,0 +1,25 @@
+# Problems whose `uniqueId` disagrees with the `url` it carries.
+#
+# In every case here the `name` and `url` agree with each other and describe a
+# real problem -- it is the id that is mistyped. Correcting an id is therefore
+# the right fix, but not a free one: `uniqueId` is what Firebase keys user
+# progress and `userProblemSolutions` on, so a rename orphans progress that
+# people genuinely earned on the problem the entry describes. That wants a
+# migration alongside it, so the renames are deferred rather than dropped.
+#
+# What each should become, confirmed against the Codeforces API:
+#
+#   cf-1083B  -> cf-37C      37C is "Old Berland Language"; 1083B is
+#                            "The Fair Nut and Strings"
+#   cf-949D   -> cf-1981D    949 was the round number, not the contest id
+#   cf-880D   -> cf-800D     "Varying Kibibits" is 772D, mirrored at 800D;
+#                            880D is neither
+#   cf-1534F1 -> cf-1534F2   tagged SCC at difficulty Hard, i.e. the hard version
+#
+# This list only shrinks. A new mismatch fails the check; an entry here that no
+# longer mismatches must be removed.
+
+cf-1083B
+cf-949D
+cf-880D
+cf-1534F1

--- a/scripts/check-code-snippets.ts
+++ b/scripts/check-code-snippets.ts
@@ -33,6 +33,30 @@ import { promisify } from 'util';
 const execFileAsync = promisify(execFile);
 
 const STANDARD = process.env.CXX_STANDARD ?? 'c++20';
+
+/**
+ * Diagnostics promoted to errors. Deliberately a short list: g++ has plenty
+ * more to say about this corpus, but almost all of it is noise here. Of the 76
+ * warnings the wider set produced, 46 were not defects -- every -Wparentheses
+ * hit was code that already means what it looks like (`1 << j - 1` really is
+ * `1 << (j-1)`), every -Wreorder hit initialised from a constructor parameter
+ * rather than another member, and -Wshift-count-overflow fired on the module
+ * that exists to demonstrate that `1 << 32` overflows.
+ *
+ * These two are not like that:
+ *
+ *   -Wvla          Adding_Solution.mdx bans variable-length arrays outright,
+ *                  and reviewers were still catching them by hand.
+ *   -Wreturn-type  Falling off the end of a non-void function is undefined
+ *                  behaviour, whatever the caller does with the result.
+ *
+ * Both were clean at zero remaining occurrences when this was introduced, so a
+ * new hit is a new defect. The checker only compiles snippets that contain both
+ * an #include and an int main(, which is why the deliberate VLA in
+ * Intro_DS.mdx -- a bare fragment, shown precisely to say not to write one --
+ * needs no opt-out.
+ */
+const ERRORS = ['-Werror=vla', '-Werror=return-type'];
 /** Each check is its own process, so the pool can be as wide as the machine. */
 const JOBS = Number(process.env.JOBS) || availableParallelism();
 const PYTHON = process.env.PYTHON ?? 'python3';
@@ -175,7 +199,16 @@ async function main() {
           const { snippet, source } = jobs[at];
           const [command, args] =
             snippet.lang === 'cpp'
-              ? [cxx, [`-std=${STANDARD}`, ...include, '-fsyntax-only', source]]
+              ? [
+                  cxx,
+                  [
+                    `-std=${STANDARD}`,
+                    ...include,
+                    ...ERRORS,
+                    '-fsyntax-only',
+                    source,
+                  ],
+                ]
               : [PYTHON, ['-c', PARSE_PYTHON, source]];
           try {
             await execFileAsync(command, args, { maxBuffer: 32 << 20 });

--- a/scripts/check-code-snippets.ts
+++ b/scripts/check-code-snippets.ts
@@ -17,7 +17,7 @@ import { promisify } from 'util';
  * -fsyntax-only, Python is parsed.
  *
  * Only C++ snippets that look like a whole program are compiled — the block
- * has to contain both an #include and an int main(. Fragments illustrating one
+ * has to contain both an #include and a main (see MAIN). Fragments illustrating one
  * function, and snippets including a header that ships with the problem such
  * as grader.h, are skipped; neither is meant to compile alone. Python is
  * parsed rather than run, so fragments are fine as long as they stand on their
@@ -52,9 +52,8 @@ const STANDARD = process.env.CXX_STANDARD ?? 'c++20';
  *
  * Both were clean at zero remaining occurrences when this was introduced, so a
  * new hit is a new defect. The checker only compiles snippets that contain both
- * an #include and an int main(, which is why the deliberate VLA in
- * Intro_DS.mdx -- a bare fragment, shown precisely to say not to write one --
- * needs no opt-out.
+ * an #include and a main, which is why the deliberate VLA in Intro_DS.mdx -- a
+ * bare fragment, shown precisely to say not to write one -- needs no opt-out.
  */
 const ERRORS = ['-Werror=vla', '-Werror=return-type'];
 /** Each check is its own process, so the pool can be as wide as the machine. */
@@ -94,8 +93,17 @@ const PCH_WORTH_IT_ABOVE = 8;
 /** Snippets that only build on x86, for the intrinsics or the target pragma. */
 const X86_ONLY = /immintrin\.h|target\s*\(\s*"[^"]*(avx|sse|bmi|popcnt)/i;
 
-/** How a C++ snippet's entry point may be spelled. */
-const MAIN = /^\s*(?:int|signed|int32_t|auto)\s+main\s*\(/m;
+/**
+ * How a C++ snippet's entry point may be spelled. The return type is optional
+ * and may run to several words, so this takes any run of type keywords: plain
+ * `int main()`, the `signed main()` that `#define int long long` forces,
+ * `long long main()`, a fixed-width `int32_t main()`, and a bare `main()`.
+ *
+ * A bare `main()` is not valid C++ -- implicit int is long gone -- which is a
+ * reason to compile the snippet and say so, not to quietly skip it.
+ */
+const MAIN =
+  /^\s*(?:(?:signed|unsigned|int|long|short|void|auto|int32_t|int64_t)\s+)+main\s*\(|^\s*main\s*\([^;)]*\)\s*\{/m;
 
 type Lang = 'cpp' | 'py';
 
@@ -283,8 +291,8 @@ export function extractSnippets(file: string, source: string): Snippet[] {
     i = end;
 
     if (lang === 'cpp') {
-      // A whole program, not a fragment illustrating one function. Solutions
-      // spell the entry point `int main`, `signed main` or `int32_t main`.
+      // A whole program, not a fragment illustrating one function. See MAIN
+      // for the entry-point spellings that count.
       if (!code.includes('#include') || !MAIN.test(code)) continue;
       // Needs a header that ships with the problem, e.g. grader.h. Quoting
       // the GCC catch-all is just a style, not a missing header -- seven whole

--- a/solutions/advanced/cses-1732.mdx
+++ b/solutions/advanced/cses-1732.mdx
@@ -7,7 +7,7 @@ author: Mihnea Brebenel
 
 ## Explanation
 
-The comparison between prefixes and suffixes can be quickly done using [String Hashing](https://usaco.guide/gold/hashing#string-hashing).
+The comparison between prefixes and suffixes can be quickly done using [String Hashing](/gold/hashing#string-hashing).
 
 ## Implementation
 

--- a/solutions/advanced/cses-1753.mdx
+++ b/solutions/advanced/cses-1753.mdx
@@ -145,7 +145,7 @@ int main() {
 
 ## Solution - Rabin-Karp Algorithm
 
-Precompute the [rolling hash](https://usaco.guide/gold/string-hashing?lang=cpp) of both $P$ and $T$. Each substring of length $|P|$ can be compared for equality in $\mathcal{O}(1)$ time. Since there is a relatively small number of comparisons, using a single set of hash values is fine (although it doesn't hurt to add more!). Using hash base $9973$ and modulo $10^9 + 7$ suffices (see the string hashing module for more details on this choice).
+Precompute the [rolling hash](/gold/string-hashing?lang=cpp) of both $P$ and $T$. Each substring of length $|P|$ can be compared for equality in $\mathcal{O}(1)$ time. Since there is a relatively small number of comparisons, using a single set of hash values is fine (although it doesn't hurt to add more!). Using hash base $9973$ and modulo $10^9 + 7$ suffices (see the string hashing module for more details on this choice).
 
 <LanguageSection>
 

--- a/solutions/bronze/cf-863B.mdx
+++ b/solutions/bronze/cf-863B.mdx
@@ -32,7 +32,6 @@ int main() {
 
 	ios_base::sync_with_stdio(0);
 	cin.tie(0);
-	cout.tie(0);
 
 	// read in the input values
 	cin >> N;

--- a/solutions/bronze/usaco-509.mdx
+++ b/solutions/bronze/usaco-509.mdx
@@ -43,7 +43,7 @@ $$
 This is a much more manageable problem! From here, there are a few ways
 we can implement a fast solution:
 
-- Use [two pointers](https://usaco.guide/silver/two-pointers) to keep track of
+- Use [two pointers](/silver/two-pointers) to keep track of
   the most relevant value of $y$ at every step
 - Use a data structure like a `std::map` to store all precomputed values for $n_2$
 - Keep the precomputed base $10$ values in an array, and use binary search

--- a/solutions/bronze/usaco-784.mdx
+++ b/solutions/bronze/usaco-784.mdx
@@ -25,8 +25,7 @@ int32_t main() {
 
 	int cows;
 	cin >> cows;
-	int startT[cows];
-	int endT[cows];
+	vector<int> startT(cows), endT(cows);
 	int times[1000];
 	int shiftTotal = -1;
 

--- a/solutions/bronze/usaco-785.mdx
+++ b/solutions/bronze/usaco-785.mdx
@@ -30,8 +30,7 @@ int main() {
 	// as well as the difference variable
 	int n;
 	cin >> n;
-	int og[n];
-	int sorted[n];
+	vector<int> og(n), sorted(n);
 	int diff = 0;
 
 	// Take in the values of the array as input,
@@ -42,7 +41,7 @@ int main() {
 	}
 
 	// Actually sort the "sorted" array
-	sort(sorted, sorted + n);
+	sort(sorted.begin(), sorted.end());
 
 	// Count the number of differences in the arrays
 	for (int i = 0; i < n; i++) {

--- a/solutions/bronze/usaco-892.mdx
+++ b/solutions/bronze/usaco-892.mdx
@@ -127,7 +127,7 @@ int main() {
 	// Take in size of array (n) and create a array to store the cow positions
 	int n;
 	cin >> n;
-	int cows[n];
+	vector<int> cows(n);
 
 	// Take in the start positions of the cows and store them in the array
 	for (int i = 0; i < n; i++) { cin >> cows[i]; }

--- a/solutions/gold/cf-1513D.mdx
+++ b/solutions/gold/cf-1513D.mdx
@@ -9,7 +9,7 @@ author: Chuyang Wang, Raagav Bala
 
 ## Explanation
 
-Like [Kruskal's Algorithm](https://usaco.guide/gold/mst#kruskals), we generate
+Like [Kruskal's Algorithm](/gold/mst#kruskals), we generate
 our MST by adding edges greedily. Except the edges between any two adjacent
 elements in the array which cost $p$, an edge only exists between $i$ and $j$ if
 the greatest common divisor of all elements in $[i, j]$ equals the minimum of

--- a/solutions/gold/cf-1713E.mdx
+++ b/solutions/gold/cf-1713E.mdx
@@ -98,7 +98,7 @@ struct DSU {
 void solve() {
 	int n;
 	cin >> n;
-	int a[n][n];
+	vector<vector<int>> a(n, vector<int>(n));
 	for (int i = 0; i < n; i++) {
 		for (int j = 0; j < n; j++) { cin >> a[i][j]; }
 	}

--- a/solutions/gold/cf-888D.mdx
+++ b/solutions/gold/cf-888D.mdx
@@ -48,8 +48,7 @@ int main() {
 	cin >> n >> k;
 
 	// Use Pascal's Identity to precalculate combinations.
-	ll c[n + 1][k + 1];
-	fill_n(&c[0][0], (n + 1) * (k + 1), 0);
+	vector<vector<ll>> c(n + 1, vector<ll>(k + 1, 0));
 	for (int i = 0; i <= n; i++) { c[i][0] = 1; }
 	for (int i = 1; i <= n; i++) {
 		for (int j = 1; j <= k; j++) { c[i][j] = c[i - 1][j] + c[i - 1][j - 1]; }
@@ -61,7 +60,7 @@ int main() {
 
 		// Calculate number of valid permutations result in all positions
 		// shuffled.
-		int a[i];
+		vector<int> a(i);
 		for (int j = 0; j < i; j++) a[j] = j;
 		int amt = 0;
 		do {
@@ -69,7 +68,7 @@ int main() {
 			for (int j = 0; j < i; j++)
 				if (a[j] == j) valid = 0;
 			if (valid) amt++;
-		} while (next_permutation(a, a + i));
+		} while (next_permutation(a.begin(), a.end()));
 
 		// Add the number of valid permutations of i elements multiplied by the
 		// number of ways to choose i elements.

--- a/solutions/gold/cf-888E.mdx
+++ b/solutions/gold/cf-888E.mdx
@@ -9,7 +9,7 @@ author: Chuyang Wang
 
 ## Explanation
 
-For this problem, we are given $n \leq 35$ numbers and have to find a combination such that the sum of all elements in this combination modulo $m$ is maximized. A naive approach, i.e. trying out all $2^{35}$ possible combinations, is not feasible. However, we can use the [Meet-In-The-Middle Technique](https://usaco.guide/gold/meet-in-the-middle) to reduce the time complexity to $2^{\frac{n}{2}}$, which would be enough for our time bound.
+For this problem, we are given $n \leq 35$ numbers and have to find a combination such that the sum of all elements in this combination modulo $m$ is maximized. A naive approach, i.e. trying out all $2^{35}$ possible combinations, is not feasible. However, we can use the [Meet-In-The-Middle Technique](/gold/meet-in-the-middle) to reduce the time complexity to $2^{\frac{n}{2}}$, which would be enough for our time bound.
 
 We first split the given array into two halves that are equally long. In case of odd $n$, we just put one more element into the first half. Then, we generate all combinations of numbers in the first half by using a bit mask and save the results modulo $m$ in a sorted set. For the second half, let's also generate all combinations for them. For each of these combinations, the maximal sum is the sum of all elements in this combination, $current\_sum$, plus the largest sum of a combination of the first half, $left\_sum$, which is less than $m - current\_sum$. It is never optimal to choose a value larger than $m - current\_sum$ since otherwise the result would be $left\_sum + current\_sum - m$, which is strictly less than $current\_sum$.
 

--- a/solutions/gold/cses-1147.mdx
+++ b/solutions/gold/cses-1147.mdx
@@ -410,7 +410,7 @@ char g[1000][1000];
 int ans = 0;
 
 void solve(int x) {
-	vi nex[m + 1];
+	vector<vi> nex(m + 1);
 	F0R(i, n) nex[cur[i] - x].pb(i);
 	DSU<1000> D;
 	R0F(i, m + 1) for (int a : nex[i]) {

--- a/solutions/gold/cses-1681.mdx
+++ b/solutions/gold/cses-1681.mdx
@@ -42,7 +42,7 @@ int main() {
 	cin.tie(0);
 	int m;
 	cin >> n >> m;
-	int in_degree[n + 1], dp[n + 1];
+	vector<int> in_degree(n + 1), dp(n + 1);
 	for (int i = 0; i <= n; i++) {
 		in_degree[i] = 0;
 		dp[i] = 0;

--- a/solutions/gold/usaco-1211.mdx
+++ b/solutions/gold/usaco-1211.mdx
@@ -29,7 +29,7 @@ Could we use the [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_in
 
 ## Solution
 
-The subtask of this problem can be solved using brute force: insert all the edges from $N$ points into an edge list and solve using [Kruskal's MST algorithm](https://usaco.guide/gold/mst#kruskals). Upon closer look at our brute force solution, the actual bottleneck is the time to insert all the edges.
+The subtask of this problem can be solved using brute force: insert all the edges from $N$ points into an edge list and solve using [Kruskal's MST algorithm](/gold/mst#kruskals). Upon closer look at our brute force solution, the actual bottleneck is the time to insert all the edges.
 So our focus should be on finding a way to exploit the constraint $0 \le y_i \le 10$, so that the edges we need to insert can be reduced.
 
 Given three points $p_1$, $p_2$, and $p_3$, with coordinates $(x_1, y_1)$, $(x_2, y_2)$, and $(x_3, y_3)$ respectively, where $x_1 < x_2 < x_3$. We observe that if $y_1 = y_2$, the length of $p_1 p_3$ will always be larger than $p_1 p_2$ and $p_2 p_3$ individually. If we follow Kruskal's algorithm, we consider the edges starting from the shortest one, and only add an edge to the tree if it connects two different components. The $p_1 p_3$ edge being the longest edge will always be behind $p_1 p_2$ and $p_2 p_3$, and when its turn comes, $p_1$ and $p_3$ are already connected. So we can see that $p_1 p_3$ is an extraneous edge that we can safely remove.

--- a/solutions/gold/usaco-695.mdx
+++ b/solutions/gold/usaco-695.mdx
@@ -89,7 +89,7 @@ bool inside(int x, int y) {
 	return false;
 }
 // set a state as visited
-bool setvisited(state cur) { visited[cur.x1][cur.y1][cur.x2][cur.y2][cur.dir] = 1; }
+void setvisited(state cur) { visited[cur.x1][cur.y1][cur.x2][cur.y2][cur.dir] = 1; }
 // check if a state has been visited
 bool free(state cur) {
 	if (visited[cur.x1][cur.y1][cur.x2][cur.y2][cur.dir] == -1) { return true; }

--- a/solutions/platinum/cfgym-104128E.mdx
+++ b/solutions/platinum/cfgym-104128E.mdx
@@ -34,7 +34,7 @@ $$
 \texttt{dp}[v] = \min \left( \min_{x\in[d-\text{depth}[v],d]}a_x, \sum_{u\in\text{Children}(v)} \text{dp}[u] \right)
 $$
 
-We will aim to leverage this fact. Define $S_d$ as the set of vertices at depth $d$, and take $S$ to be the [virtual tree](https://usaco.guide/plat/VT) of $S_d$.
+We will aim to leverage this fact. Define $S_d$ as the set of vertices at depth $d$, and take $S$ to be the [virtual tree](/plat/VT) of $S_d$.
 
 We continue in a similar fashion to previously, but we only compute dynamic programming values for nodes in $S$. The range minimum query can be answered using data structures in logarithmic or linear time.
 

--- a/solutions/platinum/ioi-05-mountain.mdx
+++ b/solutions/platinum/ioi-05-mountain.mdx
@@ -120,7 +120,7 @@ int main() {
 <Spoiler title = "Coordinate Compression Solution">
 
 Consider an easier version of the problem where $N \leq 10^{6}$. In that case,
-we use a [maximum prefix sum segment tree](https://usaco.guide/problems/cses-2166-prefix-sum-queries/solution)
+we use a [maximum prefix sum segment tree](/problems/cses-2166-prefix-sum-queries/solution)
 with lazy updates. Then, to find the last index where the maximum prefix sum
 $\leq H$, we walk on the segment tree.
 

--- a/solutions/silver/cf-1244E.mdx
+++ b/solutions/silver/cf-1244E.mdx
@@ -23,7 +23,7 @@ search, which we will elaborate on more later.
 
 Intuition tells us that setting $L$ or $L+d$ to some value of $a_i$ is optimal. This
 is true, and we can informally justify this by drawing parallels to the minimizing sums
-problem, which is explored in [CPH 6.4](https://usaco.guide/CPH.pdf#page=271). A more
+problem, which is explored in [CPH 6.4](/CPH.pdf#page=271). A more
 thorough explanation is in the spoiler below.
 
 <Spoiler title="Proof">

--- a/solutions/silver/cses-1131.mdx
+++ b/solutions/silver/cses-1131.mdx
@@ -23,7 +23,7 @@ Since the diameter is the longest path, one of its endpoints must be furthest aw
 Therefore, the node with the maximum distance is one of the endpoints of the diameter.
 We can run a second DFS from this endpoint, since the maximum distance found will be the diameter.
 
-This approach is [Approach 2](https://usaco.guide/CPH.pdf#page=145) in CPH 14.2.
+This approach is [Approach 2](/CPH.pdf#page=145) in CPH 14.2.
 
 ## Implementation
 
@@ -197,7 +197,7 @@ Using DFS, we traverse down from the root and compute the heights of each node's
 By adding them together in a bottom-up manner, we find the length of the longest path passing through that point.
 The diameter is the maximum of the longest paths we've found across all nodes.
 
-This DP approach is [Approach 1](https://usaco.guide/CPH.pdf#page=145) in CPH.
+This DP approach is [Approach 1](/CPH.pdf#page=145) in CPH.
 
 ## Implementation
 

--- a/solutions/silver/cses-1630.mdx
+++ b/solutions/silver/cses-1630.mdx
@@ -5,7 +5,7 @@ title: Tasks & Deadlines
 author: Rameez Parwez
 ---
 
-[Unofficial Analysis](https://usaco.guide/CPH.pdf#page=70)
+[Unofficial Analysis](/CPH.pdf#page=70)
 
 ## Explanation
 

--- a/solutions/silver/cses-3294.mdx
+++ b/solutions/silver/cses-3294.mdx
@@ -42,7 +42,7 @@ int main() {
 	cin >> n >> m;
 
 	// .first is other node, .second is weight
-	vector<pair<int, int>> adj[n + 1];
+	vector<vector<pair<int, int>>> adj(n + 1);
 	vector<ll> pref(n + 1);
 	vector<bool> visited(n + 1);
 

--- a/solutions/silver/usaco-1230.mdx
+++ b/solutions/silver/usaco-1230.mdx
@@ -10,7 +10,7 @@ author: Aditya Gupta, Chuyang Wang
 
 ## Explanation
 
-As each cow $i$ only wants to visit one of the other cows $j$, we can interpret the input as a [functional graph](https://usaco.guide/silver/func-graphs) with edges $i \to j$. The resulting graph is not necessarily connected, so we have to find out all connected components in this graph and find the maximum amount of "moos" for each of them separately.
+As each cow $i$ only wants to visit one of the other cows $j$, we can interpret the input as a [functional graph](/silver/func-graphs) with edges $i \to j$. The resulting graph is not necessarily connected, so we have to find out all connected components in this graph and find the maximum amount of "moos" for each of them separately.
 
 For each connected component of the functional graph, let's observe that there must be one and only one cycle in it. Moreover, all cows can visit their buddies before their departures except one who wants to visit the cow initiating the visit chain in the cycle. For other paths that lead to the cycle, we can always visit them first before processing the cycle, so they will always be able to "moo". Therefore, the maximum amount of "moos" is the sum of all $v$ in the connected component. We need to subtract the sum by the minimum $v_i$ in the cycle because it represents the cow before the initiating cow who won't be able to moo.
 

--- a/solutions/silver/usaco-643.mdx
+++ b/solutions/silver/usaco-643.mdx
@@ -28,20 +28,21 @@ Finally, we combine the two groups to determine the maximum total number of diam
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <vector>
 
 int main() {
 	std::ifstream cin("diamond.in");
 
 	int n, k;
 	cin >> n >> k;
-	int arr[n];
+	std::vector<int> arr(n);
 	for (int i = 0; i < n; i++) { cin >> arr[i]; }
 
-	std::sort(arr, arr + n);
+	std::sort(arr.begin(), arr.end());
 
 	// how many diamonds we can take
 	// assuming i is the leftmost diamond
-	int can_take_left[n];
+	std::vector<int> can_take_left(n);
 	int l = 0, r = 0;
 	for (; l < n; l++) {
 		while (r < n && arr[r] - arr[l] <= k) r++;
@@ -49,7 +50,7 @@ int main() {
 	}
 
 	// max_val_after_i[i] = max value of can_take_left[x] for some x >= i.
-	int max_val_after_i[n + 1];
+	std::vector<int> max_val_after_i(n + 1);
 	max_val_after_i[n] = 0;
 	for (int i = n - 1; i >= 0; i--) {
 		max_val_after_i[i] = std::max(max_val_after_i[i + 1], can_take_left[i]);

--- a/solutions/silver/usaco-690.mdx
+++ b/solutions/silver/usaco-690.mdx
@@ -35,7 +35,7 @@ int main() {
 
 	int n, t;
 	cin >> n >> t;
-	int ar[n];
+	vector<int> ar(n);
 
 	for (int i = 0; i < n; i++) { cin >> ar[i]; }
 


### PR DESCRIPTION
Three checks distilled from ~900 PR review comments on this repo since late June, each measured against the tree and triaged for false positives before being proposed. The aim is narrow: reviewers spend attention on things a script does better. Prose quality — wording, unclear notation, "explain why this greedy works" — is the bulk of review here and is deliberately untouched.

Everything below was scoped down until its false-positive rate was zero on the current tree.

## 1. Problem names, urls, and cross-module consistency

New `py/check_problems_json.py`, wired into pre-commit and a `Problem Data` workflow. Three rules:

**Names** match usaco.org, using the scrape already vendored in `div_to_probs.json` (no network). 25 entries had drifted — mostly capitalisation (`Mootube`, `Out Of Sorts`, `Lightsout`) but also truncations like `UCFJ`, `3SUM`, `Mincross`. These looked deliberate until the check that settles it: of the nine whose problem has an internal solution, **five contradicted that solution's own frontmatter title**. A policy does not disagree with itself in two files.

The division suffix usaco.org appends (`High Card Low Card (Gold)`) is stripped before comparing, since `source` already carries it. Duplicate names need no disambiguation — `name` is display text and `uniqueId` is the identity everywhere it matters — so `usaco-1255` loses its hand-written "- The Game".

**Urls** point at the problem the `uniqueId` names. Four do not, and **in all four the id is the wrong side**, verified against the Codeforces API:

| entry | should become | why |
|---|---|---|
| `cf-1083B` | `cf-37C` | 37C is "Old Berland Language"; 1083B is "The Fair Nut and Strings" |
| `cf-949D` | `cf-1981D` | 949 was the round number, not the contest id |
| `cf-880D` | `cf-800D` | "Varying Kibibits" is 772D, mirrored at 800D; 880D is neither |
| `cf-1534F1` | `cf-1534F2` | tagged SCC at difficulty Hard — the hard version |

Repointing the urls instead would send readers to entirely different problems, so the check says so where it fires.

**These renames are deferred, not applied.** `uniqueId` is what Firebase keys user progress and `userProblemSolutions` on, so renaming one orphans progress people genuinely earned — and earned on the right problem, since the `name` and `url` were correct all along. That wants a migration beside it. The four are recorded in `py/problems_mismatched_id.txt` with the evidence for each; the rule stays live for new mismatches, and the list can only shrink.

**Consistency** compares only fields that cannot legitimately differ between copies: `name`, `url`, and `hasHints` when the solution is internal. `difficulty` and `isStarred` are documented as module-scoped, `tags` are unioned when the site builds its filters, and `solutionMetadata.kind` is module-scoped too — `cses-1648` is `in-module` in both PURS and Sqrt, each pointing at itself. Enforcing those four would have been ~101 false positives.

Also switches `usaco-1445` from the USACO link to the internal solution that already exists for it.

## 2. `-Werror=vla` and `-Werror=return-type` on snippets

The checker already compiles all 1,253 C++ programs, so flags are nearly free — but a wider set produced **76 warnings of which 46 were not defects**. Every `-Wparentheses` hit was correct code (`1 << j - 1` already means `1 << (j-1)`); every `-Wreorder` hit initialised from a constructor parameter; `-Wshift-count-overflow` fired on `Debugging_Cpp.mdx`, the module demonstrating that `1 << 32` overflows.

So only two are enforced. 20 VLAs across 11 snippets are fixed (`Adding_Solution.mdx` bans them outright), plus `usaco-695`'s `bool setvisited(...)` that returns nothing. Three fixes needed more than `T x[n]` → `vector<T> x(n)`: two sorted through pointers, and `cf-888D` zeroed a 2D array via `fill_n(&c[0][0], ...)`.

No opt-out mechanism is needed — the deliberate VLA in `Intro_DS.mdx` is a bare fragment the checker never compiles.

Also widens `MAIN` to any run of type keywords, and corrects three comments (including the file header) that still described the rule as "an `int main(`" — wording that predates the existing regex and misled me into reporting a snippet as missed when it had in fact been caught. No snippet in the guide uses the newly-allowed spellings, so the compiled set is unchanged at 1253; this is defensive.

## 3. Relative in-guide links

18 absolute `https://usaco.guide/...` links rewritten. A hardcoded production origin bounces the reader off a preview deployment mid-page — exactly where a reviewer clicks. The one remaining match is inside a fenced code block in `Adding_Solution.mdx`: the rule quoting its own bad example.

## Verification

- `check_problems_json.py` exits 0; every rule regression-tested by mutating the tree, in both directions for the backlog.
- Full snippet sweep: **all 1,948 snippets pass** with the new flags. The 2 x86-only snippets skipped on arm64 were hand-checked.
- `tsc`, prettier, and all pre-commit hooks clean.

## Not included

`problems.schema.json` validation was investigated and deferred. It is imported only by the Monaco editor, never by CI — but it has drifted badly from `src/models/problem.ts` (it flattens the `ProblemSolutionMetadata` discriminated union, omits `'N/A'` from the difficulty enum, invents a `source` enum where the model says `string`, and marks the optional `isStarred` required). All ~750 apparent violations are schema bugs, not content bugs. The right fix is to generate it from the TS types rather than hand-patch it, which is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NpzjAmx1J6FcdqLDE9SPK