### PR TITLE
Run the content checks on every pull request, so they can gate

### DIFF
--- a/.github/workflows/mdx.yml
+++ b/.github/workflows/mdx.yml
@@ -5,15 +5,15 @@
 # each rule is noise without that.
 name: MDX
 
+# No `paths` filter. These are required status checks, and a required check that
+# never runs leaves a pull request waiting on a status that will not arrive -- so
+# it has to report on every pull request, not only the ones touching content.
+# Nothing is lost by that: py/check_mdx.py sweeps every .mdx,
+# so it does the same work whatever the diff contains, in a few seconds.
 on:
   pull_request:
     branches:
       - master
-    paths:
-      - 'content/**/*.mdx'
-      - 'solutions/**/*.mdx'
-      - 'py/check_mdx.py'
-      - '.github/workflows/mdx.yml'
 
 # A new push supersedes whatever the previous one was still checking. Cancelling
 # is scoped to pull requests: a run on master is validating what actually ships,

--- a/.github/workflows/problem-data.yml
+++ b/.github/workflows/problem-data.yml
@@ -5,16 +5,15 @@
 # and, just as importantly, which fields are deliberately left alone.
 name: Problem Data
 
+# No `paths` filter. These are required status checks, and a required check that
+# never runs leaves a pull request waiting on a status that will not arrive -- so
+# it has to report on every pull request, not only the ones touching content.
+# Nothing is lost by that: py/check_problems_json.py compares a problem against its copies elsewhere,
+# so it does the same work whatever the diff contains, in a few seconds.
 on:
   pull_request:
     branches:
       - master
-    paths:
-      - 'content/**/*.problems.json'
-      - 'content/extraProblems.json'
-      - 'src/components/markdown/ProblemsList/DivisionList/div_to_probs.json'
-      - 'py/check_problems_json.py'
-      - '.github/workflows/problem-data.yml'
 
 # A new push supersedes whatever the previous one was still checking. Cancelling
 # is scoped to pull requests: a run on master is validating what actually ships,


### PR DESCRIPTION
Prerequisite for adding `check-mdx` and `check-problem-data` to master's required status checks.

A required check that never runs blocks a PR forever — GitHub waits on a status that will not arrive. A `paths` filter is precisely how a check comes not to run. #6596 shows the shape: it touched only `content/ordering.ts` and `src/`, and `check-solutions`, `check-problem-tags` and `code-snippets` did not report at all. That is why the three checks master requires today (`Vercel`, `build-tests`, `pre-commit.ci - pr`) are all unconditional.

So the filters come off `mdx.yml` and `problem-data.yml`. Nothing is lost by it: `check_problems_json.py` compares each problem against its copies in other modules, and `check_mdx.py` sweeps every `.mdx`, so both already do the same work whatever the diff contains. The filter was saving a few seconds off a job that takes a few seconds.

The other content workflows keep their filters and so remain unable to gate — worth revisiting separately.

Verified against all 11 open PRs merged with master: 2 would fail, both true positives (#6579's `std::cout.tie(0)`, and a new absolute in-guide link in #6497). No false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBSt9Q5eeMr3X23ENJASSz