### PR TITLE
Clean up Math tags in Bronze and Silver

### DIFF
--- a/content/2_Bronze/Conclusion.problems.json
+++ b/content/2_Bronze/Conclusion.problems.json
@@ -8,7 +8,7 @@
       "source": "CF",
       "difficulty": "Very Easy",
       "isStarred": false,
-      "tags": ["Math"],
+      "tags": [],
       "solutionMetadata": {
         "kind": "internal"
       }
@@ -32,7 +32,7 @@
       "source": "CSES",
       "difficulty": "Easy",
       "isStarred": false,
-      "tags": ["Math"],
+      "tags": [],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -705,7 +705,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Binary Search", "Functional Graph", "Math"],
+      "tags": ["Binary Search", "Functional Graph"],
       "solutionMetadata": {
         "kind": "autogen-label-from-site",
         "site": "CF"

--- a/content/3_Silver/Conclusion.problems.json
+++ b/content/3_Silver/Conclusion.problems.json
@@ -757,7 +757,7 @@
       "source": "CF",
       "difficulty": "Very Hard",
       "isStarred": false,
-      "tags": ["Math", "Priority Queue"],
+      "tags": ["Greedy", "Math", "Priority Queue"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true

--- a/content/3_Silver/Intro_Bitwise.problems.json
+++ b/content/3_Silver/Intro_Bitwise.problems.json
@@ -172,7 +172,7 @@
       "source": "CF",
       "difficulty": "Medium",
       "isStarred": false,
-      "tags": ["Greedy", "Math"],
+      "tags": ["Bitwise", "Greedy", "Math"],
       "solutionMetadata": {
         "kind": "internal",
         "hasHints": true
@@ -210,7 +210,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Interactive"],
+      "tags": ["Bitwise", "Interactive"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Intro_Bitwise.problems.json
+++ b/content/3_Silver/Intro_Bitwise.problems.json
@@ -210,7 +210,7 @@
       "source": "CF",
       "difficulty": "Hard",
       "isStarred": false,
-      "tags": ["Interactive", "Math"],
+      "tags": ["Interactive"],
       "solutionMetadata": {
         "kind": "internal"
       }

--- a/content/3_Silver/Prefix_Sums.problems.json
+++ b/content/3_Silver/Prefix_Sums.problems.json
@@ -59,7 +59,7 @@
       "source": "CF",
       "difficulty": "Easy",
       "isStarred": true,
-      "tags": ["Math", "Prefix Sums"],
+      "tags": ["Prefix Sums"],
       "solutionMetadata": {
         "kind": "internal"
       }


### PR DESCRIPTION
Reviews every Bronze–Silver problem tagged **Math** and keeps the tag only where the solution involves more math than usual for its division.

**Removed Math**
- Good Subarrays (cf-1398C): subtract 1 from each element, then count equal prefix sums, which is the same as Subarray Divisibility, tagged only Prefix Sums.
- Election (cf-1593A): the answer is `max(0, max(b, c) + 1 - a)`.
- Reading Books (cses-1631): an ordering argument giving `max(sum, 2 * max)`.
- Ehab and another another xor problem (cf-1088D): bit-by-bit interactive queries.
- Red Light, Green Light (Hard Version) (cf-2118D2): the only arithmetic is grouping lights by diagonal, `(d ∓ p) mod k`, so each group can be binary searched. The solution is binary search plus cycle detection on a functional graph, which the other tags cover.

**Kept Math**
- Who's Opposite? (cf-1560B): circle size `2|a - b|` and finding positions by wrapping around the circle.
- Digit Queries (cses-2431): counting digits by length, `n * 9 * 10^(n-1)`.
- Carrots for Rabbits (cf-1428E): the proof that the greedy works (a sum of squares is smallest when the parts are equal, and each extra cut saves less).
- AND, OR, and square sum (cf-1368D): `x & y + x | y = x + y` keeps the sum fixed, and the sum of squares grows as the values spread apart.

**Added missing tags**
- Bitwise on AND, OR, and square sum and on Ehab's xor problem. Every other problem in Intro to Bitwise has it.
- Greedy on Carrots for Rabbits, a priority-queue greedy.

Election and Reading Books are left with no tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAewmJFKach1uvxZdsbUHr