### PR TITLE
Fail the build on LaTeX-incompatible KaTeX input

### DIFF
--- a/content/4_Gold/Combinatorics.mdx
+++ b/content/4_Gold/Combinatorics.mdx
@@ -837,10 +837,12 @@ Let's take a look at a particular example for $n=3$ and $k=2$ that has $4$ possi
 separated into groups by bars:
 
 $$
-||\bigstar \bigstar \bigstar  \\
-|\bigstar |\bigstar \bigstar  \\
-|\bigstar \bigstar| \bigstar  \\
-\bigstar \bigstar \bigstar ||  \\
+\begin{gathered}
+||\bigstar \bigstar \bigstar \\
+|\bigstar |\bigstar \bigstar \\
+|\bigstar \bigstar| \bigstar \\
+\bigstar \bigstar \bigstar ||
+\end{gathered}
 $$
 
 As you've probably noticed, there can be empty boxes - when we put all the stars in the first or second box. There may be cases in

--- a/content/5_Plat/Geo_Pri.mdx
+++ b/content/5_Plat/Geo_Pri.mdx
@@ -528,8 +528,10 @@ working with angles, we'll convert the slopes into radians.
 
 Consider $\alpha$ as the angle formed by one line with the $\texttt{ox}$ axis. Then we have:
 $$
+\begin{gathered}
 \texttt{slope}=\frac{\Delta y}{\Delta x}=\tg{\alpha} \\
 \alpha=\arctg{\frac{\Delta y}{\Delta x}}
+\end{gathered}
 $$
 
 The movement of the field of view can be seen as a [sliding window](/gold/sliding-window) applied

--- a/content/6_Advanced/Catalan.mdx
+++ b/content/6_Advanced/Catalan.mdx
@@ -28,7 +28,7 @@ $$
 
 They also have the recurrence formula
 $$
-C_{n+1}= \sum^{n}_{i=0}{C_i \cdot C_{n-i}} \,\,\, \text{ for } n \ge 0 \\
+C_{n+1}= \sum^{n}_{i=0}{C_i \cdot C_{n-i}} \,\,\, \text{ for } n \ge 0
 $$
 which can also be expressed as
 $$

--- a/content/6_Advanced/Extend_Euclid.mdx
+++ b/content/6_Advanced/Extend_Euclid.mdx
@@ -360,11 +360,13 @@ solution to a system of simultaneous modular congruences with pairwise coprime m
 when divided by the given divisors leaves the given remainders. Mathematically, it solves the following system of modular congruences:
 
 $$
+\begin{gathered}
 x \equiv a_1 \pmod{m_1} \\
 x \equiv a_2 \pmod{m_2} \\
 x \equiv a_3 \pmod{m_3} \\
-\vdots\\
-x \equiv a_k \pmod{m_k} \\
+\vdots \\
+x \equiv a_k \pmod{m_k}
+\end{gathered}
 \tag{1}
 $$
 <center>$M=m_1\cdot m_2 \cdot m_3 \cdots m_k$</center>
@@ -374,8 +376,10 @@ The above system has exactly one solution modulo $M$.
 We'll focus on the particular case for $k=2$; for two coprime moduli:
 
 $$
+\begin{gathered}
 x \equiv a_1 \pmod{m_1} \\
-x \equiv a_2 \pmod{m_2} \\
+x \equiv a_2 \pmod{m_2}
+\end{gathered}
 \tag{2}
 $$
 <center>$M=m_1 \cdot m_2$</center>

--- a/solutions/advanced/kattis-thekingsguards.mdx
+++ b/solutions/advanced/kattis-thekingsguards.mdx
@@ -88,9 +88,11 @@ if $A$ and $B$ are tight, then their union and
 intersection are tight as well (use submodularity of $A \mapsto |N_X(A)|$ and Hall's condition). In more detail:
 
 $$
-|A| + |B| = |N_X(A)| + |N_X(B)| \quad\text{$A$, $B$ are tight} \\
-\ge |N_X(A \cap B)| + |N_X(A \cup B)| \quad\text{submodularity} \\
-\ge |A \cap B| + |A \cup B| \quad\text{Hall's condition}.
+\begin{aligned}
+|A| + |B| &= |N_X(A)| + |N_X(B)| \quad\text{$A$, $B$ are tight} \\
+&\ge |N_X(A \cap B)| + |N_X(A \cup B)| \quad\text{submodularity} \\
+&\ge |A \cap B| + |A \cup B| \quad\text{Hall's condition}.
+\end{aligned}
 $$
 
 Since $|A| + |B| = |A \cap B| + |A \cup B|$, we get equality throughout. To conclude $A \cap B$ and $A \cup B$ are tight, apply Hall's again on $|N_X(A \cap B)| + |N_X(A \cup B)| = |A \cap B| + |A \cup B|$.

--- a/solutions/platinum/leetcode-1453.mdx
+++ b/solutions/platinum/leetcode-1453.mdx
@@ -31,8 +31,10 @@ circle, therefore $\angle{PQL}=90\degree$. In this case, knowing that $PL=2 \cdo
 can be conveniently expressed as $\arccos$. Consequently, the angles $a, b$ have the following formulas:
 
 $$
-a=\arctg{\frac{Q_y-P_y}{Q_x-P_x}}\\
+\begin{gathered}
+a=\arctg{\frac{Q_y-P_y}{Q_x-P_x}} \\
 b=\arccos{\frac{\texttt{dist}(P,Q)}{2 \cdot r}}
+\end{gathered}
 $$
 
 Now that we know how to find the entrance angle, it'll be easier to find the exit angle.

--- a/solutions/silver/cses-3410.mdx
+++ b/solutions/silver/cses-3410.mdx
@@ -10,21 +10,21 @@ author: Mihnea Brebenel
 Let $A(x_A,y_A)$ and $B(x_B,y_B)$ be two points. The manhattan (or taxicab) distance between them is $d = |x_B-x_a|+|y_B-y_A|$.
 Usually, it's a good idea to define the cases of the absolute value:
 $$
+\begin{gathered}
 |x_B-x_A| = \left\{
 \begin{array}{ll}
 x_B-x_A & ,x_B-x_A \ge 0\\
 -(x_B-x_A) & ,x_B-x_A < 0
 \end{array}
 \right.
-
 \\
-
 |y_B-y_A| = \left\{
 \begin{array}{ll}
 y_B-y_A & y_B - y_A \ge 0\\
 -(y_B-y_A) & y_B-yA <0
 \end{array}
 \right.
+\end{gathered}
 $$
 
 Now, we distinguish four cases for the distance value, based on $x$ and $y$:

--- a/solutions/silver/usaco-1134.mdx
+++ b/solutions/silver/usaco-1134.mdx
@@ -75,7 +75,7 @@ C++ and Java.
 Unfortunately, due to Python's slow nature, this solution must be sped up. We do not keep the board as a string but rather
 keep it in its ternary form.
 
-To extract a character at index $i$ from the board, we divide by $3^i$ to remove the first $i$ digits and then $%3$.
+To extract a character at index $i$ from the board, we divide by $3^i$ to remove the first $i$ digits and then take $\% 3$.
 
 To add a new character $c$ at index $i$ with board $b$, we have the following operation:
 $$

--- a/src/components/DynamicMarkdownRenderer/DynamicMarkdownRenderer.tsx
+++ b/src/components/DynamicMarkdownRenderer/DynamicMarkdownRenderer.tsx
@@ -57,6 +57,7 @@ export default function DynamicMarkdownRenderer({
     setMarkdownProblemListsProviderValue,
   ] = useState([]);
   const [error, setError] = useState<Error | null>(null);
+  const [katexWarnings, setKatexWarnings] = useState<string[]>([]);
   const compileSeqRef = useRef(0);
 
   useEffect(() => {
@@ -66,10 +67,11 @@ export default function DynamicMarkdownRenderer({
 
     (async () => {
       try {
-        const { compiledResult, problemsList } = await compileMdxForEditor({
-          markdown: nextMarkdown,
-          problems: nextProblems,
-        });
+        const { compiledResult, problemsList, katexWarnings } =
+          await compileMdxForEditor({
+            markdown: nextMarkdown,
+            problems: nextProblems,
+          });
 
         const content = new Function(compiledResult)({
           Fragment,
@@ -79,6 +81,7 @@ export default function DynamicMarkdownRenderer({
 
         if (compileSeqRef.current !== seq) return;
         setError(null);
+        setKatexWarnings(katexWarnings);
         setMdxContent(content);
         setMarkdownProblemListsProviderValue(problemsList);
       } catch (e) {
@@ -113,10 +116,24 @@ export default function DynamicMarkdownRenderer({
   }
 
   return (
-    <ErrorBoundary>
-      <MarkdownProblemListsProvider value={markdownProblemListsProviderValue}>
-        {mdxContent}
-      </MarkdownProblemListsProvider>
-    </ErrorBoundary>
+    <>
+      {katexWarnings.length > 0 && (
+        <div className="mb-4 rounded-md border border-yellow-400 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-600 dark:bg-yellow-900/30 dark:text-yellow-200">
+          <p className="font-medium">
+            This math will fail the build. Fix it before submitting:
+          </p>
+          <ul className="mt-2 list-disc space-y-1 pl-5 font-mono text-xs">
+            {katexWarnings.map((warning, i) => (
+              <li key={i}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <ErrorBoundary>
+        <MarkdownProblemListsProvider value={markdownProblemListsProviderValue}>
+          {mdxContent}
+        </MarkdownProblemListsProvider>
+      </ErrorBoundary>
+    </>
   );
 }

--- a/src/lib/compileMdxForEditor.ts
+++ b/src/lib/compileMdxForEditor.ts
@@ -92,6 +92,7 @@ export async function compileMdxForEditor({
 }): Promise<{
   compiledResult: string;
   problemsList: ProblemsListEntry[];
+  katexWarnings: string[];
 }> {
   const deps = await loadCompilerDeps();
 
@@ -123,7 +124,10 @@ export async function compileMdxForEditor({
             ],
           },
         ],
-        deps.customRehypeKatex,
+        // The build fails on these (see parseMdxFile). Without throwOnError
+        // they become messages and the math still renders, so the preview
+        // stays usable while the author sees what CI will reject.
+        [deps.customRehypeKatex, { strict: 'error' }],
         deps.rehypeSnippets,
         [deps.rehypeExternalLinks, { target: '_blank', rel: ['nofollow'] }],
         [
@@ -150,5 +154,8 @@ export async function compileMdxForEditor({
   return {
     compiledResult: String(compiled),
     problemsList,
+    katexWarnings: compiled.messages
+      .filter(m => m.source === 'rehype-katex')
+      .map(m => m.reason),
   };
 }

--- a/src/lib/parseMdxFile.ts
+++ b/src/lib/parseMdxFile.ts
@@ -54,7 +54,11 @@ export async function parseMdxFile(filePath: string): Promise<MdxContent> {
             ],
           },
         ],
-        customRehypeKatex,
+        // Strict here only: KaTeX's default 'warn' just prints to the console,
+        // where nobody reads it, so input KaTeX merely tolerates -- a stray `%`
+        // silently comments out the rest of the math -- fails the build instead.
+        // The editor preview and group posts share the plugin and stay lenient.
+        [customRehypeKatex, { strict: 'error', throwOnError: true }],
         rehypeSnippets,
         [rehypeExternalLinks, { target: '_blank', rel: ['nofollow'] }],
         [

--- a/src/mdx-plugins/rehype-math.js
+++ b/src/mdx-plugins/rehype-math.js
@@ -13,8 +13,13 @@ const parseHtml = unified().use(parse, { fragment: true, position: false });
 const source = 'rehype-katex';
 
 const customRehypeKatex = options => {
-  const settings = options || {};
+  const { strict, ...settings } = options || {};
   const throwOnError = settings.throwOnError || false;
+  // KaTeX's own strict: 'error' only throws for some LaTeX-incompatible input;
+  // for others, like \\ in display mode, it quietly switches to LaTeX's
+  // behavior and drops the line break. So 'error' here collects every report,
+  // renders leniently as before, and then fails on what it collected.
+  const failOnNonstrict = strict === 'error';
 
   return transformMath;
 
@@ -35,13 +40,26 @@ const customRehypeKatex = options => {
       let result;
 
       try {
+        const nonstrict = [];
         result = renderToString(
           value,
           assign({}, settings, {
             displayMode: displayMode,
             throwOnError: true,
+            strict: failOnNonstrict
+              ? (code, message) => {
+                  nonstrict.push(`${message} [${code}]`);
+                  return 'ignore';
+                }
+              : strict,
           })
         );
+        if (nonstrict.length) {
+          throw new Error(
+            `LaTeX-incompatible input in ${JSON.stringify(value)}: ` +
+              nonstrict.join('; ')
+          );
+        }
       } catch (error) {
         const fn = throwOnError ? 'fail' : 'message';
         const origin = [source, error.name.toLowerCase()].join(':');


### PR DESCRIPTION
Every `yarn prebuild` printed 18 KaTeX `LaTeX-incompatible input and strict mode is set to 'warn'` lines that nobody acted on. One of them was a real rendering bug. This PR fixes all of them, makes the build fail on new ones, and shows the same problems in the live editor so authors can see what to fix.

**Content fixes**
- `solutions/silver/usaco-1134.mdx`: `$%3$` is a LaTeX comment and rendered as nothing. It's now `$\% 3$`, matching the `\%` used a few lines further down.
- 8 display blocks used `\\` outside an environment. KaTeX breaks the lines anyway, but it warns because LaTeX wouldn't. They're now wrapped in `gathered`, which keeps the lines centered as before, or in `aligned` for the chain of `\ge` in kattis-thekingsguards. Trailing `\\` are dropped. The affected files are Combinatorics, Geo_Pri, Catalan, Extend_Euclid (2 blocks), kattis-thekingsguards, leetcode-1453 and cses-3410.

**Build strict mode** (`src/lib/parseMdxFile.ts`, `src/mdx-plugins/rehype-math.js`)

The build now passes `{ strict: 'error', throwOnError: true }` to the KaTeX plugin, so `yarn prebuild` fails and names the file and the LaTeX. KaTeX's own `strict: 'error'` couldn't be used as is: for `\\` in display mode it doesn't throw, it switches to LaTeX behavior and silently drops the line break. So the plugin now collects every strict report, renders leniently as before, and then fails on what it collected. Math that doesn't parse at all, which used to ship as red error text, also fails the build now. There is currently none.

**Live editor** (`compileMdxForEditor.ts`, `DynamicMarkdownRenderer.tsx`)

The editor runs the plugin with `strict: 'error'` but without `throwOnError`. Each problem is recorded as a message and the math still renders. The preview lists the problems in a yellow box above the content, so it doesn't blank while the author types. Group posts (`SafeMarkdownRenderer`) pass no options and are unchanged.

**Testing**
- All 987 content and solution MDX files compile through the strict `parseMdxFile` with no failures and no KaTeX warnings.
- Test files containing `$%3$`, a display-mode `\\`, an unparseable `$\frac{1}{$`, and master's old Catalan.mdx each fail with the file and LaTeX named.
- In the local editor, master's usaco-1134 shows the `commentAtEnd` warning above a normally rendered preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAewmJFKach1uvxZdsbUHr