### PR TITLE
Let the snippet and tag checks report on every pull request, so they can gate

### DIFF
--- a/.github/workflows/code-snippets.yml
+++ b/.github/workflows/code-snippets.yml
@@ -5,14 +5,13 @@ on:
   # Reach for this after changing the checker, or to find breakage that landed
   # while nothing in its file was being edited.
   workflow_dispatch:
+  # No `paths` filter, because this is a required status check and one that does
+  # not report blocks a pull request forever. The filter moves inside instead:
+  # the job always reports, and decides for itself whether there is anything to
+  # compile. A pull request touching no snippet pays for a checkout and stops.
   pull_request:
     branches:
       - master
-    paths:
-      - 'content/**/*.mdx'
-      - 'solutions/**/*.mdx'
-      - 'scripts/check-code-snippets.ts'
-      - '.github/workflows/code-snippets.yml'
 
 # A new push supersedes whatever the previous one was still checking. Cancelling
 # is scoped to pull requests: a run on master is validating what actually ships,
@@ -31,7 +30,26 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # need the base branch to diff against
+
+      # What the `paths` filter used to decide, decided here so the check still
+      # reports when it comes out false.
+      - name: Anything to compile?
+        id: relevant
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: |
+          if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
+            echo 'Manual run.'
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$BASE_REF...HEAD" | grep -qE \
+              '^(content|solutions)/.*\.mdx$|^scripts/check-code-snippets\.ts$|^\.github/workflows/code-snippets\.yml$'; then
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'No snippets, checker or workflow touched; nothing to compile.'
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+          fi
       - name: Use Node.js 20.x
+        if: steps.relevant.outputs.changed == 'true'
         uses: actions/setup-node@v7
         with:
           node-version: 20.x
@@ -41,11 +59,13 @@ jobs:
       # workspace instead makes Node read yarn.js under our "type": "module"
       # package.json and fail to load that CommonJS bundle.
       - name: Cache Corepack
+        if: steps.relevant.outputs.changed == 'true'
         uses: actions/cache@v6
         with:
           path: ~/.cache/node/corepack
           key: corepack-${{ hashFiles('package.json') }}
       - name: Enable Corepack
+        if: steps.relevant.outputs.changed == 'true'
         run: corepack enable
 
       # Several Gold and Advanced snippets teach the AtCoder Library. It is
@@ -54,11 +74,13 @@ jobs:
       # people who happen to have ACL checked out, which is how eight of them
       # sat broken here unnoticed.
       - name: Fetch the AtCoder Library
+        if: steps.relevant.outputs.changed == 'true'
         run: git clone --depth 1 -q https://github.com/atcoder/ac-library.git .ac-library
 
       # The checker itself imports nothing outside Node's standard library; the
       # install is only here to provide tsx, so a cache hit skips almost all of it.
       - name: Cache node modules
+        if: steps.relevant.outputs.changed == 'true'
         uses: actions/cache@v6
         id: node-modules
         with:
@@ -69,7 +91,7 @@ jobs:
       # and `yarn` would only spend half a minute confirming that. `yarn run`
       # needs no install of its own -- Corepack provides the yarn binary.
       - name: Install dependencies
-        if: steps.node-modules.outputs.cache-hit != 'true'
+        if: steps.relevant.outputs.changed == 'true' && steps.node-modules.outputs.cache-hit != 'true'
         run: yarn
 
       # A pull request checks only the files it touches, so breakage elsewhere
@@ -77,6 +99,7 @@ jobs:
       # a manual run, and a pull request that changes the checker itself --
       # no .mdx diff exercises that, so it would otherwise check nothing at all.
       - name: Check code snippets
+        if: steps.relevant.outputs.changed == 'true'
         env:
           BASE_REF: origin/${{ github.base_ref }}
         run: |

--- a/.github/workflows/problem-tags.yml
+++ b/.github/workflows/problem-tags.yml
@@ -1,5 +1,10 @@
 name: Problem Tags
 
+# No `paths` filter, because this is a required status check: a required check
+# that does not report leaves a pull request waiting on a status that never
+# arrives. It is pure Python over the problem lists and takes a few seconds, so
+# running it on every pull request costs little. pre-commit.ci cannot cover it
+# -- it clones without the base branch this compares against.
 on:
   pull_request:
     # labeled/unlabeled so that applying `new-tag` re-runs and clears the check,
@@ -7,11 +12,6 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - master
-    paths:
-      - 'content/**/*.problems.json'
-      - 'content/extraProblems.json'
-      - 'py/check_problem_tags.py'
-      - '.github/workflows/problem-tags.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Prerequisite for adding `code-snippets` and `check-problem-tags` to master's required status checks.

## Why only these two

A required check that never reports blocks a PR forever — GitHub waits on a status that will not arrive. A `paths` filter is precisely how a check comes not to report.

Most content checks don't need fixing, though. `check-solutions`, `check-mdx` and `check-problems-json` all run as **pre-commit hooks**, and `pre-commit.ci - pr` is both required and unconditional — so they already gate today. #6579 shows it: `check-mdx` red *and* `pre-commit.ci - pr` red. Their workflows stay filtered, since those are a full-sweep supplement (`--all`) rather than the gate itself.

Two checks aren't covered that way:

| check | why pre-commit.ci misses it |
|---|---|
| `code-snippets` | no pre-commit equivalent — needs `g++` and a clone of the AtCoder Library. **A snippet that does not compile can be merged today.** |
| `check-problem-tags` | `ci: skip` — pre-commit.ci clones without the base branch this compares against |

## How

`problem-tags.yml` is pure Python over the problem lists and runs in seconds, so its filter just comes off.

`code-snippets.yml` is expensive, so the filter moves *inside* the job rather than disappearing. A first step decides whether any snippet, the checker, or the workflow changed; every later step is conditional on it. The job always reports, and a PR touching no snippet pays for one checkout and a `git diff` — skipping Node, Corepack, the ACL clone and the install.

The alternative — a second workflow with a matching job name reporting success — looks tempting but is wrong here: `paths` and `paths-ignore` are **not** complements. A mixed diff (one `.mdx` plus one unrelated file) satisfies both, so the real job and the skip job would both run and race on the same check name.

## After this merges

`code-snippets` and `check-problem-tags` get added to the required contexts, alongside `Vercel`, `build-tests` and `pre-commit.ci - pr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBSt9Q5eeMr3X23ENJASSz