### PR TITLE
Run bundlewatch through yarn dlx in build tests

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -28,8 +28,6 @@ jobs:
         run: corepack enable
       - uses: dart-lang/setup-dart@v1
 
-      - run: yarn add bundlewatch@0.4.0
-
       - name: Cache node modules
         uses: actions/cache@v6
         id: cache-node-modules
@@ -56,8 +54,11 @@ jobs:
           $HOME/.pub-cache/bin/linkcheck --no-nice --no-check-anchors \
             --skip-file .github/linkcheck-skip.txt :3000
 
+      # dlx installs just bundlewatch, where `yarn add` re-resolved the whole
+      # project ahead of the node_modules cache (~20s). It also keeps
+      # bundlewatch's pinned axios 0.28 out of yarn.lock.
       - name: Bundle Watch
-        run: yarn bundlewatch .next/static/chunks/*.js
+        run: yarn dlx bundlewatch@0.4.0 .next/static/chunks/*.js
         env:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
`build-tests` spent about 22s on `yarn add bundlewatch@0.4.0`. That step ran before the `node_modules` cache was restored, so it re-resolved and installed the whole project on every run, and then the cache overwrote the result.

This removes that step and runs `yarn dlx bundlewatch@0.4.0` in the Bundle Watch step instead. dlx installs only bundlewatch into a temporary directory, which took about 2s locally. It also keeps bundlewatch's `axios@^0.28` dependency, which has known CVEs, out of `yarn.lock`, which adding it as a devDependency would not.

The `node_modules` cache key is a hash of `yarn.lock`, which `yarn add` used to modify before the hash was taken. The first run after this merges will therefore miss the cache once and then save a new one.

The Bundle Watch step on this PR's own `build-tests` run is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAewmJFKach1uvxZdsbUHr